### PR TITLE
Add database connectivity to health check

### DIFF
--- a/api/jest.setup.js
+++ b/api/jest.setup.js
@@ -42,6 +42,7 @@ jest.mock("@prisma/client", () => {
       update: jest.fn(() => Promise.resolve({})),
       delete: jest.fn(() => Promise.resolve({})),
     },
+    $queryRaw: jest.fn(() => Promise.resolve([{ ok: 1 }])),
     $disconnect: jest.fn(),
   };
 
@@ -79,8 +80,9 @@ jest.mock("./src/db/prisma.js", () => {
       origin: data.origin,
       destination: data.destination,
       driverId: data.driverId || null,
-      status: data.status || 'created',
-      trackingNumber: 'TRK-' + Math.random().toString(36).substr(2, 9).toUpperCase(),
+      status: data.status || "created",
+      trackingNumber:
+        "TRK-" + Math.random().toString(36).substr(2, 9).toUpperCase(),
       createdAt: new Date(),
       updatedAt: new Date(),
       driver: null,
@@ -90,12 +92,12 @@ jest.mock("./src/db/prisma.js", () => {
   const mockShipmentFindMany = jest.fn(() =>
     Promise.resolve([
       {
-        id: 'shipment-1',
-        reference: 'REF-001',
-        origin: 'New York, NY',
-        destination: 'Los Angeles, CA',
-        status: 'created',
-        trackingNumber: 'TRK-ABC123',
+        id: "shipment-1",
+        reference: "REF-001",
+        origin: "New York, NY",
+        destination: "Los Angeles, CA",
+        status: "created",
+        trackingNumber: "TRK-ABC123",
         createdAt: new Date(),
         updatedAt: new Date(),
         driver: null,
@@ -105,12 +107,12 @@ jest.mock("./src/db/prisma.js", () => {
 
   const mockShipmentFindUnique = jest.fn(() =>
     Promise.resolve({
-      id: 'shipment-1',
-      reference: 'REF-001',
-      origin: 'New York, NY',
-      destination: 'Los Angeles, CA',
-      status: 'created',
-      trackingNumber: 'TRK-ABC123',
+      id: "shipment-1",
+      reference: "REF-001",
+      origin: "New York, NY",
+      destination: "Los Angeles, CA",
+      status: "created",
+      trackingNumber: "TRK-ABC123",
       createdAt: new Date(),
       updatedAt: new Date(),
       driver: null,
@@ -135,6 +137,7 @@ jest.mock("./src/db/prisma.js", () => {
     aiEvent: {
       create: jest.fn(() => Promise.resolve({})),
     },
+    $queryRaw: jest.fn(() => Promise.resolve([{ ok: 1 }])),
     $transaction: jest.fn((cb) => {
       // Mock $transaction to call the callback with a mock tx object
       const mockTx = {

--- a/api/src/db/prisma.js
+++ b/api/src/db/prisma.js
@@ -24,4 +24,4 @@ process.on("SIGTERM", async () => {
   process.exit(0);
 });
 
-module.exports = prisma;
+module.exports = { prisma };

--- a/api/src/routes/__tests__/health.test.js
+++ b/api/src/routes/__tests__/health.test.js
@@ -1,5 +1,32 @@
+const request = require("supertest");
+const app = require("../../server");
+const { prisma } = require("../../db/prisma");
+
 describe("Health Route", () => {
-  test("should return ok status", () => {
-    expect(true).toBe(true);
+  beforeEach(() => {
+    prisma.$queryRaw.mockReset();
+    prisma.$queryRaw.mockResolvedValue([{ ok: 1 }]);
+  });
+
+  test("returns ok with database connected", async () => {
+    const res = await request(app).get("/api/health");
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("ok");
+    expect(res.body.database).toBe("connected");
+    expect(res.body).toHaveProperty("timestamp");
+    expect(res.body).toHaveProperty("uptime");
+    expect(res.body.databaseLatencyMs).toEqual(expect.any(Number));
+  });
+
+  test("returns degraded when database check fails", async () => {
+    prisma.$queryRaw.mockRejectedValueOnce(new Error("db down"));
+
+    const res = await request(app).get("/api/health");
+
+    expect(res.status).toBe(503);
+    expect(res.body.status).toBe("degraded");
+    expect(res.body.database).toBe("disconnected");
+    expect(res.body.databaseLatencyMs).toBeNull();
   });
 });

--- a/api/src/routes/health.js
+++ b/api/src/routes/health.js
@@ -1,16 +1,38 @@
 const express = require("express");
 const { version } = require("../../package.json");
+const { prisma } = require("../db/prisma");
+const { logger } = require("../middleware/logger");
 
 const router = express.Router();
 
-router.get("/health", (_req, res) => {
-  res.json({
-    status: "ok",
+router.get("/health", async (_req, res) => {
+  const startedAt = Date.now();
+  let databaseStatus = "disconnected";
+  let databaseLatencyMs = null;
+
+  try {
+    await prisma.$queryRaw`SELECT 1`;
+    databaseStatus = "connected";
+    databaseLatencyMs = Date.now() - startedAt;
+  } catch (error) {
+    logger.warn(
+      { error: error.message },
+      "Database connectivity check failed during health probe",
+    );
+  }
+
+  const isHealthy = databaseStatus === "connected";
+  const statusCode = isHealthy ? 200 : 503;
+
+  res.status(statusCode).json({
+    status: isHealthy ? "ok" : "degraded",
     service: "infamous-freight-api",
     version: version || "2.0.0",
     timestamp: new Date().toISOString(),
     uptime: process.uptime(),
     environment: process.env.NODE_ENV || "development",
+    database: databaseStatus,
+    databaseLatencyMs,
   });
 });
 


### PR DESCRIPTION
## Summary
- return database connectivity status and latency from the /api/health endpoint
- export the Prisma client in a way that matches destructured imports throughout the API
- extend Jest setup and health route tests to cover database probing behavior

## Testing
- npm test -- --runInBand

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b96656624833084508b0a25d59143)