### PR TITLE
fix(api): bind server to 0.0.0.0 and honor PORT env var

### DIFF
--- a/api/src/server.js
+++ b/api/src/server.js
@@ -122,8 +122,8 @@ app.use(errorHandler);
 attachErrorHandler(app);
 
 const apiConfig = config.getApiConfig();
-const port = apiConfig.port;
-const host = apiConfig.host;
+const port = Number(process.env.PORT ?? apiConfig.port ?? 4000);
+const host = "0.0.0.0";
 
 if (require.main === module) {
   const httpServer = app.listen(port, host, async () => {


### PR DESCRIPTION
### Motivation
- Allow the API to be reachable from outside the container by binding to all interfaces instead of a host-only address.
- Enable runtime configuration of the listening port via the `PORT` environment variable for platform compatibility.
- Provide a safe fallback to existing configuration and a default port to avoid startup failures.

### Description
- Update `api/src/server.js` to set `port` to `Number(process.env.PORT ?? apiConfig.port ?? 4000)` and `host` to `"0.0.0.0"`.
- Ensure the port value is converted to a numeric type before calling `app.listen` to avoid type issues.
- Preserve existing fallback order of `apiConfig.port` then `4000` as the final default.
- No other functional changes were made beyond the server bind and port resolution.

### Testing
- Pre-commit hooks including `lint-staged` and `prettier` ran and passed during the commit process.
- The commit message format check for Conventional Commits passed.
- No unit or integration test suites were executed as part of this change.
- Manual runtime verification was not recorded in automated tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961116d50c0833094d932660ca940c3)