### PR TITLE
fix(api): align pnpm with lockfile and include shared package manifest in Dockerfile

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -5,11 +5,12 @@ WORKDIR /app
 
 # Enable pnpm via corepack
 RUN apk add --no-cache python3 make g++ openssl openssl-dev
-RUN corepack enable && corepack prepare pnpm@8.15.0 --activate
+RUN corepack enable && corepack prepare pnpm@9.12.0 --activate
 
 # Cache deps first
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml* ./
 COPY api/package.json ./api/package.json
+COPY packages/shared/package.json ./packages/shared/package.json
 
 RUN pnpm install --frozen-lockfile || pnpm install
 


### PR DESCRIPTION
### Motivation
- Fix Docker image build failures caused by pnpm workspace linking and a lockfile/pnpm version mismatch during dependency installation in the `api` image.

### Description
- Update `api/Dockerfile` to prepare `pnpm@9.12.0` via `corepack` and copy `packages/shared/package.json` into the build context before running `pnpm install` so workspace links resolve during install.

### Testing
- No automated tests were executed for this build-time change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972b6e3702483308503be6c12940ab5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package manager version in build configuration to improve compatibility and performance.
  * Enhanced Docker build process for more reliable dependency installation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->