### PR TITLE
Ensure Prisma client is generated during installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "dev": "pnpm -r dev",
     "build": "pnpm -r build",
     "test": "pnpm -r test",
-    "lint": "pnpm -r lint"
+    "lint": "pnpm -r lint",
+    "postinstall": "pnpm -r prisma:generate"
   },
   "devDependencies": {
     "lint-staged": "^15.2.9"


### PR DESCRIPTION
## Summary
- run Prisma client generation automatically after installing workspace dependencies to keep generated types available during builds

## Testing
- pnpm -r prisma:generate
- pnpm -r build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cd60b9f508330ba2745fb7650903c)