### PR TITLE
Add Render deploy workflow for API

### DIFF
--- a/.github/workflows/render-deploy.yml
+++ b/.github/workflows/render-deploy.yml
@@ -12,6 +12,7 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    if: ${{ secrets.RENDER_DEPLOY_HOOK_URL != '' }}
     timeout-minutes: 30
     steps:
       - name: Trigger Render deploy hook


### PR DESCRIPTION
## Summary
- add Render deployment workflow to trigger API deploy hook
- configure concurrency to avoid overlapping runs

## Testing
- not run (not needed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ec16481cc83309137be0473dffb29)