### PR TITLE
Add Invoice model to Prisma schema

### DIFF
--- a/api/prisma/migrations/202501100001_add_invoice/migration.sql
+++ b/api/prisma/migrations/202501100001_add_invoice/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable: Invoice
+CREATE TABLE "Invoice" (
+    "id" TEXT NOT NULL,
+    "carrier" TEXT NOT NULL,
+    "reference" TEXT NOT NULL,
+    "totalAmount" DOUBLE PRECISION NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "auditResult" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Invoice_pkey" PRIMARY KEY ("id")
+);

--- a/api/prisma/migrations/migration_lock.toml
+++ b/api/prisma/migrations/migration_lock.toml
@@ -1,0 +1,2 @@
+provider = "postgresql"
+version = "5.11.0"

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -46,3 +46,13 @@ model AiEvent {
   payload   Json
   createdAt DateTime @default(now())
 }
+
+model Invoice {
+  id          String   @id @default(cuid())
+  carrier     String
+  reference   String
+  totalAmount Float
+  status      String   @default("pending")
+  auditResult Json?
+  createdAt   DateTime @default(now())
+}


### PR DESCRIPTION
## Summary
- add an Invoice model to the Prisma schema for carrier, reference, totals, status, and audit metadata
- include migration to create the Invoice table with defaults and JSON audit storage
- add migration lock file reflecting PostgreSQL provider version

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b7ce97e20833082edb45d3eb758f0)