### PR TITLE
fix(api): scope JSON parsing to /api routes

### DIFF
--- a/src/apps/api/src/server.ts
+++ b/src/apps/api/src/server.ts
@@ -54,7 +54,7 @@ async function initializeServices() {
 
 app.use(cors());
 app.use("/api/billing/webhook", billingWebhook);
-app.use(express.json());
+app.use("/api", express.json());
 app.use(tracingMiddleware()); // Phase 3: Distributed tracing
 app.use(rateLimit);
 app.use(auditTrail);


### PR DESCRIPTION
### Motivation
- Ensure the billing webhook that relies on `express.raw()` continues receiving the unmodified request body by avoiding a global JSON parser.
- Limit JSON parsing to API endpoints so non-API routes or middleware are not affected by automatic body parsing.
- Preserve the existing middleware ordering so tracing, rate limiting, and audit middleware remain applied to API routes.

### Description
- Replaced the global `app.use(express.json())` with a scoped `app.use("/api", express.json())` in `src/apps/api/src/server.ts`.
- Kept `app.use("/api/billing/webhook", billingWebhook)` before the JSON parser so the webhook can continue using raw parsing.
- Updated the commit with Conventional Commit message `fix(api): scope json parsing to /api routes`.

### Testing
- Pre-commit checks ran `lint-staged` and `prettier` as part of the commit hook and completed successfully.
- Commit message validation ran and passed the Conventional Commits check so the change was committed.
- GitHub Actions workflow linting step was skipped due to `actionlint` not being installed.
- No automated unit or integration tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960fb37bf288330bbd30fc84d122ad7)