### PR TITLE
chore: harden api deploy config

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,35 +1,36 @@
-## Monorepo-friendly API image for Render/Fly/DO
-FROM node:20-alpine AS base
+# syntax=docker/dockerfile:1.6
 
+FROM node:20-slim AS base
+ENV NODE_ENV=production
 WORKDIR /app
+RUN corepack enable
 
-# Enable pnpm via corepack
-RUN apk add --no-cache python3 make g++ openssl openssl-dev
-RUN corepack enable && corepack prepare pnpm@9.12.0 --activate
-
-# Cache deps first
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml* ./
-COPY api/package.json ./api/package.json
-COPY packages/shared/package.json ./packages/shared/package.json
-
-RUN pnpm install --frozen-lockfile || pnpm install
-
-# Build shared package
+FROM base AS deps
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY packages ./packages
-RUN pnpm -C packages/shared build || true
+COPY api/package.json ./api/package.json
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
+    pnpm config set store-dir /pnpm/store && \
+    pnpm install --frozen-lockfile
 
-# Copy full repo (api + packages + shared assets)
+FROM base AS build
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/packages ./packages
+COPY --from=deps /app/api ./api
 COPY . .
+RUN pnpm --filter @infamous-freight/shared build
+RUN pnpm --filter infamous-freight-api build
+RUN pnpm --filter infamous-freight-api prisma:generate
 
-# Generate Prisma client
-RUN pnpm -C api prisma:generate || true
+FROM node:20-slim AS runner
+ENV NODE_ENV=production
+WORKDIR /app
+RUN useradd -m nodeuser
+USER nodeuser
 
-# Build API if script exists (CI-safe)
-RUN pnpm -C api --if-present build || true
-
-# Cleanup build dependencies
-RUN apk del --no-cache python3 make g++
+COPY --from=build /app/api ./api
+COPY --from=build /app/packages ./packages
+COPY --from=build /app/node_modules ./node_modules
 
 EXPOSE 3001
-ENV NODE_ENV=production
-CMD ["node", "api/src/index.js"]
+CMD ["node", "api/src/server.js"]

--- a/api/fly.toml
+++ b/api/fly.toml
@@ -1,0 +1,22 @@
+app = "infamous-freight-api"
+primary_region = "ord"
+
+[build]
+  dockerfile = "api/Dockerfile"
+
+[http_service]
+  internal_port = 3001
+  force_https = true
+  auto_stop_machines = true
+  auto_start_machines = true
+  min_machines_running = 1
+
+  [http_service.concurrency]
+    type = "requests"
+    soft_limit = 50
+    hard_limit = 100
+
+[[vm]]
+  cpu_kind = "shared"
+  cpus = 1
+  memory_mb = 1024

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
   "copyright": "© 2025 Infæmous Freight. All Rights Reserved.",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@9.12.3",
+  "packageManager": "pnpm@9.15.0",
   "engines": {
-    "node": ">=18.0.0",
-    "pnpm": ">=8.15.0"
+    "node": ">=20.0.0",
+    "pnpm": ">=9.15.0"
   },
   "scripts": {
     "dev": "./start-dev.sh",


### PR DESCRIPTION
### Motivation
- Ensure deterministic, CI-safe builds for the API and avoid previous deploy failures caused by lockfile/Node drift.
- Run Prisma client generation during image build and support the monorepo `packages/shared` build step for predictable production images.
- Provide a Fly.io service configuration that matches production staging expectations and enforces sensible runtime defaults.

### Description
- Replaced `api/Dockerfile` with a multi-stage image that uses `node:20-slim`, enables `corepack`, performs a frozen `pnpm install` with a cache mount, builds the shared package and API, runs `prisma:generate` at build time, and sets a non-root runtime user with the final `CMD` of `node api/src/server.js`.
- Added `api/fly.toml` that declares the Fly app (`infamous-freight-api`), primary region `ord`, the `api/Dockerfile` build, `http_service` settings (internal port `3001`, HTTPS enforcement, auto start/stop, concurrency limits), and a small VM resource block.
- Pinned package manager and runtime in the repository root `package.json` by setting `packageManager` to `pnpm@9.15.0` and updating `engines` to `node: ">=20.0.0"` and `pnpm: ">=9.15.0"`.

### Testing
- No automated tests were executed as part of this change.
- Changes were validated locally by inspecting the updated files and committing the changes (`git status` and file previews were used to confirm diffs).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973537b189883308e86cae084c78ed8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minimum Node.js requirement updated to 20.0.0 or higher
  * Updated pnpm package manager to 9.15.0 or higher
  * Optimized build and deployment pipeline for improved efficiency and reliability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->