### PR TITLE
ci: adjust health check status count

### DIFF
--- a/.github/workflows/health-check-monitoring.yml
+++ b/.github/workflows/health-check-monitoring.yml
@@ -116,11 +116,19 @@ jobs:
           
           # Count operational platforms
           OPERATIONAL=0
-          [[ "${{ steps.github-pages.outputs.status }}" =~ "Operational" ]] && ((OPERATIONAL++))
-          [[ "${{ steps.vercel.outputs.status }}" =~ "Operational" ]] && ((OPERATIONAL++))
-          [[ "${{ steps.netlify.outputs.status }}" =~ "Operational" ]] && ((OPERATIONAL++))
-          [[ "${{ steps.cloudflare.outputs.status }}" =~ "Operational" ]] && ((OPERATIONAL++))
-          [[ "${{ steps.render.outputs.status }}" =~ "Operational" ]] && ((OPERATIONAL++))
+          STATUSES=(
+            "${{ steps.github-pages.outputs.status }}"
+            "${{ steps.vercel.outputs.status }}"
+            "${{ steps.netlify.outputs.status }}"
+            "${{ steps.cloudflare.outputs.status }}"
+            "${{ steps.render.outputs.status }}"
+          )
+
+          for s in "${STATUSES[@]}"; do
+            if [[ "$s" == *Operational* ]]; then
+              OPERATIONAL=$((OPERATIONAL + 1))
+            fi
+          done
           
           echo "**Operational Platforms:** $OPERATIONAL / 5" >> $GITHUB_STEP_SUMMARY
           


### PR DESCRIPTION
### Motivation
- Simplify and harden the platform health summary by consolidating status checks into an iterable list to avoid repetitive conditional expressions in the workflow ` .github/workflows/health-check-monitoring.yml`.

### Description
- Replace five inline `[[ ... =~ "Operational" ]]` checks with a `STATUSES` array and a `for` loop that increments an `OPERATIONAL` counter when an entry contains `Operational` in ` .github/workflows/health-check-monitoring.yml`.
- Preserve the existing overall health evaluation logic that emits `overall=healthy|degraded|critical` and writes the `GITHUB_STEP_SUMMARY` output unchanged.

### Testing
- No automated tests were executed because this is a workflow-only change and the GitHub Actions workflow was not run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972b2985e7c8330a94df916507b51bd)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved health check monitoring workflow with optimized status aggregation logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->