### PR TITLE
Fix Prisma generation in API Dockerfile

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -2,10 +2,11 @@ FROM node:20-alpine
 WORKDIR /app
 
 COPY package.json ./
-RUN npm install -g pnpm && pnpm install --prod
+RUN npm install -g pnpm && pnpm install --prod=false
 
 COPY . .
 RUN pnpm prisma:generate && pnpm build
+RUN pnpm prune --prod
 
 EXPOSE 4000
 CMD ["node", "dist/server.js"]


### PR DESCRIPTION
## Summary
- install dev dependencies during the API Docker build so the Prisma CLI is available
- prune dev dependencies after building to keep the runtime image lean

## Testing
- pnpm build (api)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c90abca8c8330ac0c62dd5c3beca6)