### PR TITLE
feat(api): add v1 MVP intake, API-key auth, and job/document Prisma models

### DIFF
--- a/src/apps/api/prisma/schema.prisma
+++ b/src/apps/api/prisma/schema.prisma
@@ -14,6 +14,9 @@ model Organization {
   name      String
   users     User[]
   webhooks  Webhook[]
+  apiKeys   ApiKey[]
+  documents Document[]
+  jobs      Job[]
   createdAt DateTime    @default(now())
 }
 
@@ -40,6 +43,76 @@ model Invoice {
   vendor         String
   status         String   @default("pending")
   createdAt      DateTime @default(now())
+}
+
+enum ApiKeyRole {
+  admin
+  analyst
+  dispatcher
+}
+
+model ApiKey {
+  id             String       @id @default(cuid())
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  name           String
+  keyHash        String       @unique
+  role           ApiKeyRole   @default(analyst)
+  lastUsedAt     DateTime?
+  createdAt      DateTime     @default(now())
+
+  @@index([organizationId])
+}
+
+enum DocumentType {
+  invoice
+  rate_conf
+  bol
+  other
+}
+
+model Document {
+  id             String       @id @default(cuid())
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  type           DocumentType
+  s3Key          String
+  sha256         String
+  bytes          Int
+  mime           String
+  uploadedBy     String?
+  createdAt      DateTime     @default(now())
+
+  @@index([organizationId, type])
+}
+
+enum JobType {
+  parse_rate_confirmation
+  audit_invoice
+  detention_detection
+}
+
+enum JobStatus {
+  queued
+  working
+  succeeded
+  failed
+}
+
+model Job {
+  id             String       @id @default(cuid())
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  type           JobType
+  status         JobStatus    @default(queued)
+  input          Json
+  output         Json?
+  attempts       Int          @default(0)
+  error          Json?
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
+
+  @@index([organizationId, status])
 }
 
 model AiDecision {

--- a/src/apps/api/src/middleware/apiKeyAuth.ts
+++ b/src/apps/api/src/middleware/apiKeyAuth.ts
@@ -1,0 +1,52 @@
+import crypto from "crypto";
+import { NextFunction, Request, Response } from "express";
+import { prisma } from "../db/prisma";
+import { AuthUser } from "./auth";
+
+function hashKey(key: string) {
+  return crypto.createHash("sha256").update(key).digest("hex");
+}
+
+function extractApiKey(header?: string, explicitKey?: string) {
+  if (explicitKey) return explicitKey.trim();
+  if (!header) return null;
+  if (header.startsWith("Bearer ")) {
+    return header.slice("Bearer ".length).trim();
+  }
+  return null;
+}
+
+export function requireApiKey() {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const apiKeyValue = extractApiKey(
+      req.headers.authorization,
+      req.headers["x-api-key"] as string | undefined,
+    );
+
+    if (!apiKeyValue) {
+      return res.status(401).json({ error: "API key required" });
+    }
+
+    const apiKey = await prisma.apiKey.findUnique({
+      where: { keyHash: hashKey(apiKeyValue) },
+    });
+
+    if (!apiKey) {
+      return res.status(401).json({ error: "Invalid API key" });
+    }
+
+    await prisma.apiKey.update({
+      where: { id: apiKey.id },
+      data: { lastUsedAt: new Date() },
+    });
+
+    const user: AuthUser = {
+      id: apiKey.id,
+      organizationId: apiKey.organizationId,
+      role: apiKey.role,
+    };
+
+    req.user = user;
+    return next();
+  };
+}

