### PR TITLE
fix(deps): remove missing 'automated' label from Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,6 @@ updates:
       - "MrMiless44"
     labels:
       - "dependencies"
-      - "automated"
     versioning-strategy: increase
     commit-message:
       prefix: "chore(deps)"


### PR DESCRIPTION
### Motivation
- Fix Dependabot failures caused by an invalid label reference so automated dependency PRs can be created without errors.

### Description
- Remove the nonexistent `automated` label from the root npm update block in `.github/dependabot.yml` while leaving other update entries intact.

### Testing
- No automated tests were run because this is a config-only change; syntax and structure were reviewed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697735fa37d483309b59a0477a399f8b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->