### PR TITLE
Add driver coaching and dispatch intelligence capabilities

### DIFF
--- a/api/src/routes/ai.ts
+++ b/api/src/routes/ai.ts
@@ -1,5 +1,84 @@
 import { Router } from "express";
+import { z } from "zod";
 import { aiDecisionV1 } from "../ai/v1";
+import { prisma } from "../db/prisma";
+import { requireAuth } from "../middleware/auth";
+import { driverCoach } from "../services/ai-engine/src/skills/driverCoach";
+import { dispatchIntel } from "../services/ai-engine/src/skills/dispatchIntel";
 
 export const ai = Router();
 ai.post("/audit", (_, res) => res.json(aiDecisionV1()));
+
+const driverCoachSchema = z.object({
+  driverId: z.string(),
+  event: z.object({
+    lateMinutes: z.number().min(0).default(0),
+    hardBrakes: z.number().min(0).default(0),
+    dwellMinutes: z.number().min(0).optional(),
+    routeId: z.string().optional(),
+  }),
+});
+
+const dispatchSchema = z.object({
+  route: z.object({
+    id: z.string().optional(),
+    trafficRisk: z.number().min(0).max(1),
+    delayMinutes: z.number().optional(),
+    etaMinutes: z.number().optional(),
+    customerPriority: z.enum(["standard", "priority", "expedite"]).optional(),
+  }),
+  driver: z.object({
+    id: z.string().optional(),
+    name: z.string().optional(),
+    safetyScore: z.number().min(0).max(1).optional(),
+    utilization: z.number().min(0).max(1).optional(),
+    currentLoad: z.number().min(0).optional(),
+  }),
+});
+
+ai.post("/driver/coach", requireAuth, async (req, res) => {
+  const parsed = driverCoachSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.message });
+  }
+
+  const result = await driverCoach(
+    parsed.data.driverId,
+    req.user.organizationId,
+    parsed.data.event,
+  );
+
+  return res.json({
+    ...result,
+    driverId: parsed.data.driverId,
+    organizationId: req.user.organizationId,
+  });
+});
+
+ai.post("/dispatch/evaluate", requireAuth, async (req, res) => {
+  const parsed = dispatchSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.message });
+  }
+
+  const result = dispatchIntel(parsed.data.route, parsed.data.driver);
+  const decision = await prisma.aiDecision.create({
+    data: {
+      organizationId: req.user.organizationId,
+      type: "dispatch:evaluate",
+      confidence: result.confidence,
+      rationale: JSON.stringify({
+        route: parsed.data.route,
+        driver: parsed.data.driver,
+        recommendedNext: result.recommendedNext,
+      }),
+    },
+  });
+
+  return res.json({
+    ...result,
+    decisionId: decision.id,
+    routeId: parsed.data.route.id ?? null,
+    driverId: parsed.data.driver.id ?? null,
+  });
+});

