### PR TITLE
fix(docker): use Node 24 base and run Prisma generate with explicit schema

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
-FROM node:25-alpine AS deps
+ARG NODE_VERSION=24-alpine
+FROM node:${NODE_VERSION} AS deps
 
 LABEL maintainer="Santorio Djuan Miles <237955567+MrMiless44@users.noreply.github.com>"
 LABEL description="Infamous Freight Enterprises - Full-stack application"
 
 WORKDIR /app
 
-# Install pnpm (Corepack is unavailable in node:25-alpine)
+# Install pnpm (Corepack is unavailable in node:alpine)
 RUN npm install -g pnpm@9.15.0
 
 # Copy workspace and package files
@@ -17,7 +18,7 @@ COPY web/package.json ./web/
 # Install ALL dependencies (including dev dependencies needed for build)
 RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store pnpm install --frozen-lockfile
 
-FROM node:25-alpine AS build
+FROM node:${NODE_VERSION} AS build
 WORKDIR /app
 RUN npm install -g pnpm@9.15.0
 
@@ -29,11 +30,11 @@ COPY --from=deps /app/web/node_modules ./web/node_modules
 
 # Build the application (shared, generate Prisma client, api, then web)
 RUN pnpm --filter @infamous-freight/shared build \
-  && cd api && pnpm prisma:generate \
+  && pnpm --filter api exec prisma generate --schema=./api/prisma/schema.prisma \
   && pnpm --filter api build \
   && pnpm --filter web build
 
-FROM node:25-alpine AS run
+FROM node:${NODE_VERSION} AS run
 WORKDIR /app
 ENV NODE_ENV=production
 ENV PORT=3000


### PR DESCRIPTION
### Motivation
- Fly build failed during `prisma generate` with a Prisma schema validation error and Prisma recommends supported Node versions (20.19+, 22.12+, 24.0+) while the image used Node 25.0.
- The build selected a schema that contained a `url = env("DATABASE_URL")` entry and caused Prisma CLI v7 validation to fail, so the build must target the correct schema file.

### Description
- Add `ARG NODE_VERSION=24-alpine` and switch all stages to `node:${NODE_VERSION}` so the image uses Node 24 Alpine across `deps`, `build`, and `run` stages.
- Adjust pnpm/prisma invocation to run `pnpm --filter api exec prisma generate --schema=./api/prisma/schema.prisma` to explicitly target the intended Prisma schema during the build.
- Small comment edit clarifying Corepack is unavailable on the Alpine base used.

### Testing
- No automated tests or image builds were run as part of this change (only the Dockerfile was updated and committed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975e00bdfc08330937edb990f6b251a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker image with production-only dependencies for leaner deployment packages
  * Added health checks to monitor application status in containerized environments
  * Enhanced Docker build configuration for greater flexibility across deployment scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->