### PR TITLE
feat(api): add billing checkout alias and dev header auth

### DIFF
--- a/src/apps/api/src/routes/billing.ts
+++ b/src/apps/api/src/routes/billing.ts
@@ -85,7 +85,9 @@ function featuresForPrice(priceId: string) {
 }
 
 function planName(priceId: string) {
-  if ([PRICE.DISPATCH_MONTHLY, PRICE.DISPATCH_ANNUAL].includes(priceId as any)) {
+  if (
+    [PRICE.DISPATCH_MONTHLY, PRICE.DISPATCH_ANNUAL].includes(priceId as any)
+  ) {
     return "AI Dispatch Operator";
   }
   if ([PRICE.FLEET_MONTHLY, PRICE.FLEET_ANNUAL].includes(priceId as any)) {
@@ -94,7 +96,9 @@ function planName(priceId: string) {
   if ([PRICE.OPS_MONTHLY, PRICE.OPS_ANNUAL].includes(priceId as any)) {
     return "Autonomous Ops Suite";
   }
-  if ([PRICE.ENTERPRISE_MONTHLY, PRICE.ENTERPRISE_ANNUAL].includes(priceId as any)) {
+  if (
+    [PRICE.ENTERPRISE_MONTHLY, PRICE.ENTERPRISE_ANNUAL].includes(priceId as any)
+  ) {
     return "Enterprise";
   }
   return "Unknown";
@@ -108,13 +112,10 @@ function requireUserId(req: express.Request) {
   return userId;
 }
 
-export const billing = Router();
-export const billingWebhook = Router();
-
-billing.use(requireAuth);
-billing.use(requireScope("billing:write"));
-
-billing.post("/stripe/checkout", express.json(), async (req, res) => {
+async function handleStripeCheckout(
+  req: express.Request,
+  res: express.Response,
+) {
   const stripeConfig = config.getStripeConfig();
   if (!stripeConfig.enabled) {
     return res.status(503).json({ error: "Stripe not configured" });
@@ -164,7 +165,16 @@ billing.post("/stripe/checkout", express.json(), async (req, res) => {
   } catch (err: any) {
     return res.status(500).json({ error: err?.message ?? "Unknown error" });
   }
-});
+}
+
+export const billing = Router();
+export const billingWebhook = Router();
+
+billing.use(requireAuth);
+billing.use(requireScope("billing:write"));
+
+billing.post("/checkout", express.json(), handleStripeCheckout);
+billing.post("/stripe/checkout", express.json(), handleStripeCheckout);
 
 billing.post("/stripe/session", async (req, res, next) => {
   const stripeConfig = config.getStripeConfig();
@@ -317,9 +327,8 @@ billingWebhook.post(
               : invoice.subscription?.id;
           if (!subscriptionId) break;
 
-          const subscription = await createStripeClient().subscriptions.retrieve(
-            subscriptionId,
-          );
+          const subscription =
+            await createStripeClient().subscriptions.retrieve(subscriptionId);
           const userId = subscription.metadata?.userId;
           if (!userId) break;
 


### PR DESCRIPTION
### Motivation

- Allow quick local/dev testing of billing endpoints without a full JWT auth flow by accepting header-based user context.
- Provide a concise price-based checkout endpoint that clients can call with a `priceId` for subscription creation.
- Reduce duplicated checkout logic by centralizing Stripe session creation.

### Description

- Add a non-production fallback in `requireAuth` to seed `req.user` from `x-user-id` and optional `x-user-scopes`, with `x-org-id`, `x-user-role`, and `x-user-email` supported and limited to non-production environments.
- Default to injecting the `billing:write` scope for header-based requests hitting billing routes when no scopes are provided.
- Introduce `handleStripeCheckout` in `src/apps/api/src/routes/billing.ts` and wire it to both `POST /api/billing/checkout` and the existing `POST /api/billing/stripe/checkout` to remove duplicated logic.
- Small formatting/cleanup around the billing route and subscription webhook retrieval call.

### Testing

- Pre-commit checks (`lint-staged` + `prettier`) ran as part of the commit hook and succeeded.
- Commit message validation (Conventional Commits) ran and passed.
- No unit or integration tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960fb99514c8330975a5c0123c66d79)