### PR TITLE
docs: remove invalid live URL from deployment certification

### DIFF
--- a/DEPLOYMENT_100_PERCENT_CERTIFICATION.md
+++ b/DEPLOYMENT_100_PERCENT_CERTIFICATION.md
@@ -15,7 +15,6 @@ All platforms operational. All pipelines green. All revenue paths live. All AI s
 - Node engine pinned & verified
 - Env validation enforced
 - Domain active & assigned
-- Live: `infamous-freight-enterprises.vercel.app`
 
 ### ✅ API (Fly.io)
 - Containerized build (Dockerfile validated)


### PR DESCRIPTION
### Motivation
- The documented live URL `infamous-freight-enterprises.vercel.app` returned 404, so the manifest should not reference a broken endpoint.

### Description
- Deleted the `Live: infamous-freight-enterprises.vercel.app` line from `DEPLOYMENT_100_PERCENT_CERTIFICATION.md` to keep the Web platform section accurate and well-formatted.

### Testing
- Documentation-only change; no automated tests were run and existing CI was not affected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977601ec60c8330bcfc0258661b7b01)