### PR TITLE
Ensure Prisma artifacts are generated in Docker and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Generate Prisma client
+        run: pnpm -C api prisma generate
+
       - name: Build shared
         run: pnpm --filter @infamous-freight/shared build || true
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,12 +1,23 @@
-FROM node:20-alpine
+FROM node:20-alpine AS builder
+
 WORKDIR /app
 
-COPY package.json ./
-RUN npm install -g pnpm && pnpm install --prod=false
+COPY package.json pnpm-lock.yaml ./
+RUN corepack enable && pnpm install
+
+COPY prisma ./prisma
+RUN pnpm prisma generate
 
 COPY . .
-RUN pnpm prisma:generate && pnpm build
-RUN pnpm prune --prod
+RUN pnpm build
 
-EXPOSE 4000
+FROM node:20-alpine AS runner
+WORKDIR /app
+
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/prisma ./prisma
+COPY package.json ./
+
+ENV NODE_ENV=production
 CMD ["node", "dist/server.js"]


### PR DESCRIPTION
## Summary
- switch the API Dockerfile to a multi-stage build that generates Prisma artifacts before compiling and runs from the built output
- run Prisma client generation in CI before building packages to avoid missing artifacts during builds

## Testing
- pnpm -C api build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c932e5170833084ee5563ac28f49b)