### PR TITLE
ci: make deploy-all callable via `workflow_call`

### DIFF
--- a/.github/workflows/deploy-all.yml
+++ b/.github/workflows/deploy-all.yml
@@ -2,6 +2,7 @@ name: Deploy ALL Platforms
 
 on:
   workflow_dispatch:
+  workflow_call:
 
 concurrency:
   group: deploy-all


### PR DESCRIPTION
### Motivation
- Prevent unintended orchestration and allow programmatic invocation by making the top-level deploy orchestration runnable only by manual dispatch or other workflows.

### Description
- Added `workflow_call` to the `on:` section of `.github/workflows/deploy-all.yml` while keeping the existing `workflow_dispatch` trigger and existing `concurrency`/`cancel-in-progress` settings unchanged.

### Testing
- No automated tests were run because this change only updates GitHub Actions workflow configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697773089b7c8330b0b6fe3c7d30f6eb)