### PR TITLE
Fix internal AI sim route path

### DIFF
--- a/api/src/routes/aiSim.internal.js
+++ b/api/src/routes/aiSim.internal.js
@@ -1,7 +1,7 @@
 const express = require("express");
 const router = express.Router();
 
-router.post("/ai-sim", (req, res) => {
+router.post("/", (req, res) => {
   const { command, payload, meta } = req.body || {};
   res.json({
     echoCommand: command,


### PR DESCRIPTION
## Summary
- register the internal AI simulator handler at the root of the router to avoid a duplicated path when mounted

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932ab984a388330b4358789820ed232)