### PR TITLE
Add Stripe subscription checkout and webhook support

### DIFF
--- a/src/apps/api/src/routes/billing.ts
+++ b/src/apps/api/src/routes/billing.ts
@@ -1,7 +1,8 @@
-import { Router } from "express";
+import express, { Router } from "express";
 import Stripe from "stripe";
 import paypal from "@paypal/checkout-server-sdk";
 import config from "../config";
+import { prisma } from "../db/prisma";
 import { requireAuth, requireScope } from "../middleware/auth";
 
 const stripeApiVersion = "2024-06-20" as Stripe.LatestApiVersion;
@@ -26,10 +27,138 @@ const DEFAULT_PLAN = {
   name: "Infamous Freight AI",
 };
 
+const PRICE = {
+  DISPATCH_MONTHLY: "price_1Sne9YJBKY4ohJDA62rFeOh7",
+  FLEET_MONTHLY: "price_1SneAFJBKY4ohJDATu9s9af6",
+  OPS_MONTHLY: "price_1SneAkJBKY4ohJDAkULygwM7",
+  ENTERPRISE_MONTHLY: "price_1SneKlJBKY4ohJDAML8txHCO",
+  DISPATCH_ANNUAL: "price_1SneHuJBKY4ohJDA97jEMaf4",
+  FLEET_ANNUAL: "price_1SneIJJBKY4ohJDAeadaRPi5",
+  OPS_ANNUAL: "price_1SneIcJBKY4ohJDAGaw2PUzW",
+  ENTERPRISE_ANNUAL: "price_1SneMeJBKY4ohJDAfnjjWJSV",
+} as const;
+
+function featuresForPrice(priceId: string) {
+  const base = {
+    ai_dispatch: true,
+    driver_view: true,
+    basic_loads: true,
+    analytics: false,
+    automation: false,
+    audit_logs: false,
+    api_access: false,
+    invoice_audit: false,
+  };
+
+  switch (priceId) {
+    case PRICE.DISPATCH_MONTHLY:
+    case PRICE.DISPATCH_ANNUAL:
+      return base;
+    case PRICE.FLEET_MONTHLY:
+    case PRICE.FLEET_ANNUAL:
+      return { ...base, analytics: true };
+    case PRICE.OPS_MONTHLY:
+    case PRICE.OPS_ANNUAL:
+      return { ...base, analytics: true, automation: true };
+    case PRICE.ENTERPRISE_MONTHLY:
+    case PRICE.ENTERPRISE_ANNUAL:
+      return {
+        ...base,
+        analytics: true,
+        automation: true,
+        audit_logs: true,
+        api_access: true,
+        invoice_audit: true,
+      };
+    default:
+      return {
+        ai_dispatch: false,
+        driver_view: false,
+        basic_loads: false,
+        analytics: false,
+        automation: false,
+        audit_logs: false,
+        api_access: false,
+        invoice_audit: false,
+      };
+  }
+}
+
+function planName(priceId: string) {
+  if ([PRICE.DISPATCH_MONTHLY, PRICE.DISPATCH_ANNUAL].includes(priceId as any)) {
+    return "AI Dispatch Operator";
+  }
+  if ([PRICE.FLEET_MONTHLY, PRICE.FLEET_ANNUAL].includes(priceId as any)) {
+    return "Fleet Intelligence";
+  }
+  if ([PRICE.OPS_MONTHLY, PRICE.OPS_ANNUAL].includes(priceId as any)) {
+    return "Autonomous Ops Suite";
+  }
+  if ([PRICE.ENTERPRISE_MONTHLY, PRICE.ENTERPRISE_ANNUAL].includes(priceId as any)) {
+    return "Enterprise";
+  }
+  return "Unknown";
+}
+
+function requireUserId(req: express.Request) {
+  const userId = req.user?.id;
+  if (!userId) {
+    throw new Error("User context required for billing checkout.");
+  }
+  return userId;
+}
+
 export const billing = Router();
+export const billingWebhook = Router();
 
 billing.use(requireAuth);
 billing.use(requireScope("billing:write"));