--- a/src/apps/api/src/routes/mvp.ts
+++ b/src/apps/api/src/routes/mvp.ts
@@ -1,0 +1,231 @@
+import { randomUUID } from "node:crypto";
+import crypto from "crypto";
+import AWS from "aws-sdk";
+import { Router } from "express";
+import { z } from "zod";
+import { prisma } from "../db/prisma";
+import { requireApiKey } from "../middleware/apiKeyAuth";
+
+const MAX_UPLOAD_BYTES = 25 * 1024 * 1024;
+const PRESIGN_EXPIRES_SECONDS = Number(
+  process.env.S3_PRESIGN_EXPIRES_SECONDS ?? 900,
+);
+
+const bucket =
+  process.env.S3_BUCKET ||
+  process.env.S3_BUCKET_NAME ||
+  "infamous-freight-docs";
+
+const s3 = new AWS.S3({
+  accessKeyId: process.env.S3_ACCESS_KEY || process.env.AWS_ACCESS_KEY_ID,
+  secretAccessKey:
+    process.env.S3_SECRET_KEY || process.env.AWS_SECRET_ACCESS_KEY,
+  region: process.env.AWS_REGION || "us-east-1",
+});
+
+const presignSchema = z.object({
+  fileName: z.string().min(1),
+  mime: z.string().min(1),
+  bytes: z.number().int().positive().max(MAX_UPLOAD_BYTES),
+  type: z.enum(["invoice", "rate_conf", "bol", "other"]),
+  sha256: z.string().optional(),
+});
+
+const rateConfirmationSchema = z.object({
+  documentId: z.string().min(1),
+});
+
+const invoiceAuditSchema = z.object({
+  invoiceDocumentId: z.string().min(1),
+  rateConfirmationId: z.string().optional(),
+});
+
+const detentionSchema = z
+  .object({
+    shipmentId: z.string().optional(),
+    stops: z
+      .array(
+        z.object({
+          kind: z.enum(["pickup", "dropoff"]),
+          locationName: z.string().optional(),
+          plannedArrive: z.string().datetime().optional(),
+          plannedDepart: z.string().datetime().optional(),
+          actualArrive: z.string().datetime().optional(),
+          actualDepart: z.string().datetime().optional(),
+        }),
+      )
+      .optional(),
+    policy: z
+      .object({
+        freeMinutes: z.number().int().nonnegative().default(120),
+        ratePerHourCents: z.number().int().nonnegative().default(5000),
+      })
+      .optional(),
+  })
+  .refine((data) => data.shipmentId || data.stops?.length, {
+    message: "shipmentId or stops required",
+  });
+
+function buildS3Key(
+  orgId: string,
+  type: string,
+  fileName: string,
+  seed: string,
+) {
+  const extension = fileName.includes(".")
+    ? fileName.slice(fileName.lastIndexOf("."))
+    : "";
+  const hash = crypto
+    .createHash("sha256")
+    .update(`${orgId}:${type}:${seed}`)
+    .digest("hex");
+  return `${orgId}/${type}/${hash}${extension}`;
+}
+
+async function createJob({
+  organizationId,
+  type,
+  input,
+}: {
+  organizationId: string;
+  type: "parse_rate_confirmation" | "audit_invoice" | "detention_detection";
+  input: Record<string, unknown>;
+}) {
+  return prisma.job.create({
+    data: {
+      organizationId,
+      type,
+      status: "queued",
+      input,
+    },
+  });
+}
+
+export const mvp = Router();
+
+mvp.get("/health", (_, res) => {
+  res.json({ status: "ok" });
+});
+
+mvp.use(requireApiKey());
+
+mvp.post("/uploads/presign", async (req, res) => {
+  const parsed = presignSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.message });
+  }
+
+  const orgId = req.user!.organizationId;
+  const documentId = randomUUID();
+  const s3Key = buildS3Key(
+    orgId,
+    parsed.data.type,
+    parsed.data.fileName,
+    documentId,
+  );
+
+  await prisma.document.create({
+    data: {
+      id: documentId,
+      organizationId: orgId,
+      type: parsed.data.type,
+      s3Key,
+      sha256: parsed.data.sha256 ?? "pending",
+      bytes: parsed.data.bytes,
+      mime: parsed.data.mime,
+      uploadedBy: req.user?.id,
+    },
+  });
+
+  const uploadUrl = s3.getSignedUrl("putObject", {
+    Bucket: bucket,
+    Key: s3Key,
+    Expires: PRESIGN_EXPIRES_SECONDS,
+    ContentType: parsed.data.mime,
+    ContentLength: parsed.data.bytes,
+  });
+
+  return res.status(201).json({
+    documentId,
+    uploadUrl,
+    s3Key,
+    expiresIn: PRESIGN_EXPIRES_SECONDS,
+  });
+});
+
+mvp.post("/rate-confirmations/parse", async (req, res) => {
+  const parsed = rateConfirmationSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.message });
+  }
+
+  const document = await prisma.document.findFirst({
+    where: {
+      id: parsed.data.documentId,
+      organizationId: req.user!.organizationId,
+    },
+  });
+
+  if (!document) {
+    return res.status(404).json({ error: "Document not found" });
+  }
+
+  const job = await createJob({
+    organizationId: req.user!.organizationId,
+    type: "parse_rate_confirmation",
+    input: { documentId: document.id },
+  });
+
+  return res.status(202).json({ jobId: job.id, status: job.status });
+});
+
+mvp.post("/invoices/audit", async (req, res) => {
+  const parsed = invoiceAuditSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.message });
+  }
+
+  const job = await createJob({
+    organizationId: req.user!.organizationId,
+    type: "audit_invoice",
+    input: parsed.data,
+  });
+
+  return res.status(202).json({ jobId: job.id, status: job.status });
+});
+
+mvp.post("/detention-detection", async (req, res) => {
+  const parsed = detentionSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.message });
+  }
+
+  const job = await createJob({
+    organizationId: req.user!.organizationId,
+    type: "detention_detection",
+    input: parsed.data,
+  });
+
+  return res.status(202).json({ jobId: job.id, status: job.status });
+});
+
+mvp.get("/jobs/:id", async (req, res) => {
+  const job = await prisma.job.findFirst({
+    where: { id: req.params.id, organizationId: req.user!.organizationId },
+  });
+
+  if (!job) {
+    return res.status(404).json({ error: "Job not found" });
+  }
+
+  return res.json({
+    id: job.id,
+    type: job.type,
+    status: job.status,
+    input: job.input,
+    output: job.output,
+    error: job.error,
+    createdAt: job.createdAt,
+    updatedAt: job.updatedAt,
+  });
+});

