### PR TITLE
feat(api): bounded in-memory audit buffer with metadata sanitization

### DIFF
--- a/src/apps/api/src/compliance/audit/logger.ts
+++ b/src/apps/api/src/compliance/audit/logger.ts
@@ -128,8 +128,9 @@ export function recordAuditLog(entry: AuditLogInput): AuditLogEntry {
 
   logs.push(storedEntry);
 
-  while (logs.length > MAX_AUDIT_LOGS) {
-    logs.shift();
+  if (logs.length > MAX_AUDIT_LOGS) {
+    const overflow = logs.length - MAX_AUDIT_LOGS;
+    logs.splice(0, overflow);
   }
 
   // Return a cloned entry so callers cannot mutate internal log state


### PR DESCRIPTION
### Motivation
- Prevent unbounded memory growth by bounding the in-memory audit buffer and trimming oldest entries when capacity is exceeded.
- Reduce risk of accidentally persisting PII or very large metadata by sanitizing and bounding metadata fields before storage.
- Provide a simple, local API to record and read recent audit events for lightweight compliance/debugging use.

### Description
- Added `src/apps/api/src/compliance/audit/logger.ts` which exports `recordAuditLog` and `getAuditLogs` along with `AuditLogEntry`/`AuditLogInput` types.
- Introduced an env-configurable `MAX_AUDIT_LOGS` and implemented the retention policy that pushes a new entry and then trims old entries while `logs.length > MAX_AUDIT_LOGS`.
- Implemented `sanitizeMetadata` using an allowlist (`ALLOWED_METADATA_KEYS`), a PII key set (`PII_KEYS`) that are redacted, truncation for long strings/objects (`MAX_STRING_LENGTH`, `MAX_OBJECT_LENGTH`), and type enforcement for stored metadata.
- Ensured `createdAt` is preserved and the sanitized metadata is persisted on the `AuditLogEntry` pushed to the buffer.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69774935c3648330b26ac3ea6bdb9bf7)