+
+billing.post("/stripe/checkout", async (req, res) => {
+  const stripeConfig = config.getStripeConfig();
+  if (!stripeConfig.enabled) {
+    return res.status(503).json({ error: "Stripe not configured" });
+  }
+
+  const { priceId } = req.body as { priceId?: string };
+  if (!priceId) {
+    return res.status(400).json({ error: "priceId is required" });
+  }
+
+  try {
+    const userId = requireUserId(req);
+    const stripeClient = createStripeClient();
+
+    let stripeCustomer = await prisma.stripeCustomer.findUnique({
+      where: { userId },
+    });
+    if (!stripeCustomer) {
+      const customer = await stripeClient.customers.create({
+        metadata: { userId },
+      });
+      stripeCustomer = await prisma.stripeCustomer.create({
+        data: { userId, stripeCustomerId: customer.id },
+      });
+    }
+
+    const session = await stripeClient.checkout.sessions.create({
+      mode: "subscription",
+      customer: stripeCustomer.stripeCustomerId,
+      line_items: [{ price: priceId, quantity: 1 }],
+      allow_promotion_codes: true,
+      client_reference_id: userId,
+      subscription_data: {
+        metadata: { userId, plan: planName(priceId) },
+      },
+      success_url: stripeConfig.successUrl,
+      cancel_url: stripeConfig.cancelUrl,
+    });
+
+    return res.status(200).json({ url: session.url, id: session.id });
+  } catch (err: any) {
+    return res.status(500).json({ error: err?.message ?? "Unknown error" });
+  }
+});
 
 billing.post("/stripe/session", async (req, res, next) => {
   const stripeConfig = config.getStripeConfig();
@@ -78,6 +207,187 @@ billing.post("/stripe/session", async (req, res, next) => {
     return next(err);
   }
 });
+
+billingWebhook.post(
+  "/",
+  express.raw({ type: "application/json" }),
+  async (req, res) => {
+    const stripeConfig = config.getStripeConfig();
+    if (!stripeConfig.enabled) {
+      return res.status(503).json({ error: "Stripe not configured" });
+    }
+
+    const { stripeWebhookSecret } = config.getApiKeys();
+    const signature = req.headers["stripe-signature"];
+    if (!signature || typeof signature !== "string") {
+      return res.status(400).send("Missing Stripe-Signature header");
+    }
+
+    let event: Stripe.Event;
+
+    try {
+      event = createStripeClient().webhooks.constructEvent(
+        req.body,
+        signature,
+        stripeWebhookSecret,
+      );
+    } catch (err: any) {
+      return res
+        .status(400)
+        .send(
+          `Webhook signature verification failed: ${err?.message ?? "Unknown error"}`,
+        );
+    }
+
+    const existing = await prisma.stripeEvent.findUnique({
+      where: { eventId: event.id },
+    });
+    if (existing) {
+      return res.status(200).json({ received: true, duplicate: true });
+    }
+
+    await prisma.stripeEvent.create({
+      data: { eventId: event.id, type: event.type },
+    });
+
+    try {
+      switch (event.type) {
+        case "invoice.paid": {
+          const invoice = event.data.object as Stripe.Invoice;
+          const subscriptionId =
+            typeof invoice.subscription === "string"
+              ? invoice.subscription
+              : invoice.subscription?.id;
+          if (!subscriptionId) break;
+
+          const stripeClient = createStripeClient();
+          const subscription = await stripeClient.subscriptions.retrieve(
+            subscriptionId,
+            {
+              expand: ["items.data.price"],
+            },
+          );
+
+          const userId = subscription.metadata?.userId;
+          if (!userId) break;
+
+          const priceId = subscription.items.data[0]?.price?.id;
+          if (!priceId) break;
+
+          const status = subscription.status;
+          const currentPeriodEnd = subscription.current_period_end
+            ? new Date(subscription.current_period_end * 1000)
+            : null;
+
+          await prisma.subscriptionEntitlement.upsert({
+            where: { userId },
+            create: {
+              userId,
+              plan: planName(priceId),
+              status,
+              stripeSubscriptionId: subscription.id,
+              stripePriceId: priceId,
+              currentPeriodEnd,
+              featuresJson: featuresForPrice(priceId),
+            },
+            update: {
+              plan: planName(priceId),
+              status,
+              stripeSubscriptionId: subscription.id,
+              stripePriceId: priceId,
+              currentPeriodEnd,
+              featuresJson: featuresForPrice(priceId),
+            },
+          });
+
+          break;
+        }
+
+        case "invoice.payment_failed": {
+          const invoice = event.data.object as Stripe.Invoice;
+          const subscriptionId =
+            typeof invoice.subscription === "string"
+              ? invoice.subscription
+              : invoice.subscription?.id;
+          if (!subscriptionId) break;
+
+          const subscription = await createStripeClient().subscriptions.retrieve(
+            subscriptionId,
+          );
+          const userId = subscription.metadata?.userId;
+          if (!userId) break;
+
+          await prisma.subscriptionEntitlement
+            .update({
+              where: { userId },
+              data: { status: "past_due" },
+            })
+            .catch(() => undefined);
+
+          break;
+        }
+
+        case "customer.subscription.deleted": {
+          const subscription = event.data.object as Stripe.Subscription;
+          const userId = subscription.metadata?.userId;
+          if (!userId) break;
+
+          await prisma.subscriptionEntitlement
+            .update({
+              where: { userId },
+              data: { status: "canceled" },
+            })
+            .catch(() => undefined);
+
+          break;
+        }
+
+        case "customer.subscription.updated": {
+          const subscription = event.data.object as Stripe.Subscription;
+          const userId = subscription.metadata?.userId;
+          if (!userId) break;
+
+          const priceId = subscription.items.data[0]?.price?.id ?? null;
+          const currentPeriodEnd = subscription.current_period_end
+            ? new Date(subscription.current_period_end * 1000)
+            : null;
+
+          await prisma.subscriptionEntitlement.upsert({
+            where: { userId },
+            create: {
+              userId,
+              plan: priceId ? planName(priceId) : "Unknown",
+              status: subscription.status,
+              stripeSubscriptionId: subscription.id,
+              stripePriceId: priceId ?? undefined,
+              currentPeriodEnd,
+              featuresJson: priceId ? featuresForPrice(priceId) : {},
+            },
+            update: {
+              plan: priceId ? planName(priceId) : "Unknown",
+              status: subscription.status,
+              stripeSubscriptionId: subscription.id,
+              stripePriceId: priceId ?? undefined,
+              currentPeriodEnd,
+              featuresJson: priceId ? featuresForPrice(priceId) : {},
+            },
+          });
+
+          break;
+        }
+
+        default:
+          break;
+      }
+
+      return res.status(200).json({ received: true });
+    } catch (err: any) {
+      return res
+        .status(500)
+        .json({ error: err?.message ?? "Webhook handler error" });
+    }
+  },
+);
 
 billing.post("/paypal/order", async (req, res, next) => {
   const paypalConfig = config.getPayPalConfig();

--- a/src/apps/api/src/server.ts
+++ b/src/apps/api/src/server.ts
@@ -19,7 +19,7 @@ import { route } from "./routes/route";
 import { invoices } from "./routes/invoices";
 import { admin } from "./routes/admin";
 import { voice } from "./routes/voice";
-import { billing } from "./routes/billing";
+import { billing, billingWebhook } from "./routes/billing";
 import { dispatch } from "./routes/dispatch";
 import { driver } from "./routes/driver";
 import { fleet } from "./routes/fleet";
@@ -53,6 +53,7 @@ async function initializeServices() {
 }
 
 app.use(cors());
+app.use("/api/billing/webhook", billingWebhook);
 app.use(express.json());
 app.use(tracingMiddleware()); // Phase 3: Distributed tracing
 app.use(rateLimit);


### PR DESCRIPTION
### Motivation
- Provide a subscription checkout flow that creates Stripe Checkout sessions and Stripe customers for authenticated users.  
- Map Stripe Price IDs to human plan names and feature flags so entitlements can be provisioned automatically.  
- Handle Stripe webhook events with signature verification and idempotency to keep local subscription state in sync.

### Description
- Add plan constants and helpers: `PRICE`, `featuresForPrice`, and `planName` to map price IDs to features and names.  
- Implement `POST /stripe/checkout` in the `billing` router which uses `createStripeClient()` to create a Checkout Session and ensures a `prisma.stripeCustomer` exists for the user.  
- Add a `billingWebhook` router that uses `express.raw({ type: 'application/json' })` to verify webhook signatures with `createStripeClient().webhooks.constructEvent` and deduplicate events using `prisma.stripeEvent`.  
- Upsert `prisma.subscriptionEntitlement` on relevant events (`invoice.paid`, `invoice.payment_failed`, `customer.subscription.updated`, `customer.subscription.deleted`) and mount the webhook router at `/api/billing/webhook` before `express.json()` in `server.ts`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960f4f935488330b7da3189e7b732b9)