### PR TITLE
Fix API TypeScript config to avoid React Native lib conflicts

### DIFF
--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -4,6 +4,9 @@
     "target": "ES2020",
     "module": "ESNext",
     "moduleResolution": "Node",
+    "lib": ["ES2020"],
+    "types": ["node"],
+    "skipLibCheck": true,
     "strict": true,
     "esModuleInterop": true
   },


### PR DESCRIPTION
## Summary
- scope the API TypeScript configuration to Node by limiting libs and types
- enable skipLibCheck to avoid conflicts from React Native typings during backend builds

## Testing
- pnpm exec tsc --pretty false (api)
- pnpm build *(fails: Next.js attempted to patch missing SWC deps and could not fetch packages; ENETUNREACH)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d0019ac54833081c64e8a714ec5fc)