### PR TITLE
docs(ci): add jq rollback example to deploy-genesis-ai workflow

### DIFF
--- a/.github/workflows/deploy-genesis-ai.yml
+++ b/.github/workflows/deploy-genesis-ai.yml
@@ -1,2 +1,7 @@
 # Workflow intentionally disabled: genesis-ai app does not exist in this repository yet.
 # Recreate a proper deploy workflow once apps/genesis-ai (and corresponding pnpm workspace entry) is added.
+# Rollback example (jq-based):
+# prev=$(flyctl releases list -a "$FLY_APP" --json | jq -r '.[1].version // ""')
+# if [ -n "$prev" ]; then
+#   flyctl releases rollback -a "$FLY_APP" --version "$prev"
+# fi


### PR DESCRIPTION
### Motivation
- Replace a Node-based JSON parse example with a `jq`-based snippet so rollback logic does not require `actions/setup-node` when it's skipped.

### Description
- Add a commented jq-based rollback example to `.github/workflows/deploy-genesis-ai.yml` using `prev=$(flyctl releases list -a "$FLY_APP" --json | jq -r '.[1].version // ""')` and an `if [ -n "$prev" ]; then flyctl releases rollback -a "$FLY_APP" --version "$prev"; fi` guard.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69777387d0748330ad0c8d8a18406696)