### PR TITLE
Add offline synthetic fallback for invoice audit command

### DIFF
--- a/api/src/services/__tests__/aiSyntheticClient.test.js
+++ b/api/src/services/__tests__/aiSyntheticClient.test.js
@@ -66,9 +66,17 @@ describe("aiSyntheticClient sendCommand", () => {
 
     const { sendCommand } = require("../aiSyntheticClient");
 
-    await expect(sendCommand("anything")).rejects.toMatchObject({
-      message: "Synthetic AI engine not configured",
-      status: 503,
+    const result = await sendCommand("audit_invoice", {
+      invoice: { currency: "USD", totalAmount: 2500 },
+    });
+
+    expect(result).toMatchObject({
+      provider: "synthetic",
+      source: "offline-fallback",
+      command: "audit_invoice",
+    });
+    expect(result.meta).toMatchObject({
+      fallbackReason: "missing_configuration",
     });
   });
 
@@ -91,10 +99,16 @@ describe("aiSyntheticClient sendCommand", () => {
 
     const { sendCommand } = require("../aiSyntheticClient");
 
-    await expect(sendCommand("track")).rejects.toMatchObject({
-      message: "Synthetic AI engine request failed",
+    const result = await sendCommand("track");
+
+    expect(result).toMatchObject({
+      provider: "synthetic",
+      source: "offline-fallback",
+      command: "track",
+    });
+    expect(result.meta).toMatchObject({
+      fallbackReason: "request_failed",
       status: 429,
-      details: { error: "rate limit" },
     });
     expect(postMock).toHaveBeenCalledTimes(1);
   });

--- a/api/src/services/__tests__/syntheticFallback.test.js
+++ b/api/src/services/__tests__/syntheticFallback.test.js
@@ -1,0 +1,51 @@
+const { auditInvoice, generateSyntheticResponse } = require("../syntheticFallback");
+
+describe("syntheticFallback", () => {
+  describe("auditInvoice", () => {
+    test("returns approval when invoice passes checks", () => {
+      const result = auditInvoice({
+        invoice: {
+          carrier: "ACME Logistics",
+          reference: "INV-123",
+          totalAmount: 12500,
+          currency: "USD",
+        },
+        ruleset: "standard_freight",
+      });
+
+      expect(result.status).toBe("approved");
+      expect(result.issues).toHaveLength(0);
+      expect(result.summary).toContain("passes");
+      expect(result.confidence).toBeGreaterThan(0.8);
+    });
+
+    test("flags missing fields and unsupported currency", () => {
+      const result = auditInvoice({
+        invoice: {
+          totalAmount: -50,
+          currency: "ZAR",
+        },
+      });
+
+      const issueCodes = result.issues.map((issue) => issue.code);
+      expect(result.status).toBe("rejected");
+      expect(issueCodes).toEqual(
+        expect.arrayContaining([
+          "invalid_total",
+          "missing_reference",
+          "missing_carrier",
+          "unsupported_currency",
+        ]),
+      );
+      expect(result.confidence).toBeLessThan(0.7);
+    });
+  });
+
+  test("generateSyntheticResponse falls back to default for unknown commands", () => {
+    const result = generateSyntheticResponse("unknown.action", { foo: "bar" });
+    expect(result.command).toBe("unknown.action");
+    expect(result.provider).toBe("synthetic");
+    expect(result.source).toBe("offline-fallback");
+    expect(result.echo.payload).toEqual({ foo: "bar" });
+  });
+});

--- a/api/src/services/syntheticFallback.js
+++ b/api/src/services/syntheticFallback.js
@@ -1,0 +1,144 @@
+const SUPPORTED_CURRENCIES = ["USD", "EUR", "GBP", "CAD", "AUD"];
+
+const severityWeights = {
+  error: 35,
+  warning: 15,
+  info: 5,
+};
+
+function calculateConfidence(issues) {
+  if (!issues.length) return 0.92;
+
+  const totalPenalty = issues.reduce(
+    (sum, issue) => sum + (severityWeights[issue.severity] || 10),
+    0,
+  );
+  const normalizedPenalty = Math.min(100, totalPenalty);
+  const confidence = Math.max(0.4, 1 - normalizedPenalty / 120);
+  return Number(confidence.toFixed(2));
+}
+
+function auditInvoice(payload = {}, meta = {}, context = {}) {
+  const invoice = payload.invoice || {};
+  const ruleset = payload.ruleset || "standard_freight";
+  const issues = [];
+
+  const amount = Number(invoice.totalAmount);
+  if (!Number.isFinite(amount) || amount <= 0) {
+    issues.push({
+      code: "invalid_total",
+      field: "invoice.totalAmount",
+      severity: "error",
+      message: "Total amount must be a positive number.",
+    });
+  } else if (amount > 50000) {
+    issues.push({
+      code: "high_value",
+      field: "invoice.totalAmount",
+      severity: "warning",
+      message: "High-value invoice. Verify contract and approval limits.",
+    });
+  }
+
+  if (!invoice.reference) {
+    issues.push({
+      code: "missing_reference",
+      field: "invoice.reference",
+      severity: "error",
+      message: "Invoice reference is required for reconciliation.",
+    });
+  }
+
+  if (!invoice.carrier) {
+    issues.push({
+      code: "missing_carrier",
+      field: "invoice.carrier",
+      severity: "warning",
+      message: "Carrier name is missing. Confirm the bill of lading source.",
+    });
+  }
+
+  if (!invoice.currency) {
+    issues.push({
+      code: "missing_currency",
+      field: "invoice.currency",
+      severity: "error",
+      message: "Currency is required to audit totals.",
+    });
+  } else if (!SUPPORTED_CURRENCIES.includes(invoice.currency)) {
+    issues.push({
+      code: "unsupported_currency",
+      field: "invoice.currency",
+      severity: "warning",
+      message: `Currency ${invoice.currency} is not in the standard freight policy list.`,
+    });
+  }
+
+  const status = issues.some((issue) => issue.severity === "error")
+    ? "rejected"
+    : issues.length
+      ? "needs_review"
+      : "approved";
+
+  const confidence = calculateConfidence(issues);
+  const recommendations = [
+    "Verify bill of lading against the invoice reference.",
+    "Confirm applied fuel surcharge and accessorial fees match contract terms.",
+    "Cross-check carrier billing contact before releasing payment.",
+  ];
+
+  return {
+    provider: "synthetic",
+    source: "offline-fallback",
+    command: "audit_invoice",
+    ruleset,
+    status,
+    confidence,
+    issues,
+    summary:
+      status === "approved"
+        ? "Invoice passes standard freight checks."
+        : "Invoice flagged for review under standard freight checks.",
+    recommendations,
+    meta: { ...meta, ...context },
+    invoice: {
+      carrier: invoice.carrier || null,
+      reference: invoice.reference || null,
+      totalAmount: Number.isFinite(amount) ? amount : null,
+      currency: invoice.currency || null,
+    },
+  };
+}
+
+function defaultSynthetic(command, payload = {}, meta = {}, context = {}) {
+  return {
+    provider: "synthetic",
+    source: "offline-fallback",
+    command,
+    summary: `Synthetic response generated locally for '${command}'.`,
+    confidence: 0.72,
+    echo: {
+      payload,
+      meta: { ...meta, ...context },
+    },
+    meta: { ...meta, ...context },
+  };
+}
+
+function generateSyntheticResponse(
+  command,
+  payload = {},
+  meta = {},
+  context = {},
+) {
+  if (command === "audit_invoice") {
+    return auditInvoice(payload, meta, context);
+  }
+
+  return defaultSynthetic(command, payload, meta, context);
+}
+
+module.exports = {
+  auditInvoice,
+  generateSyntheticResponse,
+};


### PR DESCRIPTION
## Summary
- add an offline synthetic fallback handler for AI commands, including invoice auditing logic
- route synthetic provider calls through the fallback when the engine is missing or errors
- cover the fallback behaviors with new unit tests

## Testing
- cd api && pnpm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b8193afdc8330af33db72e92dbd54)