### PR TITLE
fix(api): harden stripe usage reporting auth

### DIFF
--- a/api/src/routes/stripe.js
+++ b/api/src/routes/stripe.js
@@ -57,12 +57,23 @@ function resolvePlanPriceId(plan) {
   return process.env[entry.env] || null;
 }
 
+/**
+ * Resolve the Stripe price ID environment variable for a given add-on key.
+ * @param {string} addOnKey - Add-on key such as "voice", "white_label", or "analytics_export".
+ * @returns {string|null} The Stripe price ID from environment for the add-on, or `null` if the add-on or its price ID is not configured.
+ */
 function resolveAddOnPriceId(addOnKey) {
   const entry = addOnCatalog[addOnKey];
   if (!entry) return null;
   return process.env[entry.env] || null;
 }
 
+/**
+ * Verify that a provided usage key matches a stored usage key using a timing-safe comparison.
+ * @param {string|Buffer|number} usageKey - The expected/stored usage key.
+ * @param {string|Buffer|number} providedKey - The usage key supplied by the caller to validate.
+ * @returns {boolean} `true` if both keys are present, have the same length, and match in a timing-safe manner; `false` otherwise.
+ */
 function hasValidUsageKey(usageKey, providedKey) {
   if (!usageKey || !providedKey) return false;
   const usageBuffer = Buffer.from(String(usageKey));
@@ -71,6 +82,13 @@ function hasValidUsageKey(usageKey, providedKey) {
   return crypto.timingSafeEqual(usageBuffer, providedBuffer);
 }
 
+/**
+ * Establishes an authenticated user on the request when possible.
+ *
+ * Checks for an existing authenticated user, a Bearer token validated against the configured JWT secret, or an x-user-id header fallback; when authentication succeeds, attaches a `user` object with a `sub` property to `req`.
+ * @param {import('express').Request} req - Express request object to inspect and mutate.
+ * @returns {boolean} `true` if authentication was established and `req.user` was set or already present, `false` otherwise.
+ */
 function ensureAuthenticated(req) {
   if (req.user?.sub) {
     return true;


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated access to the `/api/stripe/report-usage` endpoint when `STRIPE_USAGE_REPORT_KEY` is unset and remove a timing-vulnerable direct string comparison. 
- Ensure the route only proceeds when either a valid usage key is provided or the request is authenticated via existing JWT/x-user-id mechanisms.

### Description
- Added a constant-time comparison helper `hasValidUsageKey` that uses `crypto.timingSafeEqual` on `Buffer`s and enforces equal length before comparison. 
- Added `ensureAuthenticated` helper to accept an existing `req.user`, the dev `x-user-id` fallback, or a `Bearer` JWT verified against `process.env.JWT_SECRET` / `env.jwtSecret`. 
- Updated `/report-usage` to require either `hasValidUsageKey(STRIPE_USAGE_REPORT_KEY, providedKey)` or a successful `ensureAuthenticated(req)` before processing, returning `403` on failure. 
- Changes applied in `api/src/routes/stripe.js` and added `crypto`, `jsonwebtoken` and `env` imports used by the new helpers.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697427fc3bd08330967ffc650ef64395)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Usage reporting now accepts multiple authentication methods: timing-safe usage-key validation, Bearer JWT tokens, user-ID headers, or existing authenticated sessions.

* **Security**
  * Requests without a valid key or valid authentication are blocked with a 403 Forbidden response.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->