### PR TITLE
chore(ci): generate prisma client from api workspace

### DIFF
--- a/.github/workflows/container-security.yml
+++ b/.github/workflows/container-security.yml
@@ -47,7 +47,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Generate Prisma client
-        run: pnpm -w exec prisma generate
+        run: pnpm --filter infamous-freight-api exec prisma generate
         continue-on-error: true
 
       - name: Set up Docker Buildx
@@ -98,7 +98,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Generate Prisma client
-        run: pnpm -w exec prisma generate
+        run: pnpm --filter infamous-freight-api exec prisma generate
         continue-on-error: true
 
       - name: Set up Docker Buildx

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -28,7 +28,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Generate Prisma client
-        run: pnpm -w exec prisma generate --schema api/prisma/schema.prisma
+        run: pnpm --filter infamous-freight-api exec prisma generate --schema prisma/schema.prisma
         continue-on-error: true
 
       - name: Set up Docker Buildx

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,7 +44,7 @@ jobs:
         run: pnpm -w install --frozen-lockfile
 
       - name: Generate Prisma client
-        run: pnpm -w exec prisma generate
+        run: pnpm --filter infamous-freight-api exec prisma generate
         continue-on-error: true
 
       - name: Install Playwright browsers

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -26,7 +26,7 @@ jobs:
         run: pnpm -w install --frozen-lockfile
 
       - name: Generate Prisma client
-        run: pnpm -w exec prisma generate
+        run: pnpm --filter infamous-freight-api exec prisma generate
         continue-on-error: true
 
       - uses: superfly/flyctl-actions/setup-flyctl@master

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -25,7 +25,7 @@ jobs:
         run: pnpm --filter web lint
         continue-on-error: true
       - name: Generate Prisma client
-        run: pnpm -w exec prisma generate
+        run: pnpm --filter infamous-freight-api exec prisma generate
         continue-on-error: true
       - name: Pull Vercel Environment Information
         run: npx vercel pull --yes --environment=production --token=${{


### PR DESCRIPTION
## Summary
- update Prisma generate steps in GitHub workflows to run within the API workspace where the Prisma CLI is installed
- keep Docker build Prisma generation pointed at the API schema using the package working directory

## Testing
- pnpm --filter infamous-freight-api exec prisma generate --schema prisma/schema.prisma

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ce6351b248330b58fc21691106b03)