### PR TITLE
feat(billing): add Stripe checkout & metered billing endpoints + pricing UI

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -79,6 +79,15 @@ STRIPE_PRICE_STARTER=price_starter_monthly
 STRIPE_PRICE_PRO=price_pro_monthly
 STRIPE_PRICE_ENTERPRISE=price_enterprise_monthly
 
+# Stripe Billing + Checkout (seat plans, metered usage, add-ons)
+STRIPE_PRO_PRICE_ID=price_pro_seat_monthly
+STRIPE_BUSINESS_PRICE_ID=price_business_seat_monthly
+STRIPE_AI_METERED_PRICE_ID=price_ai_actions_metered
+STRIPE_VOICE_PRICE_ID=price_voice_seat_monthly
+STRIPE_WHITE_LABEL_PRICE_ID=price_white_label_monthly
+STRIPE_ANALYTICS_PRICE_ID=price_analytics_export_monthly
+STRIPE_USAGE_REPORT_KEY=change_me_for_cron_jobs
+
 # PayPal
 PAYPAL_CLIENT_ID=your_paypal_client_id_here
 PAYPAL_CLIENT_SECRET=your_paypal_client_secret_here

--- a/api/src/routes/stripe.js
+++ b/api/src/routes/stripe.js
@@ -1,0 +1,381 @@
+/*
+ * Copyright © 2025 Infæmous Freight. All Rights Reserved.
+ * Proprietary and Confidential - See COPYRIGHT file for details.
+ * Module: Stripe Checkout + Billing Portal + Webhooks
+ */
+
+const express = require("express");
+const { z } = require("zod");
+const { stripeClient, isStripeConfigured } = require("../billing/stripe");
+const { authenticate, limiters } = require("../middleware/security");
+const persist = require("../billing/persist");
+
+const stripeRouter = express.Router();
+const stripeWebhookRouter = express.Router();
+
+const planCatalog = [
+  { key: "pro", label: "Infæmous Freight Pro (per seat)", env: "STRIPE_PRO_PRICE_ID" },
+  {
+    key: "business",
+    label: "Infæmous Freight Business (per seat)",
+    env: "STRIPE_BUSINESS_PRICE_ID",
+  },
+];
+
+const addOnCatalog = {
+  voice: {
+    label: "Voice (per seat)",
+    env: "STRIPE_VOICE_PRICE_ID",
+    quantity: "seats",
+  },
+  white_label: {
+    label: "White-label (flat)",
+    env: "STRIPE_WHITE_LABEL_PRICE_ID",
+    quantity: "flat",
+  },
+  analytics_export: {
+    label: "Analytics export (flat)",
+    env: "STRIPE_ANALYTICS_PRICE_ID",
+    quantity: "flat",
+  },
+};
+
+function getAppUrl() {
+  return (
+    process.env.APP_URL ||
+    process.env.PUBLIC_APP_URL ||
+    "http://localhost:3000"
+  );
+}
+
+function resolvePlanPriceId(plan) {
+  const entry = planCatalog.find((item) => item.key === plan);
+  if (!entry) return null;
+  return process.env[entry.env] || null;
+}
+
+function resolveAddOnPriceId(addOnKey) {
+  const entry = addOnCatalog[addOnKey];
+  if (!entry) return null;
+  return process.env[entry.env] || null;
+}
+
+// --------------------------------------------
+// GET /api/stripe/plans
+// --------------------------------------------
+stripeRouter.get("/plans", (_req, res) => {
+  const plans = planCatalog.map((plan) => ({
+    key: plan.key,
+    label: plan.label,
+    priceId: process.env[plan.env] || null,
+  }));
+
+  res.json({
+    ok: true,
+    configured: isStripeConfigured(),
+    plans,
+  });
+});
+
+// --------------------------------------------
+// POST /api/stripe/checkout
+// --------------------------------------------
+stripeRouter.post(
+  "/checkout",
+  limiters.billing,
+  authenticate,
+  async (req, res) => {
+    try {
+      const Schema = z.object({
+        plan: z.enum(["pro", "business"]),
+        seats: z.number().int().min(1).max(500).optional().default(1),
+        addOns: z
+          .array(z.enum(["voice", "white_label", "analytics_export"]))
+          .optional()
+          .default([]),
+        customerEmail: z.string().email().optional(),
+        tenantId: z.string().optional(),
+        includeAiMetered: z.boolean().optional().default(true),
+      });
+      const body = Schema.parse(req.body);
+
+      const stripe = stripeClient();
+      if (!stripe) {
+        return res.status(400).json({
+          ok: false,
+          error:
+            "Stripe not configured. Set STRIPE_SECRET_KEY and price ID env vars.",
+        });
+      }
+
+      const planPriceId = resolvePlanPriceId(body.plan);
+      if (!planPriceId) {
+        return res.status(400).json({
+          ok: false,
+          error: `Missing price ID for plan ${body.plan}.`,
+        });
+      }
+
+      const lineItems = [{ price: planPriceId, quantity: body.seats }];
+
+      for (const addOn of body.addOns) {
+        const addOnPriceId = resolveAddOnPriceId(addOn);
+        if (!addOnPriceId) {
+          return res.status(400).json({
+            ok: false,
+            error: `Missing price ID for add-on ${addOn}.`,
+          });
+        }
+        const quantity =
+          addOnCatalog[addOn].quantity === "seats" ? body.seats : 1;
+        lineItems.push({ price: addOnPriceId, quantity });
+      }
+
+      if (body.includeAiMetered && process.env.STRIPE_AI_METERED_PRICE_ID) {
+        lineItems.push({
+          price: process.env.STRIPE_AI_METERED_PRICE_ID,
+          quantity: 1,
+        });
+      }
+
+      const tenantId =
+        body.tenantId || req.auth?.organizationId || req.user?.sub || "";
+
+      const session = await stripe.checkout.sessions.create({
+        mode: "subscription",
+        customer_email: body.customerEmail,
+        line_items: lineItems,
+        success_url: `${getAppUrl()}/billing/success?session_id={CHECKOUT_SESSION_ID}`,
+        cancel_url: `${getAppUrl()}/billing/cancel`,
+        subscription_data: {
+          metadata: {
+            tenantId,
+            plan: body.plan,
+            seats: String(body.seats),
+            addOns: body.addOns.join(","),
+          },
+        },
+        metadata: {
+          tenantId,
+          plan: body.plan,
+          seats: String(body.seats),
+          addOns: body.addOns.join(","),
+        },
+      });
+
+      return res.json({ ok: true, url: session.url });
+    } catch (err) {
+      return res.status(500).json({
+        ok: false,
+        error: err?.message || "Checkout failed",
+      });
+    }
+  }
+);
+
+// --------------------------------------------
+// POST /api/stripe/portal
+// --------------------------------------------
+stripeRouter.post(
+  "/portal",
+  limiters.billing,
+  authenticate,
+  async (req, res) => {
+    try {
+      const Schema = z.object({ customerId: z.string().min(1) });
+      const body = Schema.parse(req.body);
+
+      const stripe = stripeClient();
+      if (!stripe) {
+        return res.status(400).json({
+          ok: false,
+          error: "Stripe not configured.",
+        });
+      }
+
+      const session = await stripe.billingPortal.sessions.create({
+        customer: body.customerId,
+        return_url: `${getAppUrl()}/billing`,
+      });
+
+      return res.json({ ok: true, url: session.url });
+    } catch (err) {
+      return res.status(500).json({
+        ok: false,
+        error: err?.message || "Portal failed",
+      });
+    }
+  }
+);
+
+// --------------------------------------------
+// POST /api/stripe/report-usage
+// --------------------------------------------
+stripeRouter.post("/report-usage", limiters.billing, async (req, res) => {
+  try {
+    const usageKey = process.env.STRIPE_USAGE_REPORT_KEY;
+    if (usageKey) {
+      const providedKey = req.headers["x-usage-report-key"];
+      if (providedKey !== usageKey) {
+        return res.status(403).json({ ok: false, error: "Forbidden" });
+      }
+    }
+
+    const Schema = z.object({
+      subscriptionItemId: z.string().min(1),
+      quantity: z.number().int().positive(),
+      timestamp: z.number().int().optional(),
+    });
+    const body = Schema.parse(req.body);
+
+    const stripe = stripeClient();
+    if (!stripe) {
+      return res.status(400).json({
+        ok: false,
+        error: "Stripe not configured.",
+      });
+    }
+
+    await stripe.subscriptionItems.createUsageRecord(body.subscriptionItemId, {
+      quantity: body.quantity,
+      timestamp: body.timestamp || Math.floor(Date.now() / 1000),
+      action: "increment",
+    });
+
+    return res.json({ ok: true });
+  } catch (err) {
+    return res.status(500).json({
+      ok: false,
+      error: err?.message || "Usage reporting failed",
+    });
+  }
+});
+
+// --------------------------------------------
+// POST /api/stripe/webhook (raw body)
+// --------------------------------------------
+stripeWebhookRouter.post(
+  "/webhook",
+  limiters.webhook,
+  express.raw({ type: "application/json" }),
+  async (req, res) => {
+    const stripe = stripeClient();
+    if (!stripe) {
+      return res.status(400).json({ ok: false, error: "Stripe not configured." });
+    }
+
+    const sig = req.headers["stripe-signature"];
+    if (!sig || !process.env.STRIPE_WEBHOOK_SECRET) {
+      return res.status(400).json({
+        ok: false,
+        error: "Missing Stripe webhook signature or secret.",
+      });
+    }
+
+    let event;
+    try {
+      event = stripe.webhooks.constructEvent(
+        req.body,
+        sig,
+        process.env.STRIPE_WEBHOOK_SECRET
+      );
+    } catch (err) {
+      return res
+        .status(400)
+        .send(`Webhook Error: ${err?.message || "Invalid signature"}`);
+    }
+
+    try {
+      switch (event.type) {
+        case "checkout.session.completed": {
+          const session = event.data.object;
+          const tenantId =
+            session.metadata?.tenantId || session.client_reference_id || "";
+          const plan = session.metadata?.plan || "unknown";
+          const seats = session.metadata?.seats || "1";
+          const addOns = session.metadata?.addOns || "";
+
+          if (tenantId) {
+            await persist.setEntitlement(tenantId, "plan", String(plan));
+            await persist.setEntitlement(tenantId, "seats", String(seats));
+            await persist.setEntitlement(tenantId, "add_ons", String(addOns));
+            await persist.setEntitlement(tenantId, "stripe_status", "active");
+            await persist.setEntitlement(
+              tenantId,
+              "stripe_customer_id",
+              String(session.customer || "")
+            );
+            await persist.setEntitlement(
+              tenantId,
+              "stripe_subscription_id",
+              String(session.subscription || "")
+            );
+          }
+          break;
+        }
+        case "customer.subscription.created":
+        case "customer.subscription.updated":
+        case "customer.subscription.deleted": {
+          const subscription = event.data.object;
+          const tenantId = subscription.metadata?.tenantId || "";
+          if (tenantId) {
+            await persist.setEntitlement(
+              tenantId,
+              "stripe_status",
+              String(subscription.status)
+            );
+            if (subscription.metadata?.plan) {
+              await persist.setEntitlement(
+                tenantId,
+                "plan",
+                String(subscription.metadata.plan)
+              );
+            }
+          }
+          break;
+        }
+        case "invoice.finalized":
+        case "invoice.paid": {
+          const invoice = event.data.object;
+          const tenantId = invoice.metadata?.tenantId || "";
+          if (tenantId) {
+            await persist.setEntitlement(
+              tenantId,
+              "last_invoice_status",
+              String(invoice.status)
+            );
+          }
+          break;
+        }
+        case "invoice.payment_failed": {
+          const invoice = event.data.object;
+          const tenantId = invoice.metadata?.tenantId || "";
+          if (tenantId) {
+            await persist.setEntitlement(
+              tenantId,
+              "stripe_status",
+              "past_due"
+            );
+            await persist.setEntitlement(
+              tenantId,
+              "last_invoice_status",
+              String(invoice.status)
+            );
+          }
+          break;
+        }
+        default:
+          break;
+      }
+
+      return res.json({ received: true });
+    } catch (err) {
+      return res.status(500).json({
+        ok: false,
+        error: err?.message || "Webhook handling failed",
+      });
+    }
+  }
+);
+
+module.exports = { stripeRouter, stripeWebhookRouter };

