### PR TITLE
fix(api): add Prisma datasource URL

### DIFF
--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -7,6 +7,7 @@ generator client {
 
 datasource db {
   provider = "postgresql"
+  url      = env("DATABASE_URL")
 }
 
 enum UserRole {


### PR DESCRIPTION
### Motivation
- Prisma schema was missing a configured datasource URL, which can cause schema validation failures and prevent CLI commands like `prisma migrate` and `prisma generate` from connecting to the database, so the schema should read the `DATABASE_URL` environment variable.

### Description
- Added `url = env("DATABASE_URL")` to the `datasource db` block in `api/prisma/schema.prisma`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975dfb4760c8330ae833c360b3feaf4)