### PR TITLE
chore: update workspace paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
     "prepare": "husky install"
   },
   "workspaces": [
-    "src/apps/*",
-    "src/packages/*",
-    "tests/*"
+    "api",
+    "packages/*",
+    "tests/e2e"
   ],
   "devDependencies": {
     "@playwright/test": "^1.47.0",


### PR DESCRIPTION
### Motivation
- Align the root `workspaces` configuration with the repository layout so `pnpm` recognizes the actual packages.
- Replace outdated globs (`src/apps/*`, `src/packages/*`, `tests/*`) with the correct paths `api`, `packages/*`, and `tests/e2e`.
- Prevent workspace resolution and script execution issues for the `api` and end-to-end test packages.

### Description
- Updated the `workspaces` array in `package.json` to `["api","packages/*","tests/e2e"]`.
- Reverted unintended changes to `pnpm-lock.yaml` using `git checkout -- pnpm-lock.yaml` so the lockfile was not modified.
- Staged and committed the `package.json` change with the message `chore: update workspace paths` after pre-commit hooks completed.
- No other source files were changed.

### Testing
- Pre-commit checks ran `lint-staged` which executed `prettier --write` and completed successfully.
- The commit hook validated the commit message format and accepted `chore: update workspace paths`.
- No unit, integration, or e2e test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69615f3b80188330a1dea34856e6fed2)