### PR TITLE
ci: fix Prisma schema path and shared build

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -28,7 +28,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Generate Prisma client
-        run: pnpm -w exec prisma generate
+        run: pnpm -w exec prisma generate --schema api/prisma/schema.prisma
         continue-on-error: true
 
       - name: Set up Docker Buildx

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-set -euo pipefail
+set -eu
 
 # Resolve repo root relative to this script so it works from any CWD
 REPO_ROOT="$(cd -- "$(dirname "$0")/.." && pwd -P)"

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -16,6 +16,9 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 FROM base AS builder-shared
 WORKDIR /app
 COPY --from=dependencies /app/node_modules ./node_modules
+COPY --from=dependencies /app/pnpm-lock.yaml ./pnpm-lock.yaml
+COPY --from=dependencies /app/pnpm-workspace.yaml ./pnpm-workspace.yaml
+COPY --from=dependencies /app/package.json ./package.json
 COPY packages/shared ./packages/shared
 RUN pnpm --filter=@infamous-freight/shared build
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "node": ">=20.18.1 <21"
   },
   "type": "module",
+  "prisma": {
+    "schema": "api/prisma/schema.prisma"
+  },
   "workspaces": [
     "api",
     "web",


### PR DESCRIPTION
## Summary
- declare the Prisma schema path so CI and tooling resolve api/prisma/schema.prisma
- copy workspace manifests into the shared-package build stage to avoid missing node_modules errors during Docker builds
- make the Husky pre-commit script POSIX compatible for the configured hooks path

## Testing
- pnpm install --frozen-lockfile
- pnpm -w exec prisma generate --schema api/prisma/schema.prisma *(fails: Prisma engine download blocked by 403 Forbidden; set PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING to bypass checksum, but engine download still forbidden)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b842f9498833094854b48bd739ac3)