### PR TITLE
Prefer NEXT_PUBLIC_API_URL for Next.js API rewrites

### DIFF
--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -4,12 +4,16 @@ const withBundleAnalyzer = bundleAnalyzer({
   enabled: process.env.ANALYZE === "true",
 });
 
-const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || "https://infamous-freight-api.fly.dev";
+const apiBaseUrl =
+  process.env.NEXT_PUBLIC_API_URL ||
+  process.env.NEXT_PUBLIC_API_BASE_URL ||
+  "https://infamous-freight-api.fly.dev";
 
 const nextConfig = {
   reactStrictMode: true,
   output: "standalone", // Enable standalone output for Docker optimization
   env: {
+    NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
     NEXT_PUBLIC_API_BASE_URL: process.env.NEXT_PUBLIC_API_BASE_URL,
     NEXT_PUBLIC_APP_NAME: process.env.NEXT_PUBLIC_APP_NAME,
     NEXT_PUBLIC_ENV: process.env.NEXT_PUBLIC_ENV,


### PR DESCRIPTION
## Summary
- prioritize NEXT_PUBLIC_API_URL for computed API base URL with fallback to NEXT_PUBLIC_API_BASE_URL
- expose NEXT_PUBLIC_API_URL to the Next.js runtime environment for API calls

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ba419d2708330ab26202d01d74cba)