### PR TITLE
chore: set Vercel framework to nextjs

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "framework": null,
+  "framework": "nextjs",
   "buildCommand": "cd web && bash scripts/validate-build.sh && cd .. && pnpm --filter web build",
   "devCommand": "pnpm --filter web dev",
   "installCommand": "pnpm install",


### PR DESCRIPTION
### Motivation
- Enable Vercel to detect the Next.js framework automatically so platform-specific builds and optimizations apply correctly.

### Description
- Update `vercel.json` to set `framework` from `null` to `"nextjs"` (file: `vercel.json`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697530008c608330aea7a63cf4a5404f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration settings to ensure optimal platform compatibility and build consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->