### PR TITLE
ci: pin flyctl action version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,7 +67,7 @@ jobs:
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
 
       - name: Deploy to Fly.io
-        uses: superfly/flyctl-actions/setup-flyctl@master
+        uses: superfly/flyctl-actions/setup-flyctl@v1.5.0
 
       - name: Deploy API
         run: flyctl deploy --remote-only


### PR DESCRIPTION
### Motivation
- Pin the Fly.io setup action to a fixed release tag to ensure reproducible, supply-chain-safe CI runs rather than using the mutable `@master` reference.

### Description
- Update ` .github/workflows/deploy.yml` to replace `superfly/flyctl-actions/setup-flyctl@master` with `superfly/flyctl-actions/setup-flyctl@v1.5.0`.

### Testing
- No automated tests were run because this is a workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975c94424248330bdae2b2067c8fde6)