### PR TITLE
chore(vercel): simplify ignoreCommand to basic git diff

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
   "devCommand": "pnpm --filter web dev",
   "installCommand": "pnpm install",
   "outputDirectory": "web/.next",
-  "ignoreCommand": "git diff HEAD^ HEAD --quiet . ':(exclude)api/**' ':(exclude)packages/**' ':(exclude)archive/**' ':(exclude)mobile/**'",
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD ./",
   "crons": [],
   "github": {
     "silent": false,


### PR DESCRIPTION
### Motivation
- Simplify and harden the Vercel build guard because the previous `ignoreCommand` with path exclusions was brittle in some environments (e.g. shallow clones).

### Description
- Updated `vercel.json` to replace the complex exclusion-based command with a simpler check: `"ignoreCommand": "git diff --quiet HEAD^ HEAD ./"`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697530616d8c8330b3d29da3652b5645)