### PR TITLE
Add CD workflow for main branch builds

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -75,9 +75,9 @@ jobs:
   #     - uses: actions/setup-node@v4
   #       with:
   #         node-version: 20
-  #     - run: pnpm dlx vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
-  #     - run: pnpm dlx vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
-  #     - run: pnpm dlx vercel deploy --prod --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
+  #     - run: npx vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+  #     - run: npx vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+  #     - run: npx vercel deploy --prod --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
 
   # OPTIONAL: Deploy API (Fly.io example)
   # deploy_api:


### PR DESCRIPTION
## Summary
- add a CD workflow that runs on main pushes or manual dispatch
- install pnpm dependencies and build the API and web apps
- include commented examples for optional Vercel or Fly.io deploys

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694eb6790db083308f5a45fdef2e8446)