### PR TITLE
docs: add ADR-0007 (Architecture Freeze and Change Control)

### DIFF
--- a/docs/adr/0007-architecture-freeze.md
+++ b/docs/adr/0007-architecture-freeze.md
@@ -1,0 +1,80 @@
+# ADR-0007: Architecture Freeze and Change Control
+
+**Title**: Architecture Freeze and Change Control
+
+**Number**: ADR-0007
+
+**Status**: Accepted
+
+**Date**: 2026-01-09
+
+---
+
+## Context
+
+The repository has experienced repeated structural churn (package moves, layering shifts, and tooling pivots) that slows delivery and increases review overhead. The current architecture is documented and stable, and the immediate priority is to stop architectural thrash while allowing incremental, product-focused work to continue.
+
+---
+
+## Decision
+
+We will **freeze the architecture** and introduce explicit change control for any structural modifications.
+
+**Frozen elements (default no-change):**
+
+- Monorepo layout and workspace boundaries.
+- Layer responsibilities documented in `docs/architecture.md`.
+- API/Web/Mobile app boundaries and shared package structure.
+- Deployment topology (API, web, mobile, data stores) unless a business-critical exception is approved.
+
+**Permitted changes without an ADR:**
+
+- Feature work that stays within existing modules.
+- Refactors that do not move ownership boundaries (packages/apps remain where they are).
+- Dependency upgrades that do not require moving files across layers.
+- Performance or reliability fixes that preserve the existing architecture.
+
+**Changes that require an ADR + approval:**
+
+- Moving or renaming top-level apps/packages.
+- Splitting or merging packages.
+- Changing the API/web/mobile boundary (or moving shared logic between them).
+- Replacing the core stack (runtime, framework, ORM, database, queueing).
+- Introducing new deployment topology or breaking existing CI/CD flows.
+
+---
+
+## Alternatives Considered
+
+| Option                  | Pros                     | Cons                             | Why Not Chosen                      |
+| ----------------------- | ------------------------ | -------------------------------- | ----------------------------------- |
+| Continue ad-hoc changes | Fast for one-off changes | Ongoing churn, unclear ownership | Too costly long-term                |
+| Full rewrite            | Clean slate              | High risk, long delivery         | Not aligned with current priorities |
+
+---
+
+## Consequences
+
+**Positive:**
+
+- ✅ Predictable delivery and review cycles.
+- ✅ Reduced architectural churn and clearer ownership boundaries.
+- ✅ Easier onboarding with stable docs and layout.
+
+**Negative:**
+
+- ❌ Architectural improvements require more process.
+- ❌ Some optimizations may be deferred.
+
+**Mitigations:**
+
+- Use lightweight ADRs for justified changes.
+- Revisit the freeze quarterly or when business priorities shift.
+
+---
+
+## Related Decisions
+
+- [ADR-0001: Monorepo Architecture](0001-monorepo-architecture.md)
+- [ADR-0002: Shared Package Pattern](0002-shared-package-pattern.md)
+- [ADR-0003: Module System Split](0003-module-system-split.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,6 +24,7 @@ Each ADR follows this structure:
 - [ADR-0004](0004-scope-based-authentication.md) - Scope-Based RBAC Authentication
 - [ADR-0005](0005-prisma-orm.md) - Prisma ORM for Database Management
 - [ADR-0006](0006-synthetic-ai-fallback.md) - Synthetic AI Engine Fallback
+- [ADR-0007](0007-architecture-freeze.md) - Architecture Freeze and Change Control
 
 ## Creating a New ADR
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,6 +16,10 @@ AI agents are first-class system actors, with the UI remaining as a thin, statel
 
 Client (Web / Mobile) → API Gateway → AI Orchestration → Business Logic Engine → Data + Memory Layer → Automation + Jobs
 
+## Architecture Freeze Policy
+
+To stop structural churn, the architecture is frozen and changes to core boundaries require an ADR and approval. See [ADR-0007: Architecture Freeze and Change Control](adr/0007-architecture-freeze.md) for the decision, scope, and allowed changes.
+
 ### Core Responsibilities
 
 - **API Gateway**: Authentication, rate limiting, request normalization, and routing to orchestrated skills.


### PR DESCRIPTION
### Motivation

- The repository has experienced repeated structural churn that slows delivery and increases review overhead.
- The current architecture is documented and considered stable and the priority is to prevent further repo thrash. 
- A lightweight, documented change-control process is needed so product work can continue without uncoordinated structural changes.

### Description

- Add `docs/adr/0007-architecture-freeze.md` which records the Architecture Freeze and Change Control decision and scope. 
- Link the freeze policy from the main `docs/architecture.md` via an `Architecture Freeze Policy` section. 
- Index `ADR-0007` in `docs/adr/README.md` so the ADR catalog includes the new decision. 
- The ADR specifies frozen elements, permitted non-ADR changes, and the classes of modifications that require an ADR and approval.

### Testing

- Pre-commit hooks (`lint-staged` -> `prettier`) were executed and completed successfully during the commit. 
- Commit message format validation (Conventional Commits) was run and passed. 
- Workflow linter (`actionlint`) was skipped due to not being installed. 
- No unit or integration test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696148b0ec088330b98f1f7cc33cd426)