### PR TITLE
ci(vercel): limit install to web workspace

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
   "framework": "nextjs",
   "buildCommand": "cd web && bash scripts/validate-build.sh && cd .. && pnpm --filter web build",
   "devCommand": "pnpm --filter web dev",
-  "installCommand": "pnpm install --frozen-lockfile",
+  "installCommand": "pnpm install --frozen-lockfile --filter web...",
   "outputDirectory": "web/.next",
   "ignoreCommand": "git diff --quiet HEAD^ HEAD ./",
   "crons": [],


### PR DESCRIPTION
### Motivation
- Reduce the install surface during Vercel deployments to avoid installing the entire monorepo (notably the API with Prisma) and to speed up and prevent Prisma-related installation failures.

### Description
- Modify `vercel.json` so the `installCommand` is `pnpm install --frozen-lockfile --filter web...`, updating only `vercel.json` to install the `web` workspace and its dependencies.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975bd91d4cc8330ab82a08795384b37)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build configuration for deployment optimization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->