### PR TITLE
Update Vercel config for supported web build

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,5 @@
 {
   "framework": "nextjs",
-  "rootDirectory": "web",
-  "buildCommand": "pnpm build",
-  "outputDirectory": ".next"
+  "buildCommand": "cd web && pnpm install --frozen-lockfile && pnpm build",
+  "outputDirectory": "web/.next"
 }


### PR DESCRIPTION
## Summary
- replace the unsupported `rootDirectory` setting in `vercel.json` with the supported build/output configuration
- ensure the build runs inside the `web` workspace using `pnpm install --frozen-lockfile && pnpm build` and outputs `web/.next`

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ba58a1c6883309cde47663070a632)