### PR TITLE
docs: add language specifiers to build trigger examples

### DIFF
--- a/VERCEL_BUILD_TRIGGER_TESTING.md
+++ b/VERCEL_BUILD_TRIGGER_TESTING.md
@@ -106,13 +106,13 @@ vercel logs [deployment-url]
 ## Expected Build Behavior
 
 ### Successful Skip
-```
+```text
 ✓ Running git diff HEAD^ HEAD --quiet . ':(exclude)api/**' ':(exclude)packages/**' ':(exclude)archive/**' ':(exclude)mobile/**'
 ✓ Build skipped because ignoreCommand returned 0
 ```
 
 ### Successful Trigger
-```
+```text
 ✓ Running git diff HEAD^ HEAD --quiet . ':(exclude)api/**' ':(exclude)packages/**' ':(exclude)archive/**' ':(exclude)mobile/**'
 ✗ Command exited with non-zero status (1)
 ✓ Proceeding with build


### PR DESCRIPTION
### Motivation
- Fix MD040 and improve readability by adding language specifiers to example fenced code blocks in `VERCEL_BUILD_TRIGGER_TESTING.md` so they render with explicit syntax highlighting.

### Description
- Updated `VERCEL_BUILD_TRIGGER_TESTING.md` to change the "Successful Skip" and "Successful Trigger" example fences to use a `text` language token (i.e., ` ```text `) so the blocks include an explicit language specifier.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697753dc1704833096205052e91f2eda)