### PR TITLE
Support STRIPE_SECRET_KEY in API configuration

### DIFF
--- a/src/apps/api/src/config/config.ts
+++ b/src/apps/api/src/config/config.ts
@@ -69,7 +69,10 @@ export class Config {
     const keys = {
       openai: this.requireEnv("OPENAI_API_KEY"),
       anthropic: this.requireEnv("ANTHROPIC_API_KEY"),
-      stripe: this.requireEnv("STRIPE_API_KEY"),
+      stripe: this.requireEnv(
+        "STRIPE_SECRET_KEY",
+        this.getEnv("STRIPE_API_KEY"),
+      ),
       stripeWebhookSecret: this.requireEnv("STRIPE_WEBHOOK_SECRET"),
       paypalClientId: this.requireEnv("PAYPAL_CLIENT_ID"),
       paypalClientSecret: paypalSecret,


### PR DESCRIPTION
### Motivation
- Allow the API to read a dedicated Stripe secret environment variable when present.
- Preserve backward compatibility with the existing `STRIPE_API_KEY` environment variable as a fallback.
- Make credential sourcing consistent between `getApiKeys()` and `getStripeConfig()` to avoid surprises in different runtime setups.

### Description
- Updated `src/apps/api/src/config/config.ts` to read `STRIPE_SECRET_KEY` in `getApiKeys()` with `STRIPE_API_KEY` as a fallback using `this.getEnv()`.
- The `stripe` entry in the returned keys object now calls `this.requireEnv("STRIPE_SECRET_KEY", this.getEnv("STRIPE_API_KEY"))`.
- No other behavior or consumers were modified; this change only alters how the API configuration resolves the Stripe secret.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960f358ca4883309185a9fa5661c898)