--- a/api/src/server.js
+++ b/api/src/server.js
@@ -45,6 +45,7 @@ const healthDetailedRoutes = require("./routes/health-detailed");
 const aiRoutes = require("./routes/ai.commands");
 const billingRoutes = require("./routes/billing");
 const billingPaymentsRoutes = require("./routes/billing-payments");
+const { stripeRouter, stripeWebhookRouter } = require("./routes/stripe");
 const voiceRoutes = require("./routes/voice");
 const aiSimRoutes = require("./routes/aiSim.internal");
 const usersRoutes = require("./routes/users");
@@ -131,6 +132,9 @@ app.use(jwtRotationAuth());
 if (marketplaceEnabled && marketplaceWebhooks) {
   app.use("/api/webhooks", marketplaceWebhooks);
 }
+if (stripeWebhookRouter) {
+  app.use("/api/stripe", stripeWebhookRouter);
+}
 
 app.use(express.json({ limit: "12mb" }));
 
@@ -157,6 +161,7 @@ app.use("/api", analyticsRoutes);
 app.use("/api", metricsRoutes);
 app.use("/api", adminFeatureFlagsRoutes);
 app.use("/api", adminOpsRoutes);
+app.use("/api/stripe", stripeRouter);
 app.use("/v1/auth", authRouter);
 
 // Serve static avatar files (Phase 1 & Phase 2)

