### PR TITLE
docs(deploy): fix docs-only ignore checks

### DIFF
--- a/deploy/vercel-project-settings.md
+++ b/deploy/vercel-project-settings.md
@@ -59,7 +59,7 @@ if echo "$CHANGED" | grep -E '^(web/|api/|packages/|package\.json|pnpm-lock\.yam
   exit 1
 fi
 
-if echo "$CHANGED" | grep -E '^(docs/|mobile/|README\.md|\.github/|\.vscode/)' -q; then
+if ! echo "$CHANGED" | grep -q -v -E '^(docs/|mobile/|README\.md|\.github/|\.vscode/)'; then
   exit 0
 fi
 
@@ -82,7 +82,7 @@ if echo "$CHANGED" | grep -E '^(pages/|app/|src/|public/|components/|lib/|next\.
   exit 1
 fi
 
-if echo "$CHANGED" | grep -E '^(docs/|README\.md)' -q; then
+if ! echo "$CHANGED" | grep -q -v -E '^(docs/|README\.md)'; then
   exit 0
 fi
 


### PR DESCRIPTION
### Motivation
- The existing docs-only check returned true when any docs path was present, which incorrectly skipped builds for mixed commits containing both docs and code changes. 
- The goal is to skip the Vercel ignored-build step only when there are no non-doc files changed, while preserving the existing `CHANGED` variable and skip behavior text.

### Description
- Updated the examples in `deploy/vercel-project-settings.md` for both the monorepo and single-app ignore scripts to detect the absence of non-doc changes. 
- Replaced the positive docs-match `grep -E` checks with an inverted test using `if ! echo "$CHANGED" | grep -q -v -E '(...patterns...)'; then exit 0; fi` so the build is skipped only when no non-doc paths are found.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69773f95bf84833082e407593923599e)