### PR TITLE
chore(web): clarify env example URLs and align auth/site vars

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -12,6 +12,7 @@ NODE_ENV=development
 # ============================================
 NEXT_PUBLIC_APP_NAME=Infæmous Freight
 NEXT_PUBLIC_ENV=development
+# Local development URL (set to production URL for deployments)
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 WEB_PORT=3000
 
@@ -19,15 +20,19 @@ WEB_PORT=3000
 # API Configuration
 # ============================================
 # Internal API URL (server-side)
+# Local API base (set to production API base for deployments)
 API_BASE_URL=http://localhost:4000/api
 
 # Public API URL (client-side/browser)
+# Local API base for browser usage (set to production API base for deployments)
 NEXT_PUBLIC_API_BASE=http://localhost:4000/api
+# Local API origin (set to production API origin for deployments)
 NEXT_PUBLIC_API_URL=http://localhost:4000
 
 # ============================================
 # Authentication
 # ============================================
+# Auth/redirect base URL (keep aligned with NEXT_PUBLIC_SITE_URL/NEXT_PUBLIC_APP_URL in development)
 NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=replace_with_long_random_value_minimum_32_characters
 JWT_SECRET=replace_with_long_random_value_minimum_32_characters
@@ -97,6 +102,7 @@ GOOGLE_CLIENT_SECRET=
 NEXT_PUBLIC_META_TITLE=Infamous Freight Enterprises | Global Logistics
 NEXT_PUBLIC_META_DESCRIPTION=Enterprise freight management platform serving 120+ countries
 NEXT_PUBLIC_OG_IMAGE=https://infamousfreight.com/og-image.png
+# Site base URL (set to production URL for deployments)
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
 
 # ============================================


### PR DESCRIPTION
### Motivation
- Clarify ambiguous mix of production URLs and development flags in `web/.env.example` to avoid confusion during local development.
- Ensure auth/redirect environment variables (`NEXTAUTH_URL`, `NEXT_PUBLIC_SITE_URL`, `NEXT_PUBLIC_APP_URL`) point to the same localhost value for development so developers have a single source of truth for endpoints.

### Description
- Updated `web/.env.example` to add explanatory comments and label local vs production usage for `NEXT_PUBLIC_APP_URL`, `API_BASE_URL`, `NEXT_PUBLIC_API_BASE`, and `NEXT_PUBLIC_API_URL`.
- Added a comment above `NEXTAUTH_URL` advising it be kept aligned with `NEXT_PUBLIC_SITE_URL`/`NEXT_PUBLIC_APP_URL` in development.
- Added a comment for `NEXT_PUBLIC_SITE_URL` indicating it should be set to the production URL for deployments.
- This change only modifies the documentation/example env file: `web/.env.example`.

### Testing
- No runtime or unit tests were executed because this is a documentation-only change.
- Local commit validation initially failed due to conventional commit formatting and then passed after using `git commit -m "chore(web): clarify env example urls"`.
- No other automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974a24b7cd48330be4756cc8f5e5d72)