### PR TITLE
fix: enable pnpm lockfile and add shared workspace package

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,3 +2,6 @@ engine-strict=true
 package-lock=false
 fund=false
 audit=false
+
+# --- pnpm lockfile must be enabled for CI frozen installs ---
+lockfile=true

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "shared",
+  "version": "0.0.1",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "lint": "echo \"(shared) lint skipped\"",
+    "test": "echo \"(shared) test skipped\""
+  },
+  "devDependencies": {
+    "typescript": "^5.5.4"
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,1 @@
+export const SHARED_VERSION = "0.0.1";

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
### Motivation
- Ensure pnpm lockfile is enabled so CI can perform frozen installs reliably with a lockfile present.
- Add a missing workspace package at `packages/shared` to satisfy the monorepo workspace layout and provide a shared TypeScript package.
- Keep workspace globs including `packages/*` so new packages are picked up by pnpm workspaces.

### Description
- Appended `lockfile=true` to `.npmrc` to enable pnpm lockfile behavior.
- Added `packages/shared/package.json` with basic metadata, scripts, and `typescript` devDependency.
- Added `packages/shared/tsconfig.json` and `packages/shared/src/index.ts` exporting `SHARED_VERSION` as the initial implementation.
- Prepared the repo to regenerate the pnpm lockfile by running `pnpm install --no-frozen-lockfile`.

### Testing
- Ran `pnpm install --no-frozen-lockfile`, which failed with: `No matching version found for json2csv@^6.0.0` when resolving dependencies, so lockfile regeneration did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960b2dd97108330872b9a0c203b9e58)