### PR TITLE
ci: upgrade actions/upload-artifact to v4 in workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -121,7 +121,7 @@ jobs:
           pnpm outdated --depth=0 | tee outdated-output.txt || true
 
       - name: 📤 Upload audit results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: dependency-audit
@@ -157,7 +157,7 @@ jobs:
           output-file: sbom-cyclonedx.json
 
       - name: 📤 Upload SBOM
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sbom
           path: sbom-cyclonedx.json
@@ -325,7 +325,7 @@ jobs:
           path: security-artifacts
 
       - name: 📤 Upload final artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: codeql-complete-report

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -109,7 +109,7 @@ jobs:
       
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: playwright-report-${{ matrix.browser }}
           path: e2e/playwright-report/
@@ -117,7 +117,7 @@ jobs:
       
       - name: Upload test videos
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: playwright-videos-${{ matrix.browser }}
           path: e2e/test-results/
@@ -238,7 +238,7 @@ jobs:
           pnpm build
       
       - name: Upload bundle stats
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bundle-stats
           path: web/.next/analyze/

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -70,7 +70,7 @@ jobs:
         run: pnpm --filter ${{ inputs.package-name }} ${{ inputs.build-command }}
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.artifact-name }}
           path: ${{ inputs.working-directory }}/${{ inputs.artifact-path }}


### PR DESCRIPTION
### Motivation
- Replace deprecated `actions/upload-artifact@v3` usages with the supported `actions/upload-artifact@v4` to remove deprecation warnings and keep CI workflows up to date.

### Description
- Updated `actions/upload-artifact@v3` → `actions/upload-artifact@v4` in `.github/workflows/codeql.yml`, `.github/workflows/reusable-build.yml`, and `.github/workflows/e2e-tests.yml`.

### Testing
- No automated tests were executed because this is a workflow configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974a66a6608833087db3ce974259dd9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow automation tools to their latest versions for improved reliability and performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->