### PR TITLE
ci: restrict auto test fix workflow to trusted main runs

### DIFF
--- a/.github/workflows/auto-pr-test-fix.yml
+++ b/.github/workflows/auto-pr-test-fix.yml
@@ -20,7 +20,8 @@ jobs:
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.conclusion == 'failure' &&
        github.event.workflow_run.event == 'push' &&
-       github.event.workflow_run.head_branch == 'main')
+       github.event.workflow_run.head_branch == 'main' &&
+       github.event.workflow_run.head_repository.full_name == github.repository)
     runs-on: ubuntu-latest
     timeout-minutes: 25
 


### PR DESCRIPTION
## Summary
- limit auto test fix workflow to trusted CI runs on the main branch by requiring the workflow run’s head repository to match this repository

## Testing
- not run (workflow-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d990ab42883308e76bb3d989f03b5)