### PR TITLE
fix(docker): copy workspace node_modules for build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,9 @@ RUN npm install -g pnpm@9.15.0
 
 COPY . .
 COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/packages/shared/node_modules ./packages/shared/node_modules
+COPY --from=deps /app/api/node_modules ./api/node_modules
+COPY --from=deps /app/web/node_modules ./web/node_modules
 
 # Build the application (shared, generate Prisma client, api, then web)
 RUN pnpm --filter @infamous-freight/shared build \


### PR DESCRIPTION
### Motivation
- The build failed because workspace-installed binaries like `tsc` were not present in the `build` stage, causing `pnpm --filter @infamous-freight/shared build` to error with `sh: tsc: not found`.

### Description
- Update `Dockerfile` to copy per-package `node_modules` from the `deps` stage into the `build` stage by adding `COPY --from=deps /app/packages/shared/node_modules ./packages/shared/node_modules`, `COPY --from=deps /app/api/node_modules ./api/node_modules`, and `COPY --from=deps /app/web/node_modules ./web/node_modules` so workspace binaries and dev deps are available during the build.

### Testing
- No automated tests were run for this change; the modification is limited to `Dockerfile` and intended to unblock the Docker build process.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975894118e88330b9c0bc279e586a6c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build process to include prebuilt dependencies for improved build efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->