### PR TITLE
chore: update pnpm workspace globs

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,6 @@
 packages:
   - "api"
-  - "packages/shared"
+  - "packages/*"
   - "tests/e2e"
-  # Explicitly exclude backups/archives from workspace execution
   - "!archive/**"
   - "!**/node_modules/**"


### PR DESCRIPTION
### Motivation
- Simplify workspace package selection to include all packages under the `packages` directory instead of a single explicit package.
- Ensure the workspace still includes `api` and `tests/e2e` entries.
- Avoid running workspace operations against archive and `node_modules` paths by keeping exclusions.

### Description
- Updated `pnpm-workspace.yaml` to replace `"packages/shared"` with the wildcard `"packages/*"`.
- Preserved the `"!archive/**"` and `"!**/node_modules/**"` exclusions.
- No other workspace or dependency changes were introduced (lockfile was not modified in the final change).

### Testing
- Pre-commit hooks were executed and passed the configured checks.
- `lint-staged` reported no staged files to process.
- Workflow validation was skipped with a warning because `actionlint` is not installed.
- Commit message format validation passed for the applied change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69615b6571ec83308239b32d9aa40ea9)