### PR TITLE
fix(db): expose prisma named export

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-set -euo pipefail
+set -eu
 
 # Resolve repo root relative to this script so it works from any CWD
 REPO_ROOT="$(cd -- "$(dirname "$0")/.." && pwd -P)"

--- a/api/__tests__/db.prisma.test.js
+++ b/api/__tests__/db.prisma.test.js
@@ -1,0 +1,15 @@
+describe("Prisma client export", () => {
+  test("exports the client for named imports (and optional default)", () => {
+    jest.resetModules();
+
+    // Use the real module but rely on the global Prisma mock from jest.setup.js
+    const prismaModule = jest.requireActual("../src/db/prisma");
+
+    expect(prismaModule).toBeDefined();
+    expect(prismaModule.prisma).toBeDefined();
+    expect(prismaModule.default ?? prismaModule.prisma).toBe(
+      prismaModule.prisma,
+    );
+    expect(typeof prismaModule.prisma.$disconnect).toBe("function");
+  });
+});

--- a/api/src/db/prisma.js
+++ b/api/src/db/prisma.js
@@ -24,4 +24,5 @@ process.on("SIGTERM", async () => {
   process.exit(0);
 });
 
-module.exports = prisma;
+// Support named imports for compatibility with existing route handlers
+module.exports = { prisma };


### PR DESCRIPTION
## Summary
- export the Prisma client as a named export so existing route handlers can import it reliably
- add a unit test to verify the Prisma module exposes the client for named (and optional default) imports using the existing Jest Prisma mock
- update the Husky pre-commit hook to use POSIX-compatible shell options so lint-staged runs instead of failing on unsupported flags

## Testing
- pnpm -C api test -- --runInBand

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b8132762883309f0450001a8a10e7)