### PR TITLE
Improve API hook base URL handling

### DIFF
--- a/src/apps/web/hooks/useApi.ts
+++ b/src/apps/web/hooks/useApi.ts
@@ -1,5 +1,16 @@
 export function useApi() {
-  const base = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";
+  const base = (
+    process.env.NEXT_PUBLIC_API_URL ||
+    process.env.API_BASE_URL ||
+    "/api"
+  ).replace(/\/$/, "");
+
+  const buildUrl = (path: string) => {
+    if (!path.startsWith("/")) {
+      return `${base}/${path}`;
+    }
+    return `${base}${path}`;
+  };
 
   function buildHeaders(custom?: HeadersInit) {
     const headers: HeadersInit = { ...(custom || {}) };
@@ -13,7 +24,7 @@ export function useApi() {
   }
 
   async function get(path: string) {
-    const res = await fetch(base + path, {
+    const res = await fetch(buildUrl(path), {
       headers: buildHeaders(),
     });
     if (!res.ok) throw new Error(await res.text());
@@ -21,7 +32,7 @@ export function useApi() {
   }
 
   async function post(path: string, body?: unknown) {
-    const res = await fetch(base + path, {
+    const res = await fetch(buildUrl(path), {
       method: "POST",
       headers: buildHeaders({ "Content-Type": "application/json" }),
       body: body ? JSON.stringify(body) : undefined,


### PR DESCRIPTION
## Summary
- normalize API base URL to support NEXT_PUBLIC_API_URL or API_BASE_URL with trailing slash trimming
- ensure client requests build correct URLs whether paths are prefixed with a slash or not

## Testing
- pnpm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ec64eafb48330806e69937627dc5a)