### PR TITLE
ci(workflows): add health check timeouts to API deploy workflow

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -40,3 +40,19 @@ jobs:
           args: "deploy --config api/fly.toml --remote-only"
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+      - name: Wait for health
+        env:
+          HEALTH_URL: https://${{ secrets.FLY_APP_NAME }}.fly.dev/api/health
+        run: |
+          for i in {1..30}; do
+            code=$(curl -s --connect-timeout 5 --max-time 15 -o /dev/null -w "%{http_code}" "$HEALTH_URL" || true)
+            if [ "$code" = "200" ]; then
+              echo "Health check passed."
+              exit 0
+            fi
+            echo "Health check attempt $i failed with code $code. Retrying..."
+            sleep 10
+          done
+          echo "Health check failed after 30 attempts."
+          exit 1


### PR DESCRIPTION
### Motivation
- Prevent the health-check loop in the deploy workflow from hanging indefinitely by adding conservative curl timeouts and a bounded retry loop.
- Use a deterministic Fly URL for the health check so the deploy step can reliably verify the deployed instance.

### Description
- Add a `Wait for health` step after the `Deploy to Fly` step and set `HEALTH_URL` to `https://${{ secrets.FLY_APP_NAME }}.fly.dev/api/health`.
- Update the curl invocation to `curl -s --connect-timeout 5 --max-time 15 -o /dev/null -w "%{http_code}" "$HEALTH_URL" || true` so individual requests time out quickly and cannot hang the loop.
- Wrap the request in a loop of up to 30 attempts with `sleep 10` between tries and fail the job if the endpoint does not return HTTP `200` after retries.
- Commit message follows conventional commit format: `ci(workflows): add health check timeouts`.

### Testing
- No automated workflow tests were run because this is a CI workflow change only.
- The commit hook validation for conventional commit format ran and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977733fa2a08330920eb44121a050e0)