### PR TITLE
Allow informational logging

### DIFF
--- a/configs/linting/eslint.config.js
+++ b/configs/linting/eslint.config.js
@@ -43,7 +43,7 @@ export default [
     },
     rules: {
       ...js.configs.recommended.rules,
-      "no-console": ["warn", { allow: ["warn", "error"] }],
+      "no-console": ["warn", { allow: ["warn", "error", "info"] }],
       "no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
     },
   },
@@ -66,7 +66,7 @@ export default [
       "@typescript-eslint": tsPlugin,
     },
     rules: {
-      "no-console": ["warn", { allow: ["warn", "error"] }],
+      "no-console": ["warn", { allow: ["warn", "error", "info"] }],
       "no-unused-vars": "off",
     },
   },

--- a/src/apps/api/prisma/seed.js
+++ b/src/apps/api/prisma/seed.js
@@ -3,7 +3,7 @@ const { PrismaClient } = require("@prisma/client");
 const prisma = new PrismaClient();
 
 async function main() {
-  console.log("Seeding Infamous Freight database...");
+  console.info("Seeding Infamous Freight database...");
 
   await prisma.user.upsert({
     where: { email: "admin@infamous.ai" },
@@ -70,7 +70,7 @@ async function main() {
     },
   });
 
-  console.log("Seed completed.");
+  console.info("Seed completed.");
 }
 
 main()

--- a/src/apps/api/src/automation/weekly.ts
+++ b/src/apps/api/src/automation/weekly.ts
@@ -2,5 +2,5 @@ import { prisma } from "../db/prisma";
 
 export async function weeklySummary() {
   const count = await prisma.invoice.count();
-  console.log("Weekly invoices audited:", count);
+  console.info("Weekly invoices audited:", count);
 }

--- a/src/apps/api/src/server.ts
+++ b/src/apps/api/src/server.ts
@@ -36,4 +36,4 @@ app.use(errorHandler);
 const apiConfig = config.getApiConfig();
 const port = Number(apiConfig.port);
 
-app.listen(port, () => console.log(`API running on port ${port}`));
+app.listen(port, () => console.info(`API running on port ${port}`));

--- a/src/apps/web/lib/webVitalsMonitoring.js
+++ b/src/apps/web/lib/webVitalsMonitoring.js
@@ -6,7 +6,7 @@
 export const reportWebVitals = (metric) => {
   // Log to console in development
   if (process.env.NODE_ENV === "development") {
-    console.log("📊 Web Vital:", metric);
+    console.info("📊 Web Vital:", metric);
   }
 
   // Send to Vercel Analytics
@@ -52,7 +52,7 @@ export const trackCLS = () => {
   const observer = new PerformanceObserver((list) => {
     for (const entry of list.getEntries()) {
       if (!entry.hadRecentInput) {
-        console.log("🔄 Layout Shift:", {
+        console.info("🔄 Layout Shift:", {
           value: entry.value,
           source: entry.sources?.[0]?.node,
         });


### PR DESCRIPTION
## Summary
- allow console.info usage in the ESLint configuration
- switch seed scripts, API startup, and monitoring utilities to use console.info for informational messages

## Testing
- pnpm lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ecec94c108330a46fa3e9a80ab4a3)