### PR TITLE
chore(build): add root Next.js dependency for Vercel detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "eslint-plugin-node": "^11.1.0",
     "husky": "^8.0.3",
     "lint-staged": "^15.0.0",
+    "next": "^16.1.4",
     "prettier": "^3.0.0"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       lint-staged:
         specifier: ^15.0.0
         version: 15.5.2
+      next:
+        specifier: ^16.1.4
+        version: 16.1.4(@opentelemetry/api@1.9.0)(@playwright/test@1.58.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       prettier:
         specifier: ^3.0.0
         version: 3.8.1


### PR DESCRIPTION
### Motivation
- Vercel failed to detect the Next.js framework during builds because `next` was only declared in the `web` workspace, so adding it to the root ensures framework detection works. 

### Description
- Add `next`@`^16.1.4` to the root `devDependencies` in `package.json`. 
- Refresh the workspace lockfile so the root dependency is recorded in `pnpm-lock.yaml`. 
- Run `pnpm install --lockfile-only` to update the lockfile and commit the changes with the message `chore(build): add root next dependency`.

### Testing
- Ran `pnpm install --lockfile-only` to regenerate the lockfile and it completed successfully with only peer dependency warnings. 
- No automated test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975b78c53a083309600b584675e1419)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies to support latest tooling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->