### PR TITLE
chore(api): add build, typecheck, clean, and lint scripts

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -7,8 +7,11 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "NODE_ENV=production node src/server.js",
-    "lint": "echo 'Linting handled by root eslint config'",
-    "lint:fix": "echo 'Linting handled by root eslint config'",
+    "build": "node -c src/server.js",
+    "typecheck": "node -c src/server.js",
+    "clean": "rm -rf coverage .cache .turbo dist",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",


### PR DESCRIPTION
### Motivation
- Provide standard local scripts for the API package so it can be built, type-checked, cleaned, and linted independently from the monorepo root.
- Replace placeholder lint commands with real `eslint` invocations to enable direct linting from the `api` package.

### Description
- Updated `api/package.json` `scripts` to add `build`, `typecheck`, and `clean` using `node -c src/server.js` and `rm -rf coverage .cache .turbo dist` respectively.
- Replaced the echo placeholders with real lint scripts: `lint` now runs `eslint .` and `lint:fix` runs `eslint . --fix`.
- Left existing test and Prisma-related scripts unchanged in `api/package.json`.

### Testing
- Pre-commit checks including `lint-staged` and `prettier` were executed and passed. 
- No unit or integration tests (e.g., `jest`) were run as part of this change.
- No CI workflows were executed during this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696153a6d93483309e681d5aa82c6915)