### PR TITLE
docs: add Stripe product and product ID entries for subscription tiers

### DIFF
--- a/STRIPE_100_PERCENT_SETUP.md
+++ b/STRIPE_100_PERCENT_SETUP.md
@@ -76,6 +76,36 @@ BILLING_CURRENCY=usd
 - Price: $49
 - Billing: One-time
 
+#### Production Stripe Products & Payment Links
+
+**Starter**
+- Product: Starter Platform Access
+- Product ID: `prod_...`
+- Price: $29/month
+- Price ID: `price_...`
+- Payment Link: `https://buy.stripe.com/...`
+
+**Pro**
+- Product: Professional Platform Access
+- Product ID: `prod_...`
+- Price: $49/user/month
+- Price ID: `price_...`
+- Payment Link: `https://buy.stripe.com/...`
+
+**Business**
+- Product: Business Platform Access
+- Product ID: `prod_...`
+- Price: $99/user/month
+- Price ID: `price_...`
+- Payment Link: `https://buy.stripe.com/...`
+
+**Enterprise Minimum Monthly Spend**
+- Product: Enterprise Minimum Monthly Spend
+- Product ID: `prod_...`
+- Price: $2,500/month minimum
+- Price ID: `price_...`
+- Payment Link: `https://buy.stripe.com/...`
+
 ---
 
 ## 📡 API Endpoints (100% Revenue Model)


### PR DESCRIPTION
### Motivation
- Ensure the Stripe setup documentation lists `Product` and `Product ID` for all paid tiers so Pro, Business, and Enterprise match the Starter format and make it easier to configure Stripe in production.

### Description
- Added a `Production Stripe Products & Payment Links` section to `STRIPE_100_PERCENT_SETUP.md` and added entries for `Starter`, `Pro`, `Business`, and `Enterprise Minimum Monthly Spend` that include `Product`, `Product ID`, `Price`, `Price ID`, and `Payment Link` placeholders.

### Testing
- Documentation-only change; no automated tests were run (no runtime code modified).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975644619cc8330abb45d6061029b80)