### PR TITLE
docs: add AI Dispatch Operator execution plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # 🚚 Infæmous Freight Enterprise
 
-AI Synthetic Intelligence ♊️–powered logistics operating system.
+AI Synthetic Intelligence ♊️–powered **AI Operations Workforce for Freight**.
 
-Infæmous Freight Enterprise deploys autonomous AI agents to audit freight invoices,
-reduce cost leakage, enforce compliance, and integrate with ERP/TMS systems.
+Infæmous Freight Enterprise deploys the **Infæmous AI Dispatch Operator™**—an AI Operations Workforce that runs dispatch autonomously, predicts issues before they surface, and coaches drivers in real time. Sub-roles include Dispatch Operator AI, Driver Coach AI, Fleet Intelligence AI, and Customer Ops AI.
 
-This is enterprise software.
+This is enterprise software built for autonomous operations with auditable accountability.
 
 ## Monorepo
 
@@ -14,6 +13,10 @@ This is enterprise software.
 - mobile — React Native app
 - packages/shared — domain contracts
 - docs — governance & trust
+
+## Execution Plan
+
+The full go-to-market and operational rollout is documented in [`docs/AI_DISPATCH_OPERATOR_EXECUTION_PLAN.md`](docs/AI_DISPATCH_OPERATOR_EXECUTION_PLAN.md), covering the autonomous dispatch mode, driver trust framework, Dispatch Brain API, pricing, compliance, and enterprise sales motion.
 
 ## Security
 

--- a/docs/AI_DISPATCH_OPERATOR_EXECUTION_PLAN.md
+++ b/docs/AI_DISPATCH_OPERATOR_EXECUTION_PLAN.md
@@ -1,0 +1,73 @@
+# 🚀 Infæmous AI Dispatch Operator™ — Enterprise Execution Plan
+
+## Positioning & Naming
+- Public product name: **Infæmous AI Dispatch Operator™** (AI Operations Workforce for Freight).
+- Sub-roles: Dispatch Operator AI, Driver Coach AI, Fleet Intelligence AI, Customer Ops AI.
+- Messaging: “We deploy an AI Dispatch Operator that runs dispatch 24/7, predicts delays before they happen, and coaches drivers in real time.”
+- Avoid: “fleet software,” “logistics SaaS,” “dispatch tool.”
+
+## Autonomous Dispatch & Accountability (Rec 1–3)
+- **Autonomous Dispatch Mode (opt-in):** AI runs dispatch; humans approve exceptions only.
+- **AI Decision Ledger:** Log all AI actions with confidence scores and outcomes for auditability.
+- **No-human dispatch baseline:** Off-hours and peak-load automation as default.
+
+## Driver Coaching & Trust (Rec 4–5)
+- Coaching tied to measurable outcomes (time saved, safety score deltas).
+- Driver Trust Mode: show the “why” behind guidance; allow driver challenges with review + log.
+- Deliverable: **Driver Trust Dashboard** showing advice rationale, outcomes, and challenge history.
+
+## Dispatch Intelligence SKU & Predictive Alerts (Rec 6–7)
+- **Dispatch Brain API (API-only SKU):** programmatic access to routing intelligence and predictions.
+- Predictive alerts for ETA misses, escalation risk, and route failure; early-warning notifications.
+
+## Pricing & Contracts (Rec 8–9)
+- Modular pricing: **$29/driver/month** and **$99/AI-role/month**.
+- Enterprise ops contracts with SLA-backed commitments; usage-based expansion.
+
+## Compliance, White Label, Expansion, Language (Rec 10–13)
+- SOC2-lite now with a clear path to SOC2-ready; auditable controls in the Decision Ledger.
+- White-label option for partners; quiet vertical expansion playbook.
+- Language: “We deploy / operate / replace” to emphasize operational ownership.
+
+## Launch Plan (Week 1)
+- Target: fleets 10–250 drivers, owner-operators needing night/weekend coverage, 3PL automation tests.
+- Channels: direct outreach (email/LinkedIn), freight forums, existing users, partner referrals. No paid ads.
+- Offer: “AI Dispatch Operator that runs your dispatch 24/7, predicts delays early, and coaches drivers in real time.”
+
+## Pilot Framework (30 Days)
+- Free, controlled pilots for 1–2 fleets with full metrics tracking.
+- Data needed: routes, drivers, dispatch logs, delivery outcomes.
+- Deployment: intake → data access → shadow mode → autonomous mode (opt-in) → weekly reviews → end-of-pilot report.
+- Promise: prove time/money saved or human off-hours dispatch replacement.
+
+## Metrics (Moat)
+- Baseline: avg ETA variance, late deliveries/week, dispatcher hours, driver idle time, escalations.
+- AI-On: minutes saved, late deliveries prevented, safety score delta, human hours replaced, revenue recovered.
+- Output: 1-page before/after report per pilot.
+
+## Conversion to Contracts
+- Script: “During the pilot, our AI Dispatch Operator prevented X delays, saved Y hours, and reduced escalation risk by Z%. We’d like to deploy permanently under an enterprise ops agreement.”
+- Contract shape: 12–36 months, SLA-backed, usage expansion, quarterly optimization reviews.
+
+## Packaging for Sales & Investors
+- Sales assets: pilot case study (1 page), ROI calculator, AI accountability dashboard screenshots, pricing tiers.
+- Investor assets: updated deck, technical appendix, proof metrics, enterprise pipeline narrative.
+
+## Enterprise Sales Motion
+1. Cold outreach → pilot
+2. Pilot → proof
+3. Proof → contract
+4. Contract → expansion
+
+No freemium; avoid SMB churn. ICP: 50–1,000 vehicle fleets with high dispatcher cost and 24/7 ops needs.
+
+## Cold Outreach Template
+Subject: Replacing night dispatch with AI
+
+Hi {{Name}},
+
+We deploy an AI Dispatch Operator that runs dispatch autonomously during nights, weekends, and peak hours. Fleets use it to reduce delays and dispatcher burnout. Would you be open to a short pilot to see if it fits your operation?
+
+---
+
+This plan consolidates all 13 recommendations and the end-to-end go-to-market and operational execution starting today.


### PR DESCRIPTION
## Summary
- Update README messaging to position Infæmous AI Dispatch Operator as the AI Operations Workforce for Freight.
- Add AI Dispatch Operator execution plan documenting recommendations, launch, pilots, pricing, compliance, and enterprise sales motion.

## Testing
- Not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c6a811148833089abe3d437291d73)