### PR TITLE
docs: clarify Vercel build trigger behavior

### DIFF
--- a/VERCEL_BUILD_TRIGGER_TESTING.md
+++ b/VERCEL_BUILD_TRIGGER_TESTING.md
@@ -14,14 +14,15 @@ This document outlines how to test and verify that Vercel builds are triggered c
 
 ### What This Means
 
-- **Triggers Build**: Changes to `web/` directory, root config files, documentation
+- **Triggers Build**: Any changes outside the excluded paths (for example `web/`, root config files like `package.json`, `vercel.json`, and other infra/tooling files)
 - **Skips Build**: Changes only to `api/`, `packages/`, `archive/`, `mobile/`
 
 ## Test Scenarios
 
 ### ✅ Should Trigger Build
 
-1. **Web Directory Changes**
+1. **Any Non-Excluded Path Changes**
+   - Includes `web/`, root config files (for example `package.json`, `vercel.json`), and infra/tooling files outside the excluded directories.
    ```bash
    # Modify a web component
    echo "// test change" >> web/components/Header.tsx


### PR DESCRIPTION
### Motivation
- Clarify that the Vercel `ignoreCommand` triggers builds for any change outside the excluded paths (not just `web/` and a few root configs), including root config and infra/tooling files such as `package.json` and `vercel.json`.

### Description
- Updated `VERCEL_BUILD_TRIGGER_TESTING.md` to replace the previous "Triggers Build" wording with an explicit statement that any changes outside the excluded paths will trigger a build and changed the test scenario header from "Web Directory Changes" to "Any Non-Excluded Path Changes" while calling out examples like `web/`, `package.json`, `vercel.json`, and other infra/tooling files.

### Testing
- Docs-only change; no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977533743488330896becd3afdb141f)