### PR TITLE
fix(config): remove unsupported `cache` property from vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -7,11 +7,6 @@
   "outputDirectory": "web/.next",
   "ignoreCommand": "git diff HEAD^ HEAD --quiet . ':(exclude)api/**' ':(exclude)packages/**' ':(exclude)archive/**' ':(exclude)mobile/**'",
   "crons": [],
-  "cache": [
-    "web/.next/cache/**",
-    "node_modules/.cache/**",
-    ".pnpm-store/**"
-  ],
   "github": {
     "silent": false,
     "enabled": true,


### PR DESCRIPTION
### Motivation
- Vercel schema validation failed because the top-level `cache` property is not supported, so the configuration must be adjusted to satisfy the schema.

### Description
- Removed the unsupported `cache` array from `vercel.json` and left the rest of the configuration unchanged, committed with message `fix(config): remove unsupported vercel cache`.

### Testing
- No automated tests were run for this configuration-only change; the edit is intended to resolve the Vercel schema validation error reported by the platform.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974cce9c1b48330ba5c4da79d89c2ff)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment cache configuration to optimize infrastructure settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->