### PR TITLE
Fix web-vitals dynamic import typing

### DIFF
--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -14,26 +14,12 @@ export default function App({ Component, pageProps }: AppProps) {
   useEffect(() => {
     // Track Core Web Vitals
     if (typeof window !== "undefined") {
-      import("web-vitals").then((webVitals) => {
-        const {
-          onCLS,
-          onFID,
-          onFCP,
-          onLCP,
-          onTTFB,
-        } = webVitals as {
-          onCLS?: (onReport: typeof reportWebVitals) => void;
-          onFID?: (onReport: typeof reportWebVitals) => void;
-          onFCP?: (onReport: typeof reportWebVitals) => void;
-          onLCP?: (onReport: typeof reportWebVitals) => void;
-          onTTFB?: (onReport: typeof reportWebVitals) => void;
-        };
-
-        onCLS?.(reportWebVitals);
-        onFID?.(reportWebVitals);
-        onFCP?.(reportWebVitals);
-        onLCP?.(reportWebVitals);
-        onTTFB?.(reportWebVitals);
+      import("web-vitals").then(({ onCLS, onFID, onFCP, onLCP, onTTFB }) => {
+        onCLS(reportWebVitals);
+        onFID(reportWebVitals);
+        onFCP(reportWebVitals);
+        onLCP(reportWebVitals);
+        onTTFB(reportWebVitals);
       });
 
       // Track layout shifts and long tasks


### PR DESCRIPTION
## Summary
- adjust the web-vitals dynamic import in _app.tsx to use the module namespace safely and call on* handlers so metrics are reported
- keep Core Web Vitals reporting guarded behind browser checks while tracking layout shifts and long tasks

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d02a4855483309d53ba0ab11cca29)