### PR TITLE
chore: enforce pnpm-only lockfile and ignore package-lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,11 @@
 node_modules/
 **/node_modules/
 # pnpm-lock.yaml should be committed for reproducible builds
+# npm lockfiles (pnpm is required)
 package-lock.json
+**/package-lock.json
+npm-shrinkwrap.json
+**/npm-shrinkwrap.json
 
 # Build outputs
 dist/

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,4 @@
+# Prevent npm from generating lockfiles; pnpm-lock.yaml is the single source of truth
 package-lock=false
+shrinkwrap=false
 fund=false

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ For detailed setup instructions, see the [Developer Guide](docs/developer-guide.
 ## 🧩 Package Manager & Lockfiles
 
 - **pnpm only**: The repo declares `packageManager: pnpm@8.15.9` and CI installs with `pnpm install --frozen-lockfile`.
-- **Single source of truth**: `pnpm-lock.yaml` is the only lockfile used across CI and Vercel. The deprecated root `package-lock.json` referenced an old workspace layout and could make Vercel fall back to `npm install`, producing mismatched dependency graphs compared to pnpm.
-- **Prevention**: `.npmrc` disables `package-lock.json` creation and `.gitignore` blocks reintroducing it. Use pnpm for installs locally and in any deployment hooks to stay consistent.
+- **Single source of truth**: `pnpm-lock.yaml` is the only lockfile used across CI and Vercel. Remove any stray `package-lock.json` or `npm-shrinkwrap.json` files that appear from npm commands to avoid dependency drift from pnpm installs.
+- **Prevention**: `.npmrc` disables npm lockfile generation (including shrinkwrap) and `.gitignore` blocks `package-lock.json`/`npm-shrinkwrap.json` across the workspace. Use pnpm for installs locally and in any deployment hooks to stay consistent.
 
 ## 📚 Documentation
 


### PR DESCRIPTION
## Summary
- disable npm lockfile generation in `.npmrc` to reinforce pnpm-only installs
- ignore npm `package-lock.json` and `npm-shrinkwrap.json` files throughout the repo
- document the pnpm-only lockfile policy and cleanup guidance in the README

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694eb196ab9083309a85a821c0e2c0d7)