### PR TITLE
Enhance health smoke test assertions

### DIFF
--- a/api/scripts/smoke-health.js
+++ b/api/scripts/smoke-health.js
@@ -14,6 +14,21 @@ const healthUrl = process.env.HEALTH_URL || "http://localhost/api/health";
       throw new Error(`Health endpoint returned: ${JSON.stringify(json)}`);
     }
 
+    if (!json.service || typeof json.service !== "string") {
+      throw new Error("Health response missing required 'service' string");
+    }
+
+    if (!json.version || typeof json.version !== "string") {
+      throw new Error("Health response missing required 'version' string");
+    }
+
+    if (json.timestamp !== undefined) {
+      const timestamp = Date.parse(json.timestamp);
+      if (Number.isNaN(timestamp)) {
+        throw new Error("Health response includes an invalid 'timestamp'");
+      }
+    }
+
     console.log("✅ Health smoke test passed", json);
   } catch (error) {
     console.error("Health smoke test failed:", error);


### PR DESCRIPTION
## Summary
- add validation that health endpoint responses include service and version strings
- optionally verify timestamp field is parseable when present
- keep failing fast when expected fields are missing or invalid

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932ab9b6bfc8330b12977859e77e617)