### PR TITLE
docs(deploy): treat initial Vercel deploy as changed and fix docs-only skip logic

### DIFF
--- a/deploy/vercel-project-settings.md
+++ b/deploy/vercel-project-settings.md
@@ -49,17 +49,21 @@ set -e
 # exit 0 => ignore build
 # exit 1 => do NOT ignore (build)
 
-if [ -z "$VERCEL_GIT_PREVIOUS_SHA" ] || [ -z "$VERCEL_GIT_COMMIT_SHA" ]; then
+if [ -z "$VERCEL_GIT_COMMIT_SHA" ]; then
   exit 1
 fi
 
-CHANGED=$(git diff --name-only "$VERCEL_GIT_PREVIOUS_SHA" "$VERCEL_GIT_COMMIT_SHA" || true)
+if [ -z "$VERCEL_GIT_PREVIOUS_SHA" ]; then
+  CHANGED="__initial_deploy__"
+else
+  CHANGED=$(git diff --name-only "$VERCEL_GIT_PREVIOUS_SHA" "$VERCEL_GIT_COMMIT_SHA" || true)
+fi
 
 if echo "$CHANGED" | grep -E '^(web/|api/|packages/|package\.json|pnpm-lock\.yaml|turbo\.json|tsconfig\.json|next\.config\.)' -q; then
   exit 1
 fi
 
-if echo "$CHANGED" | grep -E '^(docs/|mobile/|README\.md|\.github/|\.vscode/)' -q; then
+if ! echo "$CHANGED" | grep -q -v -E '^(docs/|mobile/|README\.md|\.github/|\.vscode/)'; then
   exit 0
 fi
 
@@ -72,17 +76,21 @@ exit 1
 #!/bin/bash
 set -e
 
-if [ -z "$VERCEL_GIT_PREVIOUS_SHA" ] || [ -z "$VERCEL_GIT_COMMIT_SHA" ]; then
+if [ -z "$VERCEL_GIT_COMMIT_SHA" ]; then
   exit 1
 fi
 
-CHANGED=$(git diff --name-only "$VERCEL_GIT_PREVIOUS_SHA" "$VERCEL_GIT_COMMIT_SHA" || true)
+if [ -z "$VERCEL_GIT_PREVIOUS_SHA" ]; then
+  CHANGED="__initial_deploy__"
+else
+  CHANGED=$(git diff --name-only "$VERCEL_GIT_PREVIOUS_SHA" "$VERCEL_GIT_COMMIT_SHA" || true)
+fi
 
 if echo "$CHANGED" | grep -E '^(pages/|app/|src/|public/|components/|lib/|next\.config\.|package\.json|pnpm-lock\.yaml|tsconfig\.json)' -q; then
   exit 1
 fi
 
-if echo "$CHANGED" | grep -E '^(docs/|README\.md)' -q; then
+if ! echo "$CHANGED" | grep -q -v -E '^(docs/|README\.md)'; then
   exit 0
 fi
 


### PR DESCRIPTION
### Motivation
- The existing Vercel ignored-build scripts used `VERCEL_GIT_PREVIOUS_SHA` directly and could produce an empty `CHANGED` on first deploy, causing the deploy to be incorrectly skipped. 
- The docs-only skip check returned true if any docs file was changed, which caused mixed doc + non-doc commits to be skipped incorrectly.

### Description
- Require `VERCEL_GIT_COMMIT_SHA` to be present and exit early if it is missing by checking `if [ -z "$VERCEL_GIT_COMMIT_SHA" ]`.
- When `VERCEL_GIT_PREVIOUS_SHA` is empty set `CHANGED="__initial_deploy__"`, otherwise set `CHANGED` using `git diff --name-only "$VERCEL_GIT_PREVIOUS_SHA" "$VERCEL_GIT_COMMIT_SHA"`.
- Replace the docs-only skip condition with an inverted non-doc check using `if ! echo "$CHANGED" | grep -q -v -E '^(docs/|mobile/|README\.md|\.github/|\.vscode/)'` (and the root variant `^(docs/|README\.md)`), so the build is skipped only when there are no non-doc changes.
- Applied these updates to both the monorepo and single-app example ignore scripts in `deploy/vercel-project-settings.md`.

### Testing
- No automated tests were executed for this change because it only updates documentation and example scripts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977462657388330a77603688e0db1e0)