### PR TITLE
docs: add enterprise delivery pack

### DIFF
--- a/docs/ENTERPRISE_DELIVERY_PACK.md
+++ b/docs/ENTERPRISE_DELIVERY_PACK.md
@@ -46,21 +46,21 @@ You now have a Public Company Readiness Pack:
 **A. Government Contract Bid Templates**
 - Statement of Work (SoW)  
 - Technical capability narrative  
-- Cybersecurity compliance mapping (NIST / CMMC)  
+- Cybersecurity control alignment summary (NIST / CMMC reference)  
 - Past performance template  
 - Pricing schedule template
 
-**B. Compliance Mapping Framework**
+**B. Compliance Alignment Framework (Repository Coverage)**
 
-| Framework | Coverage |
+| Framework | Status in this repo |
 | --- | --- |
-| NIST 800-53 | Mapped |
-| CMMC | Mapped |
-| CJIS | Mapped |
-| SOC2 | Implementable |
-| FedRAMP | Roadmap only |
+| NIST 800-53 | Security practices aligned; formal control-by-control mapping not included |
+| CMMC | Security practices aligned; formal Level 2–3 mapping not included |
+| CJIS | Some controls addressed (auth, logging, hardening); no formal mapping provided |
+| SOC2 | Implementable with additional policy and control documentation |
+| FedRAMP | Conceptual roadmap only; no formal package or SSP included |
 
-✅ You now have the documentation needed to apply and compete, not just claim eligibility.
+✅ You now have structured templates and security practices that support applying and competing, but formal regulatory assessments and control mappings must be completed separately.
 
 ---
 


### PR DESCRIPTION
### Motivation
- Consolidate high-level, deployable enterprise deliverables into a single reference so teams can generate IPO, compliance, product, marketplace, M&A, and regulatory artifacts quickly.
- Provide legally and operationally grounded templates and roadmaps for Genesis AI, IGFX, and related subsidiaries to support enterprise readiness and go-to-market.
- Surface financial trajectories and licensing/compliance mapping to align productization and regulatory planning.

### Description
- Add `docs/ENTERPRISE_DELIVERY_PACK.md` containing structured deliverables for IPO readiness, government & enterprise contracting, Genesis AI productization, IGFX marketplace MVP, M&A acquisition system, regulatory & licensing playbook, corporate/legal structure, and financial trajectories.
- The document includes tables, pricing tiers, license mapping, entity architecture, and a "Next Execution" list of assets that can be generated from the pack.
- This is a documentation-only change and does not modify application code or runtime behavior.

### Testing
- No automated tests were run because this PR adds documentation only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697762fb79048330ad91daad59a635e2)