### PR TITLE
ci: add Release Ops workflow, semver bump script, and deploy notifications (Sentry + Slack)

### DIFF
--- a/.github/workflows/deploy-ai.yml
+++ b/.github/workflows/deploy-ai.yml
@@ -65,7 +65,37 @@ jobs:
         working-directory: ai
         run: flyctl deploy --remote-only
 
+      - name: Sentry release (Genesis)
+        if: success() && secrets.SENTRY_AUTH_TOKEN != '' && steps.genesis-assets.outputs.fly_config == 'true'
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT_GENESIS }}
+        run: |
+          npx --yes @sentry/cli releases new "${{ github.sha }}"
+          npx --yes @sentry/cli releases set-commits "${{ github.sha }}" --auto
+          npx --yes @sentry/cli releases finalize "${{ github.sha }}"
+          npx --yes @sentry/cli releases deploys "${{ github.sha }}" new -e production
+
       - name: Publish skip notice
         if: steps.genesis-assets.outputs.dockerfile != 'true' && steps.genesis-assets.outputs.fly_config != 'true'
         run: |
           echo "Genesis AI deployment skipped (no ai/Dockerfile or ai/fly.toml present)." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Slack notify (success)
+        if: success() && secrets.SLACK_WEBHOOK_URL != ''
+        run: |
+          payload=$(jq -n \
+            --arg text "✅ Deploy Success: ${{ github.workflow }} @ ${{ github.ref_name }} (commit ${{ github.sha }})" \
+            '{text:$text}')
+          curl -X POST -H 'Content-type: application/json' \
+            --data "$payload" "${{ secrets.SLACK_WEBHOOK_URL }}"
+
+      - name: Slack notify (failure)
+        if: failure() && secrets.SLACK_WEBHOOK_URL != ''
+        run: |
+          payload=$(jq -n \
+            --arg text "❌ Deploy Failed: ${{ github.workflow }} @ ${{ github.ref_name }} (commit ${{ github.sha }})" \
+            '{text:$text}')
+          curl -X POST -H 'Content-type: application/json' \
+            --data "$payload" "${{ secrets.SLACK_WEBHOOK_URL }}"

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -71,3 +71,33 @@ jobs:
           done
           echo "Health check failed after 30 attempts."
           exit 1
+
+      - name: Sentry release (API)
+        if: success() && secrets.SENTRY_AUTH_TOKEN != ''
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT_API }}
+        run: |
+          npx --yes @sentry/cli releases new "${{ github.sha }}"
+          npx --yes @sentry/cli releases set-commits "${{ github.sha }}" --auto
+          npx --yes @sentry/cli releases finalize "${{ github.sha }}"
+          npx --yes @sentry/cli releases deploys "${{ github.sha }}" new -e production
+
+      - name: Slack notify (success)
+        if: success() && secrets.SLACK_WEBHOOK_URL != ''
+        run: |
+          payload=$(jq -n \
+            --arg text "✅ Deploy Success: ${{ github.workflow }} @ ${{ github.ref_name }} (commit ${{ github.sha }})" \
+            '{text:$text}')
+          curl -X POST -H 'Content-type: application/json' \
+            --data "$payload" "${{ secrets.SLACK_WEBHOOK_URL }}"
+
+      - name: Slack notify (failure)
+        if: failure() && secrets.SLACK_WEBHOOK_URL != ''
+        run: |
+          payload=$(jq -n \
+            --arg text "❌ Deploy Failed: ${{ github.workflow }} @ ${{ github.ref_name }} (commit ${{ github.sha }})" \
+            '{text:$text}')
+          curl -X POST -H 'Content-type: application/json' \
+            --data "$payload" "${{ secrets.SLACK_WEBHOOK_URL }}"

--- a/.github/workflows/deploy-mobile.yml
+++ b/.github/workflows/deploy-mobile.yml
@@ -38,3 +38,21 @@ jobs:
 
       - name: EAS Update (OTA)
         run: cd src/apps/mobile && eas update --channel production