--- a/api/src/services/ai-engine/src/skills/dispatchIntel.ts
+++ b/api/src/services/ai-engine/src/skills/dispatchIntel.ts
@@ -1,0 +1,106 @@
+import { calibrate } from "../../../../ai/v2";
+
+type DispatchRoute = {
+  id?: string;
+  trafficRisk: number;
+  delayMinutes?: number;
+  etaMinutes?: number;
+  customerPriority?: "standard" | "priority" | "expedite";
+};
+
+type DispatchDriver = {
+  id?: string;
+  name?: string;
+  safetyScore?: number;
+  utilization?: number;
+  currentLoad?: number;
+};
+
+export type DispatchIntelResult = {
+  action: "REROUTE" | "MONITOR" | "BALANCE";
+  message: string;
+  confidence: number;
+  etaDeltaMinutes: number;
+  driverImpact: string;
+  recommendedNext: string[];
+};
+
+function computeDriverImpact(
+  driver: DispatchDriver,
+  etaDeltaMinutes: number,
+): string {
+  if ((driver.utilization ?? 0) > 0.9) {
+    return "Driver nearing capacity—balance remaining loads.";
+  }
+
+  if (etaDeltaMinutes < 0) {
+    return "Driver efficiency improves with the new route.";
+  }
+
+  if ((driver.safetyScore ?? 1) < 0.6) {
+    return "Guardrails applied: monitor aggressive maneuvers.";
+  }
+
+  return "Driver impact neutral—keep monitoring.";
+}
+
+export function dispatchIntel(
+  route: DispatchRoute,
+  driver: DispatchDriver,
+): DispatchIntelResult {
+  const baseRisk = route.trafficRisk ?? 0;
+  const delayMinutes = route.delayMinutes ?? 0;
+  const etaMinutes = route.etaMinutes ?? 0;
+  const isPriority = route.customerPriority === "priority";
+
+  if (baseRisk > 0.7 || delayMinutes > 15) {
+    const etaDeltaMinutes = delayMinutes > 0 ? -Math.min(delayMinutes, 25) : -18;
+    const confidence = calibrate(0.86 + baseRisk * 0.1);
+    const rerouteMessage =
+      baseRisk > 0.7
+        ? "Traffic detected. Rerouting to save 18 minutes."
+        : "Delay detected. Rerouting to claw back time.";
+    return {
+      action: "REROUTE",
+      message: rerouteMessage,
+      confidence,
+      etaDeltaMinutes,
+      driverImpact: computeDriverImpact(driver, etaDeltaMinutes),
+      recommendedNext: [
+        "Notify customer with revised ETA",
+        "Sync reroute to driver nav",
+        "Capture telemetry for post-run learning",
+      ],
+    };
+  }
+
+  if (isPriority && etaMinutes > 60) {
+    const etaDeltaMinutes = -12;
+    const confidence = calibrate(0.8);
+    return {
+      action: "BALANCE",
+      message: "Priority load detected. Rebalancing to protect SLA.",
+      confidence,
+      etaDeltaMinutes,
+      driverImpact: computeDriverImpact(driver, etaDeltaMinutes),
+      recommendedNext: [
+        "Reassign nearby driver with better proximity",
+        "Alert dispatcher with swap proposal",
+        "Update customer SLA tracker",
+      ],
+    };
+  }
+
+  return {
+    action: "MONITOR",
+    message: "Route stable.",
+    confidence: calibrate(0.68),
+    etaDeltaMinutes: 0,
+    driverImpact: computeDriverImpact(driver, 0),
+    recommendedNext: [
+      "Continue telemetry monitoring",
+      "Run next checkpoint in 15 minutes",
+      "Keep customer ETA steady",
+    ],
+  };
+}

--- a/api/src/services/ai-engine/src/skills/driverCoach.ts
+++ b/api/src/services/ai-engine/src/skills/driverCoach.ts
@@ -1,0 +1,114 @@
+import { prisma } from "../../../../db/prisma";
+
+type DriverEvent = {
+  lateMinutes?: number;
+  hardBrakes?: number;
+  dwellMinutes?: number;
+  routeId?: string;
+};
+
+type DriverCoachResult = {
+  type: "COACHING";
+  message: string;
+  confidenceImpact: number;
+  tone: "positive" | "caution" | "urgent";
+  memoryKey: string;
+  decisionId: string;
+};
+
+function selectCoaching(event: DriverEvent): Omit<
+  DriverCoachResult,
+  "type" | "memoryKey"
+> {
+  const lateMinutes = event.lateMinutes ?? 0;
+  const hardBrakes = event.hardBrakes ?? 0;
+  const dwellMinutes = event.dwellMinutes ?? 0;
+
+  if (hardBrakes > 3) {
+    return {
+      message: "Drive smoother to improve safety score.",
+      confidenceImpact: 0.2,
+      tone: "caution",
+    };
+  }
+
+  if (lateMinutes > 15) {
+    return {
+      message: "You're running late. Reduce idle time at the next stop.",
+      confidenceImpact: 0.18,
+      tone: "urgent",
+    };
+  }
+
+  if (lateMinutes > 7 || dwellMinutes > 10) {
+    return {
+      message:
+        "Trend a tighter schedule on the next leg—minimize idle and keep pace.",
+      confidenceImpact: 0.14,
+      tone: "caution",
+    };
+  }
+
+  return {
+    message: "Good job maintaining schedule.",
+    confidenceImpact: 0.1,
+    tone: "positive",
+  };
+}
+
+export async function driverCoach(
+  driverId: string,
+  organizationId: string,
+  event: DriverEvent,
+): Promise<DriverCoachResult> {
+  const memoryKey = "driver:coaching:last";
+  const prior = await prisma.avatarMemory.findFirst({
+    where: { userId: driverId, organizationId, key: memoryKey },
+    orderBy: { createdAt: "desc" },
+  });
+
+  const coaching = selectCoaching(event);
+
+  let decisionId: string | undefined;
+
+  if (prior) {
+    await prisma.avatarMemory.update({
+      where: { id: prior.id },
+      data: { value: coaching.message, confidence: coaching.confidenceImpact },
+    });
+  } else {
+    await prisma.avatarMemory.create({
+      data: {
+        userId: driverId,
+        organizationId,
+        category: "coaching",
+        key: memoryKey,
+        value: coaching.message,
+        confidence: coaching.confidenceImpact,
+        pinned: true,
+      },
+    });
+  }
+
+  const decision = await prisma.aiDecision.create({
+    data: {
+      organizationId,
+      type: "driver:coaching",
+      confidence: coaching.confidenceImpact,
+      rationale: JSON.stringify({
+        event,
+        routeId: event.routeId,
+        tone: coaching.tone,
+        memoryKey,
+      }),
+    },
+  });
+  decisionId = decision.id;
+
+  return {
+    type: "COACHING",
+    memoryKey,
+    decisionId,
+    ...coaching,
+  };
+}

