### PR TITLE
chore(docker): align pnpm to 9.15.0 and avoid Corepack on node:25-alpine

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -6,7 +6,7 @@ LABEL description="Infamous Freight Enterprises - API Server"
 WORKDIR /app
 
 # Install pnpm
-RUN npm install -g pnpm@8.15.9
+RUN npm install -g pnpm@9.15.0
 
 # Copy workspace and package files
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./

--- a/Dockerfile.fly
+++ b/Dockerfile.fly
@@ -13,9 +13,8 @@ RUN apk update && \
         ca-certificates && \
     rm -rf /var/cache/apk/*
 
-# Enable pnpm with specific version
-RUN corepack enable && corepack prepare pnpm@8.15.9 --activate
-ENV PNPM_HOME=/usr/local/bin
+# Install pnpm with specific version (Corepack unavailable in node:25-alpine)
+RUN npm install -g pnpm@9.15.0
 
 # Stage 1: Install dependencies
 FROM base AS deps
@@ -76,10 +75,8 @@ RUN apk update && \
         tini && \
     rm -rf /var/cache/apk/*
 
-# Enable pnpm
-RUN corepack enable && corepack prepare pnpm@8.15.9 --activate
-
-ENV PNPM_HOME=/usr/local/bin
+# Install pnpm (Corepack unavailable in node:25-alpine)
+RUN npm install -g pnpm@9.15.0
 ENV NODE_ENV=production
 ENV PORT=4000
 

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -9,9 +9,8 @@ RUN apk update && \
     apk add --no-cache dumb-init ca-certificates && \
     rm -rf /var/cache/apk/*
 
-# Enable pnpm
-RUN corepack enable && corepack prepare pnpm@8.15.9 --activate
-ENV PNPM_HOME=/usr/local/bin
+# Install pnpm (Corepack unavailable in node:25-alpine)
+RUN npm install -g pnpm@9.15.0
 
 # Stage 1: Install dependencies
 FROM base AS deps

--- a/src/apps/api/Dockerfile
+++ b/src/apps/api/Dockerfile
@@ -13,7 +13,7 @@ RUN apk update && \
     rm -rf /var/cache/apk/*
 
 # Enable pnpm with specific version
-RUN corepack enable && corepack prepare pnpm@8.15.9 --activate
+RUN corepack enable && corepack prepare pnpm@9.15.0 --activate
 ENV PNPM_HOME=/usr/local/bin
 
 # Stage 1: Install dependencies
@@ -85,7 +85,7 @@ RUN apk update && \
     rm -rf /var/cache/apk/*
 
 # Enable pnpm
-RUN corepack enable && corepack prepare pnpm@8.15.9 --activate
+RUN corepack enable && corepack prepare pnpm@9.15.0 --activate
 
 ENV PNPM_HOME=/usr/local/bin
 ENV NODE_ENV=production


### PR DESCRIPTION
### Motivation
- Standardize the pnpm toolchain to `9.15.0` to match the root `package.json` `packageManager` and `engines` settings.
- Remove the inconsistent `corepack` usage in `node:25-alpine` Dockerfiles because the previous change claimed Corepack is unavailable there and images were using different pnpm versions.
- No skills were used for these edits.

### Description
- Replaced `corepack enable && corepack prepare pnpm@8.15.9` with `npm install -g pnpm@9.15.0` in `Dockerfile.fly` to avoid Corepack on `node:25-alpine` and align the pnpm version.
- Replaced the same Corepack invocation with `npm install -g pnpm@9.15.0` in `Dockerfile.web` to align the pnpm version for web builds on `node:25-alpine`.
- Updated `Dockerfile.api` to install `pnpm@9.15.0` (was `8.15.9`).
- Updated `src/apps/api/Dockerfile` to prepare `pnpm@9.15.0` via Corepack (this file uses `node:20-alpine` so it continues to use Corepack) and updated the Corepack pnpm version there.
- Files modified: `Dockerfile.fly`, `Dockerfile.web`, `Dockerfile.api`, `src/apps/api/Dockerfile`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697588267b1083309d7d6e0a45c76b97)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package manager version to 9.15.0 across multiple build environments
  * Simplified package manager installation setup by replacing legacy configuration commands with streamlined installation methods

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->