### PR TITLE
chore(deploy): add Fly.io configs for api and web apps

### DIFF
--- a/src/apps/api/fly.toml
+++ b/src/apps/api/fly.toml
@@ -1,0 +1,24 @@
+app = "infamous-api"
+primary_region = "dfw"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  NODE_ENV = "production"
+  PORT = "4000"
+
+[http_service]
+  internal_port = 4000
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 1
+  processes = ["app"]
+
+  [[http_service.checks]]
+    interval = "15s"
+    timeout = "2s"
+    grace_period = "20s"
+    method = "GET"
+    path = "/api/health"

--- a/src/apps/web/fly.toml
+++ b/src/apps/web/fly.toml
@@ -1,0 +1,24 @@
+app = "infamous-web"
+primary_region = "dfw"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  NODE_ENV = "production"
+  PORT = "3000"
+
+[http_service]
+  internal_port = 3000
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 1
+  processes = ["app"]
+
+  [[http_service.checks]]
+    interval = "15s"
+    timeout = "2s"
+    grace_period = "20s"
+    method = "GET"
+    path = "/"


### PR DESCRIPTION
### Motivation
- Provide Fly.io deployment configuration for the API and web applications to enable fast, repeatable deploys.
- Ensure each app exposes the correct port and health check endpoints so platforms can verify service readiness.
- Set sensible defaults for region and runtime environment to match production expectations.

### Description
- Add `src/apps/api/fly.toml` which sets `app = "infamous-api"`, `primary_region = "dfw"`, `[build]` to use `Dockerfile`, environment variables `NODE_ENV` and `PORT`, and an `[http_service]` with `internal_port = 4000` and an HTTP health check at `/api/health`.
- Add `src/apps/web/fly.toml` which sets `app = "infamous-web"`, `primary_region = "dfw"`, `[build]` to use `Dockerfile`, environment variables `NODE_ENV` and `PORT`, and an `[http_service]` with `internal_port = 3000` and an HTTP health check at `/`.
- Configure service lifecycle options in both files such as `force_https`, `auto_start_machines`, `auto_stop_machines`, `min_machines_running`, and process list `["app"]`.

### Testing
- Pre-commit checks including `lint-staged` were executed and passed.
- CI workflow validation via `actionlint` was skipped due to `actionlint` not being installed in the environment.
- No unit or integration tests were run for these configuration file additions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69610eac96a08330bd41b9c530087924)