### PR TITLE
chore: add typed Vercel config specifying Bun runtime

### DIFF
--- a/vercel.config.ts
+++ b/vercel.config.ts
@@ -1,5 +1,7 @@
 import type { VercelConfig } from '@vercel/config/v1';
 
-export const config: VercelConfig = {
+const config: VercelConfig = {
   bunVersion: '1.x',
 };
+
+export default config;


### PR DESCRIPTION
### Motivation
- Provide an explicit Vercel configuration that pins the Bun runtime to the intended major version for consistent deployments.

### Description
- Add `vercel.config.ts` at the repository root. 
- Export a typed `VercelConfig` object imported from `@vercel/config/v1`. 
- Set `bunVersion` to `'1.x'` to signal Vercel to use the Bun 1.x runtime.

### Testing
- No automated tests were executed for this change. 
- CI will run on push to validate configuration during the normal pipeline.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69752f9cb2608330847148d97a418880)