### PR TITLE
Fix Stripe env key handling and pre-commit script

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-set -euo pipefail
+set -eu
 
 # Resolve repo root relative to this script so it works from any CWD
 REPO_ROOT="$(cd -- "$(dirname "$0")/.." && pwd -P)"

--- a/api/__tests__/config.test.js
+++ b/api/__tests__/config.test.js
@@ -11,7 +11,8 @@ describe("Config", () => {
 
     // Clear all environment variables
     Object.keys(process.env).forEach((key) => {
-      if (key.startsWith("API_") ||
+      if (
+        key.startsWith("API_") ||
         key.startsWith("DATABASE_") ||
         key.startsWith("CORS_") ||
         key.startsWith("OPENAI_") ||
@@ -21,7 +22,8 @@ describe("Config", () => {
         key.startsWith("AI_") ||
         key.startsWith("JWT_") ||
         key.startsWith("LOG_") ||
-        key === "NODE_ENV") {
+        key === "NODE_ENV"
+      ) {
         delete process.env[key];
       }
     });
@@ -91,7 +93,7 @@ describe("Config", () => {
     test("should throw error when DATABASE_URL is missing", () => {
       const config = require("../src/config");
       expect(() => config.getDatabaseUrl()).toThrow(
-        "Missing required environment variable: DATABASE_URL"
+        "Missing required environment variable: DATABASE_URL",
       );
     });
   });
@@ -104,7 +106,8 @@ describe("Config", () => {
     });
 
     test("should parse multiple CORS origins", () => {
-      process.env.CORS_ORIGINS = "http://localhost:3000, http://localhost:4000, https://example.com";
+      process.env.CORS_ORIGINS =
+        "http://localhost:3000, http://localhost:4000, https://example.com";
       const config = require("../src/config");
       const origins = config.getCorsOrigins();
       expect(origins).toEqual([
@@ -118,13 +121,15 @@ describe("Config", () => {
   describe("getApiKeys", () => {
     test("should throw errors when required API keys are missing", () => {
       const config = require("../src/config");
-      expect(() => config.getApiKeys()).toThrow(/Missing required environment variable/);
+      expect(() => config.getApiKeys()).toThrow(
+        /Missing required environment variable/,
+      );
     });
 
     test("should return all API keys when present", () => {
       process.env.OPENAI_API_KEY = "openai-key";
       process.env.ANTHROPIC_API_KEY = "anthropic-key";
-      process.env.STRIPE_API_KEY = "stripe-key";
+      process.env.STRIPE_SECRET_KEY = "stripe-secret-key";
       process.env.STRIPE_WEBHOOK_SECRET = "stripe-webhook";
       process.env.PAYPAL_CLIENT_ID = "paypal-id";
       process.env.PAYPAL_CLIENT_SECRET = "paypal-secret";
@@ -137,13 +142,30 @@ describe("Config", () => {
 
       expect(keys.openai).toBe("openai-key");
       expect(keys.anthropic).toBe("anthropic-key");
-      expect(keys.stripe).toBe("stripe-key");
+      expect(keys.stripe).toBe("stripe-secret-key");
       expect(keys.stripeWebhookSecret).toBe("stripe-webhook");
       expect(keys.paypalClientId).toBe("paypal-id");
       expect(keys.paypalClientSecret).toBe("paypal-secret");
       expect(keys.paypalSecret).toBe("paypal-secret-2");
       expect(keys.aiSyntheticUrl).toBe("http://localhost:8000");
       expect(keys.aiSyntheticKey).toBe("ai-key");
+    });
+
+    test("should support legacy STRIPE_API_KEY fallback", () => {
+      process.env.OPENAI_API_KEY = "openai-key";
+      process.env.ANTHROPIC_API_KEY = "anthropic-key";
+      process.env.STRIPE_API_KEY = "legacy-stripe-key";
+      process.env.STRIPE_WEBHOOK_SECRET = "stripe-webhook";
+      process.env.PAYPAL_CLIENT_ID = "paypal-id";
+      process.env.PAYPAL_CLIENT_SECRET = "paypal-secret";
+      process.env.PAYPAL_SECRET = "paypal-secret-2";
+      process.env.AI_SYNTHETIC_ENGINE_URL = "http://localhost:8000";
+      process.env.AI_SYNTHETIC_API_KEY = "ai-key";
+
+      const config = require("../src/config");
+      const keys = config.getApiKeys();
+
+      expect(keys.stripe).toBe("legacy-stripe-key");
     });
   });
 
@@ -157,7 +179,7 @@ describe("Config", () => {
     test("should throw error when JWT_SECRET is missing", () => {
       const config = require("../src/config");
       expect(() => config.getJwtSecret()).toThrow(
-        "Missing required environment variable: JWT_SECRET"
+        "Missing required environment variable: JWT_SECRET",
       );
     });
   });
@@ -200,7 +222,7 @@ describe("Config", () => {
       test("should throw error when variable is missing and no default", () => {
         const config = require("../src/config");
         expect(() => config.requireEnv("MISSING_VAR")).toThrow(
-          "Missing required environment variable: MISSING_VAR"
+          "Missing required environment variable: MISSING_VAR",
         );
       });
     });

--- a/api/scripts/env.validation.js
+++ b/api/scripts/env.validation.js
@@ -22,7 +22,8 @@ try {
     assertEnv(["ANTHROPIC_API_KEY"], "Anthropic configuration");
   }
 
-  if (process.env.STRIPE_SECRET_KEY) {
+  const stripeKey = process.env.STRIPE_SECRET_KEY || process.env.STRIPE_API_KEY;
+  if (stripeKey) {
     assertEnv(
       ["STRIPE_SUCCESS_URL", "STRIPE_CANCEL_URL"],
       "Stripe redirect URLs",

--- a/api/src/config.js
+++ b/api/src/config.js
@@ -31,10 +31,19 @@ class Config {
 
   // Third-party API Keys
   getApiKeys() {
+    const stripeSecret =
+      this.getEnv("STRIPE_SECRET_KEY") || this.getEnv("STRIPE_API_KEY");
+
+    if (!stripeSecret) {
+      throw new Error(
+        "Missing required environment variable: STRIPE_SECRET_KEY (or STRIPE_API_KEY)",
+      );
+    }
+
     return {
       openai: this.requireEnv("OPENAI_API_KEY"),
       anthropic: this.requireEnv("ANTHROPIC_API_KEY"),
-      stripe: this.requireEnv("STRIPE_API_KEY"),
+      stripe: stripeSecret,
       stripeWebhookSecret: this.requireEnv("STRIPE_WEBHOOK_SECRET"),
       paypalClientId: this.requireEnv("PAYPAL_CLIENT_ID"),
       paypalClientSecret: this.requireEnv("PAYPAL_CLIENT_SECRET"),


### PR DESCRIPTION
## Summary
- align API key discovery to prefer STRIPE_SECRET_KEY with legacy STRIPE_API_KEY fallback
- update config tests and env validation to match Stripe secret key usage
- fix husky pre-commit script to run under POSIX sh

## Testing
- LOG_LEVEL=error pnpm --filter infamous-freight-api test -- --runInBand --silent

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a05f2ada08330b4f7924ea9f524a8)