### PR TITLE
Ensure Prisma client generation during API builds

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -4,10 +4,11 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "prebuild": "pnpm run prisma:generate",
     "dev": "tsx watch src/server.ts",
     "build": "tsc",
     "start": "node dist/server.js",
-    "prisma:generate": "prisma generate",
+    "prisma:generate": "node ./scripts/prisma-generate.mjs",
     "prisma:migrate": "prisma migrate dev"
   },
   "dependencies": {

--- a/api/scripts/prisma-generate.mjs
+++ b/api/scripts/prisma-generate.mjs
@@ -1,0 +1,14 @@
+import { execFileSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const fallbackUrl = 'postgresql://postgres:postgres@localhost:5432/postgres';
+const databaseUrl = process.env.DATABASE_URL ?? process.env.NETLIFY_DATABASE_URL ?? fallbackUrl;
+
+// Ensure Prisma always receives a database URL, even in build environments that only expose
+// NETLIFY_DATABASE_URL (or provide nothing at all).
+process.env.DATABASE_URL = databaseUrl;
+
+const apiRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+execFileSync('pnpm', ['prisma', 'generate'], { stdio: 'inherit', cwd: apiRoot });


### PR DESCRIPTION
## Summary
- add a Prisma client generation helper that falls back to NETLIFY_DATABASE_URL or a local default
- run Prisma generation automatically before the API TypeScript build to include all models

## Testing
- pnpm -C api prisma:generate
- pnpm -C api build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c94c773548330accd5690b75fe6b6)