### PR TITLE
Secure auto-fix workflow run checkout

### DIFF
--- a/.github/workflows/auto-pr-test-fix.yml
+++ b/.github/workflows/auto-pr-test-fix.yml
@@ -33,7 +33,7 @@ jobs:
             ${{ github.event_name == 'workflow_run' &&
                 github.event.workflow_run.head_repository.full_name == github.repository &&
                 github.event.workflow_run.head_branch == github.event.repository.default_branch &&
-                github.event.workflow_run.head_sha || github.ref }}
+                github.event.workflow_run.head_sha || github.event.repository.default_branch }}
           fetch-depth: 0
 
       - name: Setup Node.js


### PR DESCRIPTION
## Summary
- restrict the auto-fix workflow_run job to trusted runs from the repository default branch
- limit checkout to the trusted head SHA when the workflow_run originates from the same repository

## Testing
- not run (workflow-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d26f7b1d88330a052606cd1f5b5ac)