### PR TITLE
fix(compliance): add updatedAt to Dispute Prisma model

### DIFF
--- a/@compliance/schemas/compliance.prisma
+++ b/@compliance/schemas/compliance.prisma
@@ -1,0 +1,5 @@
+model Dispute {
+  id        String   @id @default(cuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}


### PR DESCRIPTION
### Motivation
- Ensure Prisma persists update timestamps for `Dispute` records because `updateDispute` writes `updatedAt` but the model previously lacked that field.

### Description
- Add a new Prisma schema file at `@compliance/schemas/compliance.prisma` that defines `model Dispute` with `id String @id @default(cuid())`, `createdAt DateTime @default(now())`, and `updatedAt DateTime @updatedAt` so Prisma will update the timestamp on record changes.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69774949c8448330a3dcd8b12a49dc0d)