+
+      - name: Slack notify (success)
+        if: success() && secrets.SLACK_WEBHOOK_URL != ''
+        run: |
+          payload=$(jq -n \
+            --arg text "✅ Deploy Success: ${{ github.workflow }} @ ${{ github.ref_name }} (commit ${{ github.sha }})" \
+            '{text:$text}')
+          curl -X POST -H 'Content-type: application/json' \
+            --data "$payload" "${{ secrets.SLACK_WEBHOOK_URL }}"
+
+      - name: Slack notify (failure)
+        if: failure() && secrets.SLACK_WEBHOOK_URL != ''
+        run: |
+          payload=$(jq -n \
+            --arg text "❌ Deploy Failed: ${{ github.workflow }} @ ${{ github.ref_name }} (commit ${{ github.sha }})" \
+            '{text:$text}')
+          curl -X POST -H 'Content-type: application/json' \
+            --data "$payload" "${{ secrets.SLACK_WEBHOOK_URL }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,71 @@
+name: Release Ops
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-ops
+  cancel-in-progress: false
+
+jobs:
+  version_and_tag:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Bump version
+        id: version
+        run: |
+          node ./scripts/release-version.js
+          v=$(node -p "require('./package.json').version")
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+
+      - name: Commit version bump
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add package.json
+          git commit -m "chore(release): v${{ steps.version.outputs.version }}" || echo "No changes"
+          git push
+
+      - name: Tag
+        run: |
+          git tag "v${{ steps.version.outputs.version }}" || true
+          git push --tags || true
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.version.outputs.version }}
+          generate_release_notes: true
+
+      - name: Slack notify (success)
+        if: success() && secrets.SLACK_WEBHOOK_URL != ''
+        run: |
+          payload=$(jq -n --arg text "✅ Release created: v${{ steps.version.outputs.version }} (main)" '{text:$text}')
+          curl -X POST -H 'Content-type: application/json' --data "$payload" "${{ secrets.SLACK_WEBHOOK_URL }}"
+
+      - name: Slack notify (failure)
+        if: failure() && secrets.SLACK_WEBHOOK_URL != ''
+        run: |
+          payload=$(jq -n --arg text "❌ Release Ops failed on main (commit ${{ github.sha }})" '{text:$text}')
+          curl -X POST -H 'Content-type: application/json' --data "$payload" "${{ secrets.SLACK_WEBHOOK_URL }}"

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "env:setup": "./scripts/setup-environments.sh",
     "env:validate": "./scripts/env-validate.sh",
     "env:check": "./scripts/env-validate.sh",
+    "release:version": "node ./scripts/release-version.js",
     "security:audit": "pnpm audit --audit-level=high",
     "security:check": "pnpm audit && npm run lint",
     "prepare": "husky install || true"

--- a/scripts/release-version.js
+++ b/scripts/release-version.js
@@ -1,0 +1,56 @@
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+
+function sh(cmd) {
+  return execSync(cmd, { stdio: ["ignore", "pipe", "pipe"] }).toString().trim();
+}
+
+function lastTag() {
+  try {
+    return sh("git describe --tags --abbrev=0");
+  } catch {
+    return null;
+  }
+}
+
+function commitsSince(tag) {
+  const range = tag ? `${tag}..HEAD` : "HEAD";
+  return sh(`git log ${range} --pretty=%s%n%b---END---`)
+    .split("---END---")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function bumpType(messages) {
+  const joined = messages.join("\n");
+  if (/BREAKING CHANGE/i.test(joined) || /!:/g.test(joined)) return "major";
+  if (messages.some((m) => /^feat(\(.+\))?:/i.test(m))) return "minor";
+  return "patch";
+}
+
+function parseVersion(version) {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
+  if (!match) throw new Error(`Invalid version: ${version}`);
+  return { major: +match[1], minor: +match[2], patch: +match[3] };
+}
+
+function nextVersion(current, type) {
+  const v = parseVersion(current);
+  if (type === "major") return `${v.major + 1}.0.0`;
+  if (type === "minor") return `${v.major}.${v.minor + 1}.0`;
+  return `${v.major}.${v.minor}.${v.patch + 1}`;
+}
+
+const pkgPath = "package.json";
+const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+const current = (pkg.version || "0.1.0").replace(/^v/, "");
+
+const tag = lastTag();
+const messages = commitsSince(tag);
+const type = bumpType(messages);
+const next = nextVersion(current, type);
+
+pkg.version = next;
+fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
+
+console.log(`Bumped version ${current} -> ${next} (${type})`);


### PR DESCRIPTION
### Motivation
- Add automated Release Ops to bump package versions, create tags/releases, and notify on outcomes to reduce manual release work. 
- Tie deployments to Sentry releases so production errors are associated with the exact deploy. 
- Provide uniform Slack notifications for deploy success/failure across API, Genesis AI, and mobile flows for better team visibility.

### Description
- Add a new workflow `/.github/workflows/release.yml` that runs on `push` to `main` to compute a semver bump, update `package.json`, tag, and create a GitHub Release, and notify Slack on success/failure. 
- Add `scripts/release-version.js` (ESM) and a `release:version` npm script to compute the next semver using commit messages (`feat:` => minor, `fix:` => patch, `BREAKING CHANGE`/`!:` => major) and write the new version to `package.json`, callable via `node ./scripts/release-version.js`. 
- Update `package.json` to expose the `release:version` script. 
- Enhance deploy workflows with Sentry and Slack integration by adding a Sentry release step to API and Genesis AI deploys and adding Slack `success`/`failure` notification steps to `deploy-api.yml`, `deploy-ai.yml`, and `deploy-mobile.yml` that post to `secrets.SLACK_WEBHOOK_URL` using `jq` + `curl`.

### Testing
- No automated tests were executed as part of this change (these are CI/workflow additions and a local script); validation should be done by running the workflows in CI and by exercising the `release:version` script in a pipeline environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977764ec0a48330b35ebcdd89f5cef4)