### PR TITLE
Fix Vercel configuration JSON

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -7,5 +7,5 @@
     }
   ],
   "installCommand": "pnpm install --frozen-lockfile",
-  "buildCommand": "pnpm --filter @infamous-freight/shared build"
+  "buildCommand": "pnpm --filter @infamous-freight/shared build && pnpm --filter infamous-freight-web build"
 }


### PR DESCRIPTION
## Summary
- add valid Vercel configuration that targets the Next.js app in the `web` directory
- set pnpm-based install and shared package build steps to align with the monorepo build order

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943db00b83c8330b64c6c319bd38128)