### PR TITLE
chore(api): replace json2csv with @json2csv/node

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.20.0",
     "@infamous-freight/shared": "file:../packages/shared",
+    "@json2csv/node": "^7.0.6",
     "@paypal/checkout-server-sdk": "^1.0.3",
     "@prisma/client": "^5.11.0",
     "@sentry/node": "^7.100.0",
@@ -32,7 +33,6 @@
     "express": "^4.19.0",
     "express-rate-limit": "^7.1.5",
     "helmet": "^7.0.0",
-    "json2csv": "6.0.0-alpha.2",
     "jsonwebtoken": "^9.0.2",
     "morgan": "^1.10.0",
     "multer": "^2.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@infamous-freight/shared':
         specifier: file:../packages/shared
         version: file:packages/shared
+      '@json2csv/node':
+        specifier: ^7.0.6
+        version: 7.0.6
       '@paypal/checkout-server-sdk':
         specifier: ^1.0.3
         version: 1.0.3
@@ -59,9 +62,6 @@ importers:
       helmet:
         specifier: ^7.0.0
         version: 7.2.0
-      json2csv:
-        specifier: 6.0.0-alpha.2
-        version: 6.0.0-alpha.2
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.3
@@ -944,6 +944,23 @@ packages:
     resolution: {integrity: sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==}
     dev: false
 
+  /@json2csv/formatters@7.0.6:
+    resolution: {integrity: sha512-hjIk1H1TR4ydU5ntIENEPgoMGW+Q7mJ+537sDFDbsk+Y3EPl2i4NfFVjw0NJRgT+ihm8X30M67mA8AS6jPidSA==}
+    dev: false
+
+  /@json2csv/node@7.0.6:
+    resolution: {integrity: sha512-J3AX8cDBeQyriJj0oFxJot52hScUN4hhUBRnUGIPt+yI1YpwUuftriJi1RJS60Uz6Stce1sewHeG56dBc9/XGg==}
+    dependencies:
+      '@json2csv/plainjs': 7.0.6
+    dev: false
+
+  /@json2csv/plainjs@7.0.6:
+    resolution: {integrity: sha512-4Md7RPDCSYpmW1HWIpWBOqCd4vWfIqm53S3e/uzQ62iGi7L3r34fK/8nhOMEe+/eVfCx8+gdSCt1d74SlacQHw==}
+    dependencies:
+      '@json2csv/formatters': 7.0.6
+      '@streamparser/json': 0.0.20
+    dev: false
+
   /@napi-rs/wasm-runtime@0.2.12:
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
     requiresBuild: true
@@ -1170,8 +1187,8 @@ packages:
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
     dev: false
 
-  /@streamparser/json@0.0.6:
-    resolution: {integrity: sha512-vL9EVn/v+OhZ+Wcs6O4iKE9EUpwHUqHmCtNUMWjqp+6dr85+XPOSGTEsqYNq1Vn04uk9SWlOVmx9J48ggJVT2Q==}
+  /@streamparser/json@0.0.20:
+    resolution: {integrity: sha512-VqAAkydywPpkw63WQhPVKCD3SdwXuihCUVZbbiY3SfSTGQyHmwRoq27y4dmJdZuJwd5JIlQoMPyGvMbUPY0RKQ==}
     dev: false
 
   /@swc/helpers@0.3.17:
@@ -1985,11 +2002,6 @@ packages:
 
   /commander@6.2.0:
     resolution: {integrity: sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==}
-    engines: {node: '>= 6'}
-    dev: false
-
-  /commander@6.2.1:
-    resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
     engines: {node: '>= 6'}
     dev: false
 
@@ -4056,16 +4068,6 @@ packages:
   /json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
     dev: true
-
-  /json2csv@6.0.0-alpha.2:
-    resolution: {integrity: sha512-nJ3oP6QxN8z69IT1HmrJdfVxhU1kLTBVgMfRnNZc37YEY+jZ4nU27rBGxT4vaqM/KUCavLRhntmTuBFqZLBUcA==}
-    engines: {node: '>= 12', npm: '>= 6.13.0'}
-    hasBin: true
-    dependencies:
-      '@streamparser/json': 0.0.6
-      commander: 6.2.1
-      lodash.get: 4.4.2
-    dev: false
 
   /json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}


### PR DESCRIPTION
### Motivation
- Replace the legacy `json2csv` dependency with the maintained `@json2csv/node` package for CSV generation.
- Keep the package set and lockfile consistent after the dependency swap.
- Ensure billing/third-party SDKs remain available in the API dependencies.

### Description
- Added `@json2csv/node` to `api/package.json` and removed `json2csv` from the API dependencies.
- Updated `pnpm-lock.yaml` to reflect the new `@json2csv/node` package and its transitive dependencies.
- No source code changes aside from dependency and lockfile updates.

### Testing
- Pre-commit checks (`lint-staged` / `prettier`) ran and passed during commit. 
- Commit message format validation passed after adjusting to Conventional Commits.
- No unit or integration test suites were executed as part of this change. 
- Dependency installation (`pnpm`) completed successfully when updating the API workspace.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960f251a12883308ad0b7fc35c72350)