### PR TITLE
docs: add metered price creation steps

### DIFF
--- a/docs/final-recommendations-stripe-ai-monetization.md
+++ b/docs/final-recommendations-stripe-ai-monetization.md
@@ -50,6 +50,54 @@ This must have:
 - Interval: Monthly
 - Lookup key: `iff_ai_action_metered`
 
+#### Create the Metered Price (Dashboard or API)
+
+**Option A — Stripe Dashboard (fastest):**
+
+1. Stripe Dashboard → Products
+2. Open **Infamous AI Actions (metered)**
+3. Add price
+4. Type: **Recurring**
+5. Interval: **Monthly**
+6. Usage: **Metered (usage-based)**
+7. Aggregation: **Sum**
+8. Save → copy the new `price_...` ID
+
+**Option B — Node API (one-time admin script):**
+
+```js
+import Stripe from "stripe";
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
+  apiVersion: "2025-01-27.acacia",
+});
+
+async function createMeteredPrice() {
+  const productId = "prod_TqlbsmBT9Jw2Z0"; // Infamous AI Actions (metered)
+
+  const price = await stripe.prices.create({
+    product: productId,
+    currency: "usd",
+    unit_amount: 1, // $0.01 per action
+    recurring: {
+      interval: "month",
+      usage_type: "metered",
+      aggregate_usage: "sum",
+    },
+    nickname: "AI Actions - Metered (per action)",
+    lookup_key: "iff_ai_action_metered",
+    metadata: {
+      billing_unit: "ai_action",
+    },
+  });
+
+  console.log("Created metered price:", price.id);
+  return price.id;
+}
+
+createMeteredPrice().catch(console.error);
+```
+
 ### B) Event-Based AI SKUs (Enterprise Invoicing)
 
 You already built these correctly:


### PR DESCRIPTION
### Motivation
- Document the exact production-grade steps to create the Stripe metered recurring Price for the "Infamous AI Actions (metered)" product so teams can finish metered billing configuration via the Dashboard or a one-time Node.js admin script.

### Description
- Add instructions to `docs/final-recommendations-stripe-ai-monetization.md` providing (A) Stripe Dashboard steps and (B) a Node.js example that uses the Stripe SDK with `apiVersion`, `productId`, `recurring` set to `usage_type: "metered"` and `aggregate_usage: "sum"`, a sample `unit_amount`, and the `lookup_key: "iff_ai_action_metered"`.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975617133908330bf2548c12fbfd72f)