### PR TITLE
fix(ci): add curl timeouts to health check

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -73,7 +73,7 @@ jobs:
           RETRY_COUNT=0
 
           while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
-            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" ${{ inputs.health-check-url }})
+            HTTP_CODE=$(curl -s --connect-timeout 5 --max-time 15 -o /dev/null -w "%{http_code}" ${{ inputs.health-check-url }})
             if [ "$HTTP_CODE" = "200" ]; then
               echo "✅ ${{ inputs.app-name }} is healthy (HTTP $HTTP_CODE)"
               echo "health=ok" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Motivation
- Prevent the health check step from hanging on stalled TCP connections by making each `curl` attempt fail fast if the connection or overall request stalls.

### Description
- Add `--connect-timeout 5 --max-time 15` to the `curl` invocation inside the Health check loop in `.github/workflows/reusable-deploy.yml`, preserving the existing HTTP status check and retry/loop logic.

### Testing
- No automated tests were run because this is a workflow-only change; the file updated was ` .github/workflows/reusable-deploy.yml` and the change is limited to the `curl` flags.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977736441a88330918dc3967fa65210)