### PR TITLE
ci: update workflow for pnpm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,33 +2,67 @@ name: CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
-  build-and-test:
+  ci:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
+    timeout-minutes: 45
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Use Node.js
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+
+      - name: Setup Node + pnpm cache
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
-          cache: "npm"
+          node-version: 20
+          cache: pnpm
 
-      - name: Install
+      - name: Guard: no package-lock.json anywhere
         run: |
-          if [ -f package-lock.json ]; then npm ci; else npm i; fi
+          if git ls-files '**/package-lock.json' | grep -q .; then
+            echo "ERROR: package-lock.json found. Use pnpm only."
+            git ls-files '**/package-lock.json'
+            exit 1
+          fi
 
-      - name: Test
+      - name: Guard: no committed node_modules
         run: |
-          if npm run | grep -q " test"; then npm test; else echo "No tests defined."; fi
+          if git ls-files '**/node_modules/**' | grep -q .; then
+            echo "ERROR: node_modules tracked in git. Remove it from version control."
+            git ls-files '**/node_modules/**' | head
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Lint
-        run: |
-          if npm run | grep -q " lint"; then npm run lint; else echo "No lint script defined."; fi
+        run: pnpm -r lint
+        continue-on-error: false
+
+      - name: Typecheck
+        run: pnpm -r typecheck
+        continue-on-error: false
+
+      - name: Test
+        run: pnpm -r test
+        continue-on-error: false
+
+      - name: Build
+        run: pnpm -r build
+        continue-on-error: false


### PR DESCRIPTION
### Motivation
- Replace the npm-based CI with a pnpm-first workflow to align dependency management across the repository.
- Add concurrency controls to avoid overlapping runs and improve CI efficiency.
- Enforce repository guardrails to prevent committed `package-lock.json` files and tracked `node_modules` directories.
- Run monorepo-level `lint`, `typecheck`, `test`, and `build` steps consistently via `pnpm`.

### Description
- Updated `.github/workflows/ci.yml` to install `pnpm` using `pnpm/action-setup@v2` and use `actions/setup-node@v4` with `cache: pnpm`.
- Added `concurrency` configuration and `timeout-minutes: 45`, and renamed the job to `ci` with structured steps.
- Added guard steps that fail the job if any `package-lock.json` files are present or if `node_modules` are tracked in git.
- Install now uses `pnpm install --frozen-lockfile`, and CI runs `pnpm -r lint`, `pnpm -r typecheck`, `pnpm -r test`, and `pnpm -r build` with `continue-on-error: false`.

### Testing
- Pre-commit checks (including `lint-staged`) were executed and passed during commit preparation.
- Workflow validation with `actionlint` was skipped because `actionlint` is not installed in the environment.
- Commit message format validation ran and passed against the Conventional Commits requirement.
- The updated GitHub Actions workflow itself has not been executed as part of this change, so no pipeline run results are available yet.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69614f74e76883309862153f792d90a5)