### PR TITLE
ci: orchestrate deployments via cd workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,26 @@
+name: CD
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  deployments: write
+
+concurrency:
+  group: cd-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-api:
+    name: Deploy API to Fly.io
+    uses: ./.github/workflows/fly-deploy.yml
+    secrets: inherit
+
+  deploy-web:
+    name: Deploy Web to Vercel
+    needs: deploy-api
+    uses: ./.github/workflows/vercel-deploy.yml
+    secrets: inherit

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -1,8 +1,8 @@
 name: Deploy API to Fly.io
 
 on:
-  push:
-    branches: ["main"]
+  workflow_dispatch:
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -1,8 +1,8 @@
 name: Deploy Web to Vercel
 
 on:
-  push:
-    branches: ["main"]
+  workflow_dispatch:
+  workflow_call:
 
 permissions:
   contents: read

--- a/docs/repository-structure.md
+++ b/docs/repository-structure.md
@@ -264,6 +264,7 @@ GitHub Actions workflows in `.github/workflows/`:
 - `container-security.yml` - Container security checks
 - `docker-build.yml` - Docker image builds
 - `e2e.yml` - End-to-end tests
+- `cd.yml` - Orchestrates production deployments
 - `fly-deploy.yml` - Fly.io deployment
 - `vercel-deploy.yml` - Vercel deployment
 


### PR DESCRIPTION
## Summary
- add a CD workflow that orchestrates Fly.io and Vercel deployments from push and manual dispatch
- convert Fly.io and Vercel deployment workflows to reusable workflow_call targets
- document the new CD orchestrator in the repository structure guide

## Testing
- not run (workflow-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694eb6549cc883309a03e3f29c45fdf9)