--- a/src/apps/api/src/server.ts
+++ b/src/apps/api/src/server.ts
@@ -34,6 +34,7 @@ import { websocketService } from "./services/websocket";
 import { cacheService } from "./services/cache";
 import { monitoring } from "./routes/monitoring";
 import { tracingMiddleware } from "./services/tracing";
+import { mvp } from "./routes/mvp";
 
 const app = express();
 const httpServer = createServer(app);
@@ -57,6 +58,7 @@ async function initializeServices() {
 app.use(cors());
 app.use("/api/billing/webhook", billingWebhook);
 app.use("/api", express.json());
+app.use("/v1", express.json());
 app.use(tracingMiddleware()); // Phase 3: Distributed tracing
 app.use(rateLimit);
 app.use(auditTrail);
@@ -80,6 +82,7 @@ app.use("/api/predictions", predictions);
 app.get("/api/analytics", requireFeature("analytics"), (req, res) =>
   res.json({ ok: true }),
 );
+app.use("/v1", mvp);
 app.use(errorHandler);
 
 const apiConfig = config.getApiConfig();


### PR DESCRIPTION
### Motivation
- Provide the Day‑1 MVP public surface for document intake, parsing, invoice audit, detention detection and job tracking under a simple `/v1` API.
- Enforce multi‑tenant org scoping and lightweight auth for programmatic access via API keys scoped to an `Organization`.
- Persist documents and background work as first‑class entities so workers can process asynchronous tasks reliably.
- Support presigned S3 uploads to offload file payloads and keep the API responsive for small requests.

### Description
- Added Prisma schema models and enums for `ApiKey`, `Document`, and `Job` and wired them into `Organization` in `src/apps/api/prisma/schema.prisma`.
- Implemented API key middleware `requireApiKey` that validates keys (stored as a `keyHash`), updates `lastUsedAt`, and injects an org-scoped `req.user` (file: `src/apps/api/src/middleware/apiKeyAuth.ts`).
- Introduced a new `mvp` router mounted at `/v1` exposing `GET /v1/health`, `POST /v1/uploads/presign`, `POST /v1/rate-confirmations/parse`, `POST /v1/invoices/audit`, `POST /v1/detention-detection`, and `GET /v1/jobs/:id` with request validation via `zod` and job creation persisted to `Job` (file: `src/apps/api/src/routes/mvp.ts`).
- Mounted the new router and JSON body parsing in the server (`src/apps/api/src/server.ts`) and implemented S3 presign logic using the AWS SDK with a 25MB limit.

### Testing
- Pre-commit checks (lint‑staged / `prettier`) ran as part of the commit workflow and passed successfully during development.
- Commit tooling validated Conventional Commit format and allowed the change to be recorded after adjustment, with no other automated test suite executed as part of this change.
- No unit or integration tests were run against the new endpoints in this rollout, and database migrations (`prisma migrate`) were not executed here.
- Manual smoke/testing is recommended: run `pnpm --filter api dev` and exercise `POST /v1/uploads/presign` and the job endpoints against a local Postgres/S3/Prisma setup.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69611595e63c83308ae48d574fb83be3)