### PR TITLE
feat(api): add billing entitlement endpoint

### DIFF
--- a/src/apps/api/src/routes/billing.ts
+++ b/src/apps/api/src/routes/billing.ts
@@ -85,7 +85,9 @@ function featuresForPrice(priceId: string) {
 }
 
 function planName(priceId: string) {
-  if ([PRICE.DISPATCH_MONTHLY, PRICE.DISPATCH_ANNUAL].includes(priceId as any)) {
+  if (
+    [PRICE.DISPATCH_MONTHLY, PRICE.DISPATCH_ANNUAL].includes(priceId as any)
+  ) {
     return "AI Dispatch Operator";
   }
   if ([PRICE.FLEET_MONTHLY, PRICE.FLEET_ANNUAL].includes(priceId as any)) {
@@ -94,7 +96,9 @@ function planName(priceId: string) {
   if ([PRICE.OPS_MONTHLY, PRICE.OPS_ANNUAL].includes(priceId as any)) {
     return "Autonomous Ops Suite";
   }
-  if ([PRICE.ENTERPRISE_MONTHLY, PRICE.ENTERPRISE_ANNUAL].includes(priceId as any)) {
+  if (
+    [PRICE.ENTERPRISE_MONTHLY, PRICE.ENTERPRISE_ANNUAL].includes(priceId as any)
+  ) {
     return "Enterprise";
   }
   return "Unknown";
@@ -119,6 +123,35 @@ export const billingWebhook = Router();
 billing.use(requireAuth);
 billing.use(requireScope("billing:write"));
 
+/**
+ * GET /api/billing/me
+ * Returns entitlement + feature flags for current user
+ */
+billing.get("/me", async (req, res) => {
+  try {
+    const userId = requireUserId(req);
+    const ent = await prisma.subscriptionEntitlement.findUnique({
+      where: { userId },
+    });
+
+    return res.json({
+      userId,
+      entitlement: ent
+        ? {
+            plan: ent.plan,
+            status: ent.status,
+            stripePriceId: ent.stripePriceId,
+            stripeSubscriptionId: ent.stripeSubscriptionId,
+            currentPeriodEnd: ent.currentPeriodEnd,
+            features: ent.featuresJson,
+          }
+        : null,
+    });
+  } catch (err: any) {
+    return res.status(500).json({ error: err?.message ?? "Unknown error" });
+  }
+});
+
 const stripeCheckoutHandler: express.RequestHandler = async (req, res) => {
   const stripeConfig = config.getStripeConfig();
   if (!stripeConfig.enabled) {
@@ -137,9 +170,7 @@ const stripeCheckoutHandler: express.RequestHandler = async (req, res) => {
       : undefined);
   const cancelUrl =
     stripeConfig.cancelUrl ??
-    (process.env.APP_URL
-      ? `${process.env.APP_URL}/billing/cancel`
-      : undefined);
+    (process.env.APP_URL ? `${process.env.APP_URL}/billing/cancel` : undefined);
 
   if (!successUrl || !cancelUrl) {
     return res
@@ -336,9 +367,8 @@ billingWebhook.post(
               : invoice.subscription?.id;
           if (!subscriptionId) break;
 
-          const subscription = await createStripeClient().subscriptions.retrieve(
-            subscriptionId,
-          );
+          const subscription =
+            await createStripeClient().subscriptions.retrieve(subscriptionId);
           const userId = subscription.metadata?.userId;
           if (!userId) break;
 


### PR DESCRIPTION
### Motivation
- Provide a simple API to fetch the current user's subscription entitlement and feature flags.
- Allow frontend and backend middleware to check a user's plan, status, Stripe ids, period end, and feature gates.

### Description
- Added a `GET /api/billing/me` route to `billing` that calls `requireUserId` and looks up `prisma.subscriptionEntitlement.findUnique` for the user.
- The endpoint returns a structured `entitlement` object with `plan`, `status`, `stripePriceId`, `stripeSubscriptionId`, `currentPeriodEnd`, and `features` or `null` if missing.
- The route is mounted on the existing `billing` router which is protected by `requireAuth` and `requireScope("billing:write")`.
- Errors are caught and returned as a `500` JSON response with an error message.

### Testing
- Pre-commit checks (`lint-staged` + `prettier`) were executed as part of the commit and passed.
- Commit message format validation passed under the repository’s Conventional Commits rule.
- No unit or integration tests were executed for this change.
- Workflow linting (`actionlint`) was skipped due to the tool not being installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960fe2cf774833091f562b3722551a2)