### PR TITLE
chore: tighten workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [ "main" ]
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,6 +14,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze Code

--- a/.github/workflows/container-security.yml
+++ b/.github/workflows/container-security.yml
@@ -20,10 +20,16 @@ on:
   schedule:
     - cron: "0 1 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   api-image-scan:
     name: Build + Scan API Image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
       - name: Checkout
@@ -82,6 +88,9 @@ jobs:
   web-image-scan:
     name: Build + Scan Web Image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -5,6 +5,9 @@ on:
     branches: ["main"]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,6 +13,9 @@ on:
     # Run tests daily at 2 AM UTC
     - cron: "0 2 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   e2e-tests:
     name: E2E Tests

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -4,10 +4,17 @@ on:
   push:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     if: ${{ secrets.VERCEL_TOKEN != '' }}
+    permissions:
+      contents: read
+      deployments: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: Setup pnpm


### PR DESCRIPTION
## Summary
- set explicit read-only GITHUB_TOKEN permissions across workflows
- grant security scan jobs the security-events scope needed for SARIF uploads
- define deployment workflow permissions for required operations

## Testing
- not run (workflow configuration changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e213f80508330981801c14a948d42)