### PR TITLE
Add auto PR test fix workflow

### DIFF
--- a/.github/workflows/auto-pr-test-fix.yml
+++ b/.github/workflows/auto-pr-test-fix.yml
@@ -55,6 +55,11 @@ jobs:
       - name: Build shared package
         run: pnpm --filter @infamous-freight/shared build
       - name: Run monorepo tests
+        # Note: We use `--if-present` so that workspaces without a `test` script
+        # (e.g. the current `mobile` app, which does not yet have tests configured)
+        # are intentionally skipped instead of causing the workflow to fail.
+        # When mobile (or any other package) gains a test suite, ensure it defines
+        # a `test` script in its package.json so it is included here.
         run: pnpm -r --if-present run test
 
       - name: Upload test reports (if present)


### PR DESCRIPTION
## Summary
- add an auto-pr-test-fix workflow to validate changes on matching branches or manual dispatch
- run monorepo tests with pnpm and upload junit-style reports when present
- apply concurrency controls and permissions appropriate for pull request usage

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d268b7de483308bba6a09a56dd60c)