### PR TITLE
Fix driver coach selection typing

### DIFF
--- a/api/src/services/ai-engine/src/skills/driverCoach.ts
+++ b/api/src/services/ai-engine/src/skills/driverCoach.ts
@@ -16,10 +16,12 @@ type DriverCoachResult = {
   decisionId: string;
 };
 
-function selectCoaching(event: DriverEvent): Omit<
+type CoachingSelection = Omit<
   DriverCoachResult,
-  "type" | "memoryKey"
-> {
+  "type" | "memoryKey" | "decisionId"
+>;
+
+function selectCoaching(event: DriverEvent): CoachingSelection {
   const lateMinutes = event.lateMinutes ?? 0;
   const hardBrakes = event.hardBrakes ?? 0;
   const dwellMinutes = event.dwellMinutes ?? 0;
@@ -69,8 +71,6 @@ export async function driverCoach(
 
   const coaching = selectCoaching(event);
 
-  let decisionId: string | undefined;
-
   if (prior) {
     await prisma.avatarMemory.update({
       where: { id: prior.id },
@@ -103,12 +103,11 @@ export async function driverCoach(
       }),
     },
   });
-  decisionId = decision.id;
 
   return {
     type: "COACHING",
     memoryKey,
-    decisionId,
+    decisionId: decision.id,
     ...coaching,
   };
 }


### PR DESCRIPTION
## Summary
- adjust driver coaching selection type so helper outputs exclude decision IDs and memory fields
- return the created AI decision ID alongside coaching responses without duplication

## Testing
- pnpm build
- pnpm --filter infamous-freight-api build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c8adacb088330bb2d9d4c03d12701)