### PR TITLE
chore(api): add Prisma client and CLI (bump to v5.22.0)

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -24,7 +24,7 @@
     "@infamous-freight/shared": "file:../packages/shared",
     "@json2csv/node": "^7.0.6",
     "@paypal/checkout-server-sdk": "^1.0.3",
-    "@prisma/client": "^5.11.0",
+    "@prisma/client": "^5.22.0",
     "@sentry/node": "^7.100.0",
     "axios": "^1.7.0",
     "compression": "^1.8.1",
@@ -59,7 +59,7 @@
     "jest-junit": "^16.0.0",
     "pino": "^10.1.0",
     "pino-http": "^11.0.0",
-    "prisma": "^5.11.0",
+    "prisma": "^5.22.0",
     "supertest": "^7.1.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,7 +36,7 @@ importers:
         specifier: ^1.0.3
         version: 1.0.3
       '@prisma/client':
-        specifier: ^5.11.0
+        specifier: ^5.22.0
         version: 5.22.0(prisma@5.22.0)
       '@sentry/node':
         specifier: ^7.100.0
@@ -136,7 +136,7 @@ importers:
         specifier: ^11.0.0
         version: 11.0.0
       prisma:
-        specifier: ^5.11.0
+        specifier: ^5.22.0
         version: 5.22.0
       supertest:
         specifier: ^7.1.4


### PR DESCRIPTION
### Motivation
- Ensure the API package has the Prisma client available at the updated version for DB access. 
- Provide the Prisma CLI in devDependencies so migration and generation scripts can run in the API workspace. 
- Keep the lockfile in sync with the updated Prisma versions to ensure reproducible installs. 

### Description
- Added `@prisma/client` to `api.dependencies` and set the specifier to `^5.22.0` in `api/package.json`. 
- Added `prisma` to `api.devDependencies` and set the specifier to `^5.22.0` in `api/package.json`. 
- Updated `pnpm-lock.yaml` entries to reflect the `^5.22.0` specifiers for both `@prisma/client` and `prisma`. 

### Testing
- Installed packages with `pnpm -C api add @prisma/client` which completed successfully. 
- Added dev dependency with `pnpm -C api add -D prisma` which completed successfully. 
- Pre-commit automation (`lint-staged` / `prettier`) ran as part of the commit flow and passed. 
- No unit or integration tests (`jest`) were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960f85ad6488330b934e67c7314cb18)