### PR TITLE
fix(docker): install pnpm without corepack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ LABEL description="Infamous Freight Enterprises - Full-stack application"
 
 WORKDIR /app
 
-# Enable pnpm via Corepack
-RUN corepack enable
+# Install pnpm (Corepack is unavailable in node:25-alpine)
+RUN npm install -g pnpm@9.15.0
 
 # Copy workspace and package files
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
@@ -19,7 +19,7 @@ RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store pnpm install
 
 FROM node:25-alpine AS build
 WORKDIR /app
-RUN corepack enable
+RUN npm install -g pnpm@9.15.0
 
 COPY . .
 COPY --from=deps /app/node_modules ./node_modules
@@ -34,7 +34,7 @@ FROM node:25-alpine AS run
 WORKDIR /app
 ENV NODE_ENV=production
 ENV PORT=3000
-RUN corepack enable
+RUN npm install -g pnpm@9.15.0
 
 # Copy only runtime essentials instead of the entire /app directory
 # Root workspace metadata for pnpm


### PR DESCRIPTION
### Motivation
- The alpine Node 25 base image does not include Corepack, causing `corepack: not found` errors during image builds, so pnpm must be provisioned explicitly.

### Description
- Replace `corepack enable` with `npm install -g pnpm@9.15.0` in the `deps`, `build`, and `run` stages of the `Dockerfile` to ensure pnpm is available in all build phases.
- Keep existing `pnpm` commands and cache mount usage (e.g. `pnpm install --frozen-lockfile`) so the build flow is unchanged other than pnpm provisioning.
- Only `Dockerfile` was modified and `pnpm-lock.yaml` was restored to its original state during the rollout.

### Testing
- No image build was executed locally, so `docker build` was not run and container build validation was not performed.
- Commit message linting/validation passed during the change (`Commit message format is valid`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697576d58b308330b69ada52af4e065e)