### PR TITLE
Configure Vercel frontend to use Fly API base URL

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "framework": "nextjs",
+  "rootDirectory": "web",
+  "buildCommand": "pnpm build",
+  "outputDirectory": ".next"
+}

--- a/web/.env.preview
+++ b/web/.env.preview
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_BASE_URL=https://infamous-freight-api.fly.dev

--- a/web/.env.production
+++ b/web/.env.production
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_BASE_URL=https://infamous-freight-api.fly.dev

--- a/web/hooks/useApi.ts
+++ b/web/hooks/useApi.ts
@@ -1,5 +1,5 @@
 export function useApi() {
-  const base = process.env.NEXT_PUBLIC_API_BASE || "/api";
+  const base = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";
 
   function buildHeaders(custom?: HeadersInit) {
     const headers: HeadersInit = { ...(custom || {}) };

--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -8,7 +8,7 @@ const nextConfig = {
   reactStrictMode: true,
   output: "standalone", // Enable standalone output for Docker optimization
   env: {
-    NEXT_PUBLIC_API_BASE: process.env.NEXT_PUBLIC_API_BASE,
+    NEXT_PUBLIC_API_BASE_URL: process.env.NEXT_PUBLIC_API_BASE_URL,
     NEXT_PUBLIC_APP_NAME: process.env.NEXT_PUBLIC_APP_NAME,
     NEXT_PUBLIC_ENV: process.env.NEXT_PUBLIC_ENV,
   },
@@ -24,7 +24,7 @@ const nextConfig = {
     afterFiles: [
       {
         source: '/api/:path*',
-        destination: 'https://infamous-freight-ai.fly.dev/api/:path*',
+        destination: 'https://infamous-freight-api.fly.dev/api/:path*',
       },
     ],
   }),

--- a/web/pages/dashboard.tsx
+++ b/web/pages/dashboard.tsx
@@ -13,7 +13,7 @@ export default function Dashboard() {
       timestamp: new Date().toISOString(),
     });
 
-    const base = process.env.NEXT_PUBLIC_API_BASE || "/api";
+    const base = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";
     fetch(`${base}/health`)
       .then((res) => res.json())
       .then((data) => {


### PR DESCRIPTION
## Summary
- configure Vercel deployment to build the Next.js web app from the web directory
- add production and preview environment files pointing to the Fly API base URL
- expose the new NEXT_PUBLIC_API_BASE_URL in Next.js config and use it for frontend API requests and rewrites

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b9c336d00833080160db6cfa6d676)