### PR TITLE
Require JSON body and configured URLs for Stripe checkout

### DIFF
--- a/src/apps/api/src/routes/billing.ts
+++ b/src/apps/api/src/routes/billing.ts
@@ -114,10 +114,16 @@ export const billingWebhook = Router();
 billing.use(requireAuth);
 billing.use(requireScope("billing:write"));
 
-billing.post("/stripe/checkout", async (req, res) => {
+billing.post("/stripe/checkout", express.json(), async (req, res) => {
   const stripeConfig = config.getStripeConfig();
   if (!stripeConfig.enabled) {
     return res.status(503).json({ error: "Stripe not configured" });
+  }
+
+  if (!stripeConfig.successUrl || !stripeConfig.cancelUrl) {
+    return res
+      .status(503)
+      .json({ error: "Stripe success/cancel URLs not configured" });
   }
 
   const { priceId } = req.body as { priceId?: string };


### PR DESCRIPTION
### Motivation

- Prevent creating Stripe Checkout sessions when the app is misconfigured and avoid unclear failures by requiring success/cancel URLs to be set.
- Ensure the checkout endpoint receives a parsed JSON body so `priceId` can be validated reliably.

### Description

- Add `express.json()` middleware to the `/stripe/checkout` route to guarantee request JSON parsing.
- Return `503` with a clear error when `stripeConfig.successUrl` or `stripeConfig.cancelUrl` are not configured, preventing session creation.
- Keep existing customer creation and Checkout Session creation behavior and continue to use `stripeConfig.successUrl`/`cancelUrl` for the session URLs.

### Testing

- No automated tests were run for this change.
- Changes are limited to request handling and configuration validation in `src/apps/api/src/routes/billing.ts` and should be covered by existing integration tests if executed later.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960f9d7c2dc8330b55add23db4eb9bf)