### PR TITLE
Configure Vercel for web-only deployment using Fly.io API

### DIFF
--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -4,6 +4,8 @@ const withBundleAnalyzer = bundleAnalyzer({
   enabled: process.env.ANALYZE === "true",
 });
 
+const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || "https://infamous-freight-api.fly.dev";
+
 const nextConfig = {
   reactStrictMode: true,
   output: "standalone", // Enable standalone output for Docker optimization
@@ -24,7 +26,7 @@ const nextConfig = {
     afterFiles: [
       {
         source: '/api/:path*',
-        destination: 'https://infamous-freight-api.fly.dev/api/:path*',
+        destination: `${apiBaseUrl}/api/:path*`,
       },
     ],
   }),


### PR DESCRIPTION
## Summary
- allow the Next.js rewrite to respect NEXT_PUBLIC_API_BASE_URL with a Fly.io default

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b9ef6a0b483309c29f374fdeb1d59)