### PR TITLE
Ensure web public directory exists for Docker builds

### DIFF
--- a/web/public/README.md
+++ b/web/public/README.md
@@ -1,0 +1,2 @@
+This directory hosts static assets served by the Next.js app.
+It is intentionally present to ensure Docker builds can copy the public folder even when no assets are defined.


### PR DESCRIPTION
## Summary
- add a placeholder README in web/public so the directory exists during Docker builds

## Testing
- not run (not needed for static directory addition)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cee6f38c083309a854fd05598300c)