### PR TITLE
ci: add compliance policy presence check

### DIFF
--- a/.github/workflows/compliance-check.yml
+++ b/.github/workflows/compliance-check.yml
@@ -1,0 +1,49 @@
+name: Compliance Check
+
+on:
+  pull_request:
+    paths:
+      - 'compliance/policies/**'
+      - '.github/workflows/compliance-check.yml'
+  push:
+    branches: [main, develop]
+    paths:
+      - 'compliance/policies/**'
+      - '.github/workflows/compliance-check.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-compliance-policies:
+    name: Validate Compliance Policies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Validate Compliance Policies
+        run: |
+          required_policies=(
+            "dispute-policy.md"
+            "enforcement-policy.md"
+            "fraud-policy.md"
+            "payment-policy.md"
+            "refunds-policy.md"
+          )
+
+          missing_policies=()
+          for policy in "${required_policies[@]}"; do
+            if [[ ! -f "compliance/policies/${policy}" ]]; then
+              missing_policies+=("${policy}")
+            fi
+          done
+
+          if (( ${#missing_policies[@]} )); then
+            echo "❌ Validate Compliance Policies: missing required policy files:"
+            printf ' - %s\n' "${missing_policies[@]}"
+            exit 1
+          fi
+
+          echo "✅ Validate Compliance Policies: all required policy files are present."


### PR DESCRIPTION
### Motivation
- Ensure the repository CI fails if required compliance policy files are missing from `compliance/policies`, replacing the previous ineffective `ls`-style check in the `Validate Compliance Policies` job.

### Description
- Add a new workflow file at `.github/workflows/compliance-check.yml` triggered on `push`, `pull_request`, and `workflow_dispatch` for changes to `compliance/policies/**` and the workflow file itself.
- Implement a `validate-compliance-policies` job that declares a `required_policies` list and checks each entry with a file-exists test `[[ -f "compliance/policies/${policy}" ]]`, collecting any missing names.
- When any required file is absent the step prints a clear error listing the missing policy filenames and exits with a non-zero status, and prints a success message when all policies are present.

### Testing
- No automated tests were run for this change because it is a workflow-only update; the validation will run as part of CI when the workflow is triggered.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69774c6d39588330b6b87ee61c1eb8b1)