### PR TITLE
chore(shared): add maintenance scripts

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -5,9 +5,15 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "echo \"(shared) lint not configured\"",
+    "test": "echo \"(shared) no tests\"",
+    "clean": "rm -rf dist"
   },
   "devDependencies": {
     "typescript": "^5.5.4"


### PR DESCRIPTION
### Motivation
- Standardize maintenance scripts for the `shared` package to enable local type checking, linting, testing, and cleanup.
- Make the package consistent with monorepo tooling and developer workflows.

### Description
- Added `typecheck`, `lint`, `test`, and `clean` scripts to `packages/shared/package.json` while keeping the existing `build` script.
- Adjusted `files` array formatting in the package manifest and left `devDependencies` unchanged.
- No changes were made to package dependencies or runtime metadata.

### Testing
- Ran pre-commit automation which executed `lint-staged` and `prettier`, and those checks passed.
- Commit message format validation passed against the Conventional Commits requirement.
- No unit tests or `typecheck`/`test` scripts were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69615443284083308acb545f729640a7)