### PR TITLE
Align pnpm versions in workflows with lockfile

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NODE_VERSION: "20"
-      PNPM_VERSION: "7.5.1"
+      PNPM_VERSION: "8.15.9"
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/container-security.yml
+++ b/.github/workflows/container-security.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 7.5.1
+          version: 8.15.9
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -86,7 +86,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 7.5.1
+          version: 8.15.9
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 7.5.1
+          version: 8.15.9
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- update Fly deploy workflow to use pnpm 8.15.9 so it matches the workspace lockfile
- update container security workflow pnpm setup to version 8.15.9
- set CodeQL workflow pnpm version to 8.15.9 for lockfile compatibility

## Testing
- not run (CI workflow changes only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ce392c748833095b8d46c36d052d3)