### PR TITLE
Fix API Dockerfile workspace paths

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -7,9 +7,8 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY api/package.json ./api/package.json
 RUN corepack enable && pnpm install --filter api... --frozen-lockfile
 
-# Generate the Prisma client for the API
+# Copy Prisma schema for the API (client is generated during build via prebuild hook)
 COPY api/prisma ./api/prisma
-RUN pnpm --filter api... prisma generate
 
 # Copy the remaining API source and build
 COPY api/tsconfig.json ./api/tsconfig.json


### PR DESCRIPTION
## Summary
- install API dependencies using workspace manifests and a frozen lockfile
- ensure Prisma schema and client are available during the build
- copy the built API output and runtime assets from the correct workspace paths

## Testing
- `docker build -f api/Dockerfile . --target builder` *(fails: docker command unavailable in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d0290e83483308a89536b75dbb8ef)