### PR TITLE
Align requireFeature parameter naming

### DIFF
--- a/src/apps/api/src/middleware/multiTenant.ts
+++ b/src/apps/api/src/middleware/multiTenant.ts
@@ -217,7 +217,7 @@ export function multiTenantMiddleware(prisma: PrismaClient) {
 /**
  * Feature gate middleware
  */
-export function requireFeature(featureName: string) {
+export function requireFeature(featureKey: string) {
   return async (req: Request, res: Response, next: NextFunction) => {
     const userId = req.header("x-user-id");
     if (!userId) {
@@ -233,11 +233,11 @@ export function requireFeature(featureName: string) {
       return res.status(403).json({ error: "Subscription not active" });
     }
 
-    const features = ent.featuresJson as Record<string, boolean> | null;
-    if (!features?.[featureName]) {
+    const features = ent.featuresJson as any;
+    if (!features?.[featureKey]) {
       return res
         .status(403)
-        .json({ error: `Missing entitlement: ${featureName}` });
+        .json({ error: `Missing entitlement: ${featureKey}` });
     }
 
     return next();


### PR DESCRIPTION
### Motivation

- Ensure the feature-gate middleware uses a consistent parameter name that reflects how feature flags are looked up.
- Avoid a tight TypeScript type that conflicts with how `featuresJson` is used at runtime.

### Description

- Rename the `requireFeature` parameter from `featureName` to `featureKey` in `src/apps/api/src/middleware/multiTenant.ts` to match usage. 
- Update all internal references and the entitlement error message to use `featureKey` instead of `featureName`.
- Loosen the `featuresJson` typing to `any` to align with the dynamic JSON shape stored in the database.

### Testing

- No automated tests were executed as part of this change.
- No CI runs were triggered by this local change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960faf4111083308825dfb3a3662dba)