### PR TITLE
Document Render blueprint provisioning

### DIFF
--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -98,6 +98,8 @@ vercel --prod
 # 5. Render will detect render.yaml and deploy automatically
 ```
 
+The blueprint will pick up `render.yaml` after you connect the GitHub repository and provision the Postgres database, API, and web frontend services together.
+
 ---
 
 ## 🗄️ Database Setup

--- a/README.production.md
+++ b/README.production.md
@@ -71,6 +71,8 @@ cd web && vercel --prod
 # Connect repo at https://render.com
 ```
 
+Render's blueprint flow will auto-detect the `render.yaml` after you connect your GitHub repository and provision the Postgres database, API service, and web frontend together.
+
 ## Tech Stack
 
 ### API


### PR DESCRIPTION
## Summary
- clarify that Render's blueprint flow will auto-detect the render.yaml when the GitHub repo is connected
- note that the blueprint provisions the database, API, and web services together for a full-stack deployment

## Testing
- not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932c3859ea8833080679a8992bf3692)