### PR TITLE
Improve API simulation routing and health check handling

### DIFF
--- a/api/src/routes/aiSim.internal.js
+++ b/api/src/routes/aiSim.internal.js
@@ -1,7 +1,7 @@
 const express = require("express");
 const router = express.Router();
 
-router.post("/ai-sim", (req, res) => {
+router.post("/", (req, res) => {
   const { command, payload, meta } = req.body || {};
   res.json({
     echoCommand: command,

--- a/api/src/services/aiSyntheticClient.js
+++ b/api/src/services/aiSyntheticClient.js
@@ -23,6 +23,9 @@ function ensureClient(client, name) {
 }
 
 async function sendSynthetic(command, payload, meta) {
+  if (!syntheticUrl || !syntheticKey) {
+    throw new Error("Synthetic AI endpoint is not configured");
+  }
   const res = await axios.post(
     syntheticUrl,
     { command, payload, meta },
@@ -51,6 +54,7 @@ async function sendAnthropic(command, payload) {
   const prompt = `You are an AI logistics agent.\nCommand: ${command}\nPayload: ${JSON.stringify(payload)}`;
   const res = await anthropic.messages.create({
     model: "claude-3-haiku-20240307",
+    max_tokens: 256,
     messages: [{ role: "user", content: prompt }]
   });
   return { provider: "anthropic", text: res.content[0].text };

--- a/web/pages/dashboard.tsx
+++ b/web/pages/dashboard.tsx
@@ -5,17 +5,21 @@ import { BillingPanel } from "../components/BillingPanel";
 export default function Dashboard() {
   const [status, setStatus] = useState<any>(null);
   const [loading, setLoading] = useState(true);
+  const apiBase = process.env.NEXT_PUBLIC_API_BASE || "/api";
+  const healthUrl = `${apiBase.replace(/\/$/, "")}/health`;
 
   useEffect(() => {
-    fetch("/api/health")
+    fetch(healthUrl)
       .then(r => {
         if (!r.ok) throw new Error(r.statusText);
         return r.json();
       })
       .then(j => setStatus(j))
-      .catch(err => setStatus({ ok: false, error: err.message }))
+      .catch(err =>
+        setStatus({ ok: false, error: err.message || "Health check failed" })
+      )
       .finally(() => setLoading(false));
-  }, []);
+  }, [healthUrl]);
 
   return (
     <main style={{ padding: "2rem" }}>


### PR DESCRIPTION
## Summary
- correct the internal AI simulation endpoint mounting path
- add configuration validation and safer Anthropic request settings
- align dashboard health check with configurable API base URL

## Testing
- not run (environment lacks Node/npm tooling)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932c79bd7d08330badf5c7b4342dabf)