### PR TITLE
fix(compliance): validate dispute creation inputs and use shared DISPUTE_STATUS

### DIFF
--- a/compliance/api/disputes.ts
+++ b/compliance/api/disputes.ts
@@ -1,4 +1,9 @@
-export type DisputeStatus = "open" | "under_review" | "resolved" | "rejected";
+import { PrismaClient } from "@prisma/client";
+import type { Request, Response } from "express";
+import { DISPUTE_STATUS } from "@infamous-freight/shared";
+
+export type DisputeStatus =
+  (typeof DISPUTE_STATUS)[keyof typeof DISPUTE_STATUS];
 
 export interface DisputeRecord {
   id: string;
@@ -22,20 +27,80 @@ export interface UpdateDisputeInput {
 
 const disputes = new Map<string, DisputeRecord>();
 
-export function createDispute(id: string, input: CreateDisputeInput): DisputeRecord {
-  const now = new Date().toISOString();
-  const record: DisputeRecord = {
-    id,
-    userId: input.userId,
-    transactionId: input.transactionId,
-    processor: input.processor,
-    status: "open",
-    createdAt: now,
-    updatedAt: now,
-  };
+const prisma = new PrismaClient();
+const ALLOWED_PROCESSORS = ["stripe", "paypal", "other"] as const;
 
-  disputes.set(id, record);
-  return record;
+type AllowedProcessor = (typeof ALLOWED_PROCESSORS)[number];
+
+function sanitizeString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function isValidId(value: string): boolean {
+  return /^[A-Za-z0-9_-]{3,}$/.test(value);
+}
+
+function parseProcessor(value: unknown): AllowedProcessor | null {
+  const sanitized = sanitizeString(value);
+  if (!sanitized) {
+    return null;
+  }
+
+  const normalized = sanitized.toLowerCase() as AllowedProcessor;
+  return ALLOWED_PROCESSORS.includes(normalized) ? normalized : null;
+}
+
+export async function createDispute(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const userId = sanitizeString(req.body?.userId);
+  const transactionId = sanitizeString(req.body?.transactionId);
+  const processor = parseProcessor(req.body?.processor);
+
+  const errors: string[] = [];
+
+  if (!userId || !isValidId(userId)) {
+    errors.push("userId must be a valid ID");
+  }
+
+  if (!transactionId || !isValidId(transactionId)) {
+    errors.push("transactionId must be a valid ID");
+  }
+
+  if (!processor) {
+    errors.push(`processor must be one of: ${ALLOWED_PROCESSORS.join(", ")}`);
+  }
+
+  if (errors.length > 0) {
+    res.status(400).json({
+      error: "Invalid dispute payload",
+      details: errors,
+    });
+    return;
+  }
+
+  try {
+    const dispute = await prisma.dispute.create({
+      data: {
+        userId,
+        transactionId,
+        processor,
+        status: DISPUTE_STATUS.OPEN,
+      },
+    });
+
+    res.status(201).json({ dispute });
+  } catch (error) {
+    res.status(500).json({
+      error: "Failed to create dispute",
+    });
+  }
 }
 
 export function getDispute(id: string): DisputeRecord | undefined {

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -10,3 +10,10 @@ export const HTTP_STATUS = {
 } as const;
 
 export const SHIPMENT_STATUSES = ['CREATED','IN_TRANSIT','DELIVERED','CANCELLED'] as const;
+
+export const DISPUTE_STATUS = {
+  OPEN: "OPEN",
+  UNDER_REVIEW: "UNDER_REVIEW",
+  RESOLVED: "RESOLVED",
+  REJECTED: "REJECTED",
+} as const;


### PR DESCRIPTION
### Motivation
- Ensure dispute creation is robust by validating and sanitizing incoming payloads before writing to the DB. 
- Replace a hardcoded status string with a shared project-wide enum for consistent status usage. 
- Surface appropriate HTTP errors for client and server failures instead of silently creating records.

### Description
- Replaced the old in-memory `createDispute(id, input)` implementation with an Express handler `createDispute(req, res)` that validates `userId`, `transactionId`, and `processor` and returns `400` on validation failure. 
- Added helper functions `sanitizeString`, `isValidId`, and `parseProcessor` and defined `ALLOWED_PROCESSORS` for input sanitization and allowed-processor checks. 
- Wrapped the database call in a `try/catch` and use `prisma.dispute.create` to persist disputes, returning `201` with the created record on success and `500` on DB errors. 
- Introduced `DISPUTE_STATUS` in `packages/shared/src/constants.ts` and used `DISPUTE_STATUS.OPEN` in the create flow instead of the previous hardcoded value.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69774e8184f883309ce4b44cd9229e9e)