### PR TITLE
chore: sync pnpm lockfile for frozen installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ web/.vercel/
 **/dist/
 **/build/
 .cache/
+node-compile-cache/
 
 # Test artifacts
 junit.xml

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "postinstall": "pnpm -r prisma:generate"
   },
   "devDependencies": {
-    "lint-staged": "^15.2.9"
+    "lint-staged": "^15.5.2"
   },
   "lint-staged": {
     "*": "echo \"lint-staged: no checks configured\""

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     devDependencies:
       lint-staged:
-        specifier: ^15.2.9
+        specifier: ^15.5.2
         version: 15.5.2
 
   api:


### PR DESCRIPTION
## Summary
- align lint-staged dev dependency with the resolved 15.5.2 release
- refresh pnpm-lock.yaml so frozen installs use up-to-date metadata
- ignore node-compile-cache artifacts created during installs

## Testing
- pnpm install --frozen-lockfile


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ce96b404083308d39d5d05cf437d7)