--- a/web/.env.example
+++ b/web/.env.example
@@ -12,6 +12,7 @@ NODE_ENV=development
 # ============================================
 NEXT_PUBLIC_APP_NAME=Infæmous Freight
 NEXT_PUBLIC_ENV=development
+NEXT_PUBLIC_APP_URL=http://localhost:3000
 WEB_PORT=3000
 
 # ============================================

--- a/web/pages/pricing.tsx
+++ b/web/pages/pricing.tsx
@@ -4,7 +4,10 @@ import { useRouter } from "next/router";
 import { getLocaleFromRouter, t } from "../lib/i18n/t";
 import { GetStaticProps } from "next";
 
-const apiBase = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
+const apiBase = (process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001").replace(
+  /\/api\/?$/,
+  ""
+);
 
 type Plan = {
   key: string;
@@ -25,10 +28,12 @@ export default function Pricing({ initialPlans, initialConfigured }: PricingProp
   const [configured, setConfigured] = useState(initialConfigured || false);
   const [err, setErr] = useState<string | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
+  const [seats, setSeats] = useState<number>(5);
+  const [addOns, setAddOns] = useState<string[]>([]);
 
   // Client-side refresh (optional, for real-time updates)
   useEffect(() => {
-    fetch(`${apiBase}/v1/billing/plans`)
+    fetch(`${apiBase}/api/stripe/plans`)
       .then((r) => r.json())
       .then((d) => {
         setPlans(d.plans || []);
@@ -43,14 +48,19 @@ export default function Pricing({ initialPlans, initialConfigured }: PricingProp
     try {
       // Use dev token if no auth yet
       const token = localStorage.getItem("genesisToken") || "dev-token";
-      const res = await fetch(`${apiBase}/v1/billing/checkout`, {
+      const res = await fetch(`${apiBase}/api/stripe/checkout`, {
         method: "POST",
         headers: {
           "content-type": "application/json",
           Authorization: `Bearer ${token}`,
           "x-user-id": "demo-user",
         },
-        body: JSON.stringify({ planKey }),
+        body: JSON.stringify({
+          plan: planKey,
+          seats,
+          addOns,
+          tenantId: "demo-tenant",
+        }),
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data?.error ?? "Checkout failed");
@@ -73,8 +83,8 @@ export default function Pricing({ initialPlans, initialConfigured }: PricingProp
     <main style={{ maxWidth: 1100, margin: "0 auto", padding: 24 }}>
       <h1 style={{ margin: 0, color: "rgb(180,0,0)" }}>Pricing</h1>
       <p style={{ opacity: 0.85 }}>
-        Choose a plan. If Stripe is not configured yet, checkout will show a
-        clear setup message.
+        Choose a plan, seat count, and optional add-ons. If Stripe is not
+        configured yet, checkout will show a clear setup message.
       </p>
 
       {err ? (
@@ -88,6 +98,72 @@ export default function Pricing({ initialPlans, initialConfigured }: PricingProp
           <strong style={{ color: "rgb(180,0,0)" }}>Error:</strong> {err}
         </div>
       ) : null}
+
+      <div style={{ ...card, marginTop: 14 }}>
+        <label style={{ display: "block", fontWeight: 600 }}>
+          Seat count
+        </label>
+        <input
+          type="number"
+          min={1}
+          max={500}
+          value={seats}
+          onChange={(event) => setSeats(Number(event.target.value))}
+          style={{
+            marginTop: 6,
+            padding: "8px 12px",
+            borderRadius: 10,
+            border: "1px solid rgba(255,0,0,0.25)",
+            width: 140,
+          }}
+        />
+        <div style={{ marginTop: 12, fontWeight: 600 }}>Add-ons</div>
+        <label style={{ display: "flex", gap: 8, marginTop: 6 }}>
+          <input
+            type="checkbox"
+            checked={addOns.includes("voice")}
+            onChange={(event) => {
+              setAddOns((prev) =>
+                event.target.checked
+                  ? [...prev, "voice"]
+                  : prev.filter((item) => item !== "voice")
+              );
+            }}
+          />
+          Voice commands (per seat)
+        </label>
+        <label style={{ display: "flex", gap: 8, marginTop: 6 }}>
+          <input
+            type="checkbox"
+            checked={addOns.includes("white_label")}
+            onChange={(event) => {
+              setAddOns((prev) =>
+                event.target.checked
+                  ? [...prev, "white_label"]
+                  : prev.filter((item) => item !== "white_label")
+              );
+            }}
+          />
+          White-label (flat)
+        </label>
+        <label style={{ display: "flex", gap: 8, marginTop: 6 }}>
+          <input
+            type="checkbox"
+            checked={addOns.includes("analytics_export")}
+            onChange={(event) => {
+              setAddOns((prev) =>
+                event.target.checked
+                  ? [...prev, "analytics_export"]
+                  : prev.filter((item) => item !== "analytics_export")
+              );
+            }}
+          />
+          Analytics export (flat)
+        </label>
+        <div style={{ marginTop: 8, fontSize: 12, opacity: 0.7 }}>
+          AI actions are metered and billed monthly when enabled.
+        </div>
+      </div>
 
       <div
         style={{
@@ -105,6 +181,9 @@ export default function Pricing({ initialPlans, initialConfigured }: PricingProp
             </div>
             <div style={{ marginTop: 8, opacity: 0.8, fontSize: 12 }}>
               Stripe priceId: <code>{p.priceId ?? "not set"}</code>
+            </div>
+            <div style={{ marginTop: 8, opacity: 0.8, fontSize: 12 }}>
+              Seats: <strong>{seats}</strong>
             </div>
 
             <button
@@ -142,8 +221,10 @@ export default function Pricing({ initialPlans, initialConfigured }: PricingProp
  */
 export const getStaticProps: GetStaticProps = async () => {
   try {
-    const apiUrl = process.env.API_BASE_URL || process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
-    const res = await fetch(`${apiUrl}/v1/billing/plans`, {
+    const apiUrl = (
+      process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001"
+    ).replace(/\/api\/?$/, "");
+    const res = await fetch(`${apiUrl}/api/stripe/plans`, {
       headers: { 'User-Agent': 'Next.js-ISR' },
     });
     


### PR DESCRIPTION
### Motivation
- Implement a complete, production-ready Stripe billing flow (seat-based subscriptions, add-ons, metered AI usage, portal, and webhook handling) so the platform can create subscriptions and report usage reliably.
- Provide a minimal frontend integration so teams can start Checkout from the Next.js pricing page and test the end-to-end flow locally.

### Description
- Added a new Express route file `api/src/routes/stripe.js` providing endpoints: `GET /api/stripe/plans`, `POST /api/stripe/checkout`, `POST /api/stripe/portal`, `POST /api/stripe/report-usage`, and `POST /api/stripe/webhook` (raw body + signature verification) with plan, seats, add-ons and metadata wiring to Stripe and entitlement persistence via `billing/persist`.
- Wired the new routes into the server by importing and mounting `stripeRouter` and `stripeWebhookRouter` in `api/src/server.js` (webhook router mounted before `express.json()` to preserve raw body handling).
- Updated frontend pricing page `web/pages/pricing.tsx` to call the new API: fetch plans from `GET /api/stripe/plans`, allow selecting `seats` and `addOns`, and POST to `/api/stripe/checkout` to start Stripe Checkout.
- Added new environment variables to `api/.env.example` and `web/.env.example` for the new prices, metered price id, add-on price ids, usage report key, and public app URL (`STRIPE_PRO_PRICE_ID`, `STRIPE_BUSINESS_PRICE_ID`, `STRIPE_AI_METERED_PRICE_ID`, `STRIPE_VOICE_PRICE_ID`, `STRIPE_WHITE_LABEL_PRICE_ID`, `STRIPE_ANALYTICS_PRICE_ID`, `STRIPE_USAGE_REPORT_KEY`, `NEXT_PUBLIC_APP_URL`).

### Testing
- Started the frontend with `pnpm --filter web exec -- next dev -p 3000 -H 0.0.0.0` and confirmed Next.js started successfully (Local: `http://localhost:3000`).
- Ran a Playwright script that navigated to `/pricing` and produced a screenshot artifact showing the updated pricing UI (succeeded, artifact produced).
- During ISR/server-side fetch the pricing page attempted to call the API and hit `ECONNREFUSED`, so the page fell back to the client-side fetch and used the fallback ISR state (fetch error observed and logged). 
- Committed changes with a conventional commit `feat(billing): add stripe checkout flow`; no unit/integration test suite was run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697423df9fdc8330a76275d168980e75)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stripe payment integration now available with subscription checkout
  * Pricing page now supports selecting number of seats and add-ons (voice, white-label, analytics export)
  * Billing portal access for customers to manage their subscriptions
  * Usage reporting for metered services

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->