--- a/api/src/services/avatar-engine/src/voice.ts
+++ b/api/src/services/avatar-engine/src/voice.ts
@@ -1,0 +1,42 @@
+type VoiceContext = {
+  nextStop?: string;
+  etaMinutes?: number;
+  behindScheduleMinutes?: number;
+  safetyIssues?: string[];
+  dispatchNote?: string;
+};
+
+export async function handleVoiceCommand(
+  command: string,
+  context: VoiceContext = {},
+): Promise<string> {
+  const normalized = command.toLowerCase();
+
+  if (normalized.includes("next stop")) {
+    const eta = context.etaMinutes ?? 38;
+    const stop = context.nextStop ?? "scheduled checkpoint";
+    return `Your next stop is ${stop}. ETA ${eta} minutes.`;
+  }
+
+  if (normalized.includes("behind schedule") || normalized.includes("delay")) {
+    const delay = context.behindScheduleMinutes ?? 12;
+    return `You're behind by ${delay} minutes. Reduce idle time and maintain speed consistency.`;
+  }
+
+  if (normalized.includes("coach")) {
+    return "Maintain speed consistency to recover 7 minutes.";
+  }
+
+  if (normalized.includes("safety")) {
+    const issues = context.safetyIssues?.join(", ");
+    return issues
+      ? `Safety watch: ${issues}. Keep braking smooth and increase following distance.`
+      : "No safety issues detected. Keep braking smooth and eyes forward.";
+  }
+
+  if (normalized.includes("dispatch")) {
+    return context.dispatchNote ?? "Dispatch acknowledged. Monitoring your route.";
+  }
+
+  return "Command acknowledged.";
+}

--- a/docs/pitch-deck-content.md
+++ b/docs/pitch-deck-content.md
@@ -1,0 +1,102 @@
+# Infæmous Synthetic Intelligence Platform – Pitch Deck
+
+Below is production-ready content for PDF export. Slides are structured so design can be applied directly.
+
+---
+
+## Slide 1 — Title
+
+**Infæmous Synthetic Intelligence Platform**  
+AI Operating System for Logistics & Freight
+
+---
+
+## Slide 2 — Problem
+
+Logistics companies suffer from:
+
+- Reactive dispatch
+- Driver inefficiency
+- No intelligence continuity
+- Fragmented systems
+
+---
+
+## Slide 3 — Solution
+
+A persistent AI operator with:
+
+- Memory
+- Avatars
+- Coaching
+- Dispatch intelligence
+- Revenue optimization
+
+---
+
+## Slide 4 — Product
+
+- Driver Avatars
+- Live Coaching AI
+- Autonomous Dispatch
+- Memory-backed decisions
+- Voice-enabled operations
+
+---
+
+## Slide 5 — Technology Moat
+
+- Persistent memory graph
+- Avatar evolution layer
+- Freight-specific AI skills
+- Action-first intelligence
+- Vendor-agnostic AI stack
+
+---
+
+## Slide 6 — Market
+
+- $800B+ global logistics market
+- SMB → Enterprise scalability
+- High automation demand
+
+---
+
+## Slide 7 — Business Model
+
+- SaaS subscriptions
+- Usage-based AI billing
+- Per-driver pricing
+- Enterprise contracts
+
+---
+
+## Slide 8 — Traction (Positioning)
+
+- Freight-native architecture
+- Enterprise-ready security
+- Modular deployment
+- White-label capable
+
+---
+
+## Slide 9 — Expansion
+
+- Autonomous fleets
+- Predictive maintenance
+- AI dispatch centers
+- Cross-industry licensing
+
+---
+
+## Slide 10 — Vision
+
+Replace fragmented logistics software with one intelligent operating system.
+
+---
+
+## PDF Export Notes
+
+- Brand with Infæmous Freight palette.
+- Add route diagrams, memory graph visual, and avatar coaching mockups.
+- Export in investor-ready format (print-safe margins, selectable text).

--- a/web/components/AvatarVoice.tsx
+++ b/web/components/AvatarVoice.tsx
@@ -1,0 +1,106 @@
+import { useMemo, useState } from "react";
+
+export function AvatarVoice() {
+  const [status, setStatus] = useState<"idle" | "speaking" | "unsupported">(
+    "idle",
+  );
+
+  const supported = useMemo(
+    () => typeof window !== "undefined" && "speechSynthesis" in window,
+    [],
+  );
+
+  const speak = (text: string) => {
+    if (!supported) {
+      setStatus("unsupported");
+      return;
+    }
+
+    const utterance = new SpeechSynthesisUtterance(text);
+    utterance.onstart = () => setStatus("speaking");
+    utterance.onend = () => setStatus("idle");
+    utterance.onerror = () => setStatus("idle");
+
+    window.speechSynthesis.cancel();
+    window.speechSynthesis.speak(utterance);
+  };
+
+  return (
+    <div
+      style={{
+        marginTop: "1.5rem",
+        padding: "1rem",
+        borderRadius: "12px",
+        background: "#0b0b12",
+        border: "1px solid rgba(255,255,255,0.08)",
+      }}
+    >
+      <h3 style={{ marginTop: 0 }}>Avatar Voice</h3>
+      <p style={{ marginTop: "0.25rem", color: "#b5b5c3", lineHeight: 1.5 }}>
+        Command-driven voice for hands-free drivers. Tap to hear a live status
+        reminder tailored for the current route.
+      </p>
+
+      <button
+        onClick={() =>
+          speak(
+            "I'm monitoring your route. Maintain speed consistency to recover 7 minutes.",
+          )
+        }
+        disabled={!supported || status === "speaking"}
+        style={{
+          marginTop: "0.8rem",
+          padding: "0.7rem 1.2rem",
+          borderRadius: "999px",
+          background: supported
+            ? "linear-gradient(135deg,#8ef4ff,#7b6dff)"
+            : "#2a2a3c",
+          color: supported ? "#050509" : "#7c7c94",
+          fontWeight: 700,
+          border: "none",
+          cursor: supported ? "pointer" : "not-allowed",
+          boxShadow: supported
+            ? "0 10px 30px rgba(126,109,255,0.35)"
+            : "none",
+        }}
+      >
+        {status === "speaking" ? "Speaking…" : "🎤 Speak"}
+      </button>
+
+      <p
+        style={{
+          marginTop: "0.5rem",
+          fontSize: "0.9rem",
+          color: supported ? "#e9e9f1" : "#ff7b7b",
+        }}
+      >
+        {supported
+          ? status === "speaking"
+            ? "Live coaching playing…"
+            : "Ready for driver-safe prompts."
+          : "Browser speech synthesis is not available here."}
+      </p>
+
+      <div
+        style={{
+          marginTop: "1rem",
+          padding: "0.8rem",
+          borderRadius: "10px",
+          background: "#11111a",
+          border: "1px dashed rgba(255,255,255,0.08)",
+        }}
+      >
+        <p style={{ margin: "0 0 0.35rem 0", color: "#c3c3d6" }}>
+          Voice command examples:
+        </p>
+        <ul style={{ margin: 0, paddingLeft: "1.2rem", color: "#f1f1f6" }}>
+          <li>“What’s my next stop?”</li>
+          <li>“Why am I behind schedule?”</li>
+          <li>“Coach me”</li>
+          <li>“Any safety issues?”</li>
+          <li>“Dispatch update”</li>
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/web/pages/dashboard.tsx
+++ b/web/pages/dashboard.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { track } from "@vercel/analytics";
+import { AvatarVoice } from "../components/AvatarVoice";
 import { VoicePanel } from "../components/VoicePanel";
 import { BillingPanel } from "../components/BillingPanel";
 
@@ -50,6 +51,7 @@ export default function Dashboard() {
       )}
 
       <VoicePanel />
+      <AvatarVoice />
       <BillingPanel />
     </main>
   );


### PR DESCRIPTION
## Summary
- add driver coaching and dispatch intelligence services with authenticated AI endpoints
- extend voice command handling with avatar responses and decision logging
- introduce a driver-safe Avatar Voice UI and PDF-ready pitch deck content

## Testing
- npm test -- --runInBand *(fails: Next.js lockfile patch and jest-junit reporter require network access in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c64c6ced88330b954f39555829f87)