### PR TITLE
feat(api): add root /health endpoint

### DIFF
--- a/api/src/server.js
+++ b/api/src/server.js
@@ -103,6 +103,7 @@ app.use("/api", billingRoutes);
 app.use("/api", voiceRoutes);
 app.use("/api", usersRoutes);
 app.use("/api", shipmentsRoutes);
+app.get("/health", (_req, res) => res.status(200).send("ok"));
 
 // CSP Violation Report Handler
 app.post("/api/csp-violation", handleCSPViolation);


### PR DESCRIPTION
### Motivation
- Provide a lightweight root health endpoint for external load balancers and platform probes to verify service availability quickly.
- Offer a simple, fast check that does not require invoking the more detailed `/api/health` route and its dependencies.

### Description
- Add a one-line route in `api/src/server.js`: `app.get("/health", (_req, res) => res.status(200).send("ok"));`.
- The endpoint returns HTTP 200 with body `ok` for simple liveness checks and is registered alongside existing routes before CSP handling.

### Testing
- Pre-commit checks ran and passed, including `lint-staged` and `prettier` formatting.
- Commit-time validation enforced Conventional Commits formatting and the message met the required format.
- No unit, integration, or CI test suites were executed as part of this change.
- Manual or automated readiness/liveness probe checks were not run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961115553e8833099ce894c0bb0b4a8)