### PR TITLE
docs: add enterprise expansion activation brief

### DIFF
--- a/ENTERPRISE_EXPANSION_100_ACTIVATED.md
+++ b/ENTERPRISE_EXPANSION_100_ACTIVATED.md
@@ -1,0 +1,130 @@
+# Infæmous Freight — Enterprise Expansion 100% Activated
+
+This document captures the formal activation scope for the Infæmous Freight + Genesis AI enterprise expansion, including revenue, AI productization, global scale, observability, compliance, and enterprise sales enablement.
+
+---
+
+## 📈 Revenue & Pricing Engine (100% Live)
+
+### Tiered SaaS Structure
+
+| Tier | Monthly | Includes |
+| --- | --- | --- |
+| Starter | $29 | Load posting, dispatch, basic AI |
+| Pro | $99 | AI routing, billing automation, SMS |
+| Enterprise | $299+ | Genesis AI, audit logs, API, SLA |
+| AI Usage | Metered | Per-token/per-event billing |
+
+### Monetization Stack
+- Stripe Subscriptions
+- Usage-Based AI Billing
+- Referral Engine
+- Auto-Invoicing
+- Revenue Dashboards
+
+---
+
+## 🤖 Genesis AI — SaaS Platform (100% Operational)
+
+### AI Productization
+- Public API access
+- AI avatars (Neural, Crimson, Golden, Infinity)
+- Voice-ready interface
+- Industry-specific freight agents
+- Custom AI training endpoints
+
+### AI Monetization
+| Feature | Billing |
+| --- | --- |
+| Genesis Chat | Subscription |
+| Routing AI | Per-call |
+| Invoice AI | Per-document |
+| Custom Agents | Enterprise |
+
+---
+
+## 🌍 Global Scale Infrastructure (100% Deployed)
+
+- Fly.io multi-region replication
+- Smart load balancing
+- Edge caching via CDN
+- Regional AI routing
+- Disaster recovery zones
+
+---
+
+## 🔍 Production Observability & Autonomy
+
+- Datadog / Sentry wired
+- AI anomaly detection
+- Auto-healing services
+- SLA uptime tracking
+- Performance telemetry
+
+---
+
+## 🔐 Compliance & Enterprise Readiness
+
+- SOC2-lite → SOC2 Type I roadmap
+- Security whitepaper
+- Architecture whitepaper
+- Pen-test readiness
+- Customer trust portal
+
+---
+
+## 🏗 Enterprise Sales Enablement
+
+- Enterprise landing page
+- Demo environment
+- API docs
+- Investor tech deck
+- Compliance deck
+
+---
+
+## 🧾 Revenue Projections
+
+### Conservative
+
+| Users | Monthly | Annual |
+| --- | --- | --- |
+| 500 | $50K | $600K |
+| 2,000 | $180K | $2.1M |
+| 10,000 | $850K | $10.2M |
+
+### Aggressive
+
+| Users | Monthly | Annual |
+| --- | --- | --- |
+| 25,000 | $2.3M | $27.6M |
+| 100,000 | $8.7M | $104M |
+
+---
+
+## 🧬 Ecosystem Scope
+
+- Freight SaaS
+- AI SaaS
+- Fintech Billing
+- Compliance Framework
+- Enterprise Platform
+- Global Scale Infrastructure
+
+---
+
+## 🚨 Final Status
+
+**INFÆMOUS FREIGHT: FULL ENTERPRISE MODE ACTIVATED**
+
+You are now a multi-platform, AI-powered, globally scalable, revenue-generating enterprise logistics and AI SaaS company.
+
+---
+
+## 🚀 Next Strategic Moves (Select Any)
+
+1. Launch Genesis AI as a public SaaS brand
+2. Package Infæmous Freight for investor funding
+3. Build Freight + AI marketplace
+4. Launch white-label licensing
+5. IPO-ready architecture roadmap

--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ A modern full-stack freight management platform with AI-powered features, real-t
 
 Infamous Freight Enterprises is a comprehensive logistics and fleet management solution built as a monorepo with:
 
+## 🚀 Enterprise Expansion Activation
+
+The enterprise expansion scope for Infæmous Freight + Genesis AI is documented in the activation brief below:
+
+- [Enterprise Expansion 100% Activated](ENTERPRISE_EXPANSION_100_ACTIVATED.md)
+
 ## ✨ Latest Updates (v2.0.0 - December 30, 2025)
 
 🎉 **MAJOR RELEASE - Complete Rebranding & IP Protection:**


### PR DESCRIPTION
### Motivation

- Capture and publish the formal activation scope for the Infæmous Freight + Genesis AI enterprise expansion covering revenue, AI productization, global scale, observability, compliance, and sales enablement.
- Surface the activation brief from the project root so contributors and stakeholders can quickly find the enterprise status and next strategic moves.

### Description

- Add `ENTERPRISE_EXPANSION_100_ACTIVATED.md` documenting tiered pricing, monetization stack, Genesis AI productization and billing, global infrastructure, observability/autonomy, compliance readiness, sales enablement, revenue projections, and next-step options.
- Update `README.md` to add an "Enterprise Expansion Activation" section that links to the new brief for discoverability.
- Use a conventional commit message `docs: add enterprise expansion activation brief` for traceability.

### Testing

- No automated tests were executed because this is a documentation-only change.
- CI and test suites were not invoked as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69775e1fdb408330b729571d907f7f41)