### PR TITLE
Use shared API client for dashboard health checks

### DIFF
--- a/web/hooks/useApi.ts
+++ b/web/hooks/useApi.ts
@@ -1,21 +1,25 @@
+import { useMemo } from "react";
+
 export function useApi() {
   const base = process.env.NEXT_PUBLIC_API_BASE || "/api";
 
-  async function get(path: string) {
-    const res = await fetch(base + path);
-    if (!res.ok) throw new Error(await res.text());
-    return res.json();
-  }
+  return useMemo(() => {
+    async function get(path: string) {
+      const res = await fetch(base + path);
+      if (!res.ok) throw new Error(await res.text());
+      return res.json();
+    }
 
-  async function post(path: string, body?: any) {
-    const res = await fetch(base + path, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: body ? JSON.stringify(body) : undefined
-    });
-    if (!res.ok) throw new Error(await res.text());
-    return res.json();
-  }
+    async function post(path: string, body?: any) {
+      const res = await fetch(base + path, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: body ? JSON.stringify(body) : undefined
+      });
+      if (!res.ok) throw new Error(await res.text());
+      return res.json();
+    }
 
-  return { get, post };
+    return { get, post };
+  }, [base]);
 }


### PR DESCRIPTION
## Summary
- memoize the API client helpers so their references remain stable across renders
- have the dashboard health check use the shared API base, respecting NEXT_PUBLIC_API_BASE
- add typed health status handling with cleanup guards to avoid stale state updates

## Testing
- not run (node/npm unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932c45384ec833089d7b77bd2e3b258)