### PR TITLE
Remove unused Recharts PieChart import in RevenueMonitorDashboard

### DIFF
--- a/web/components/RevenueMonitorDashboard.tsx
+++ b/web/components/RevenueMonitorDashboard.tsx
@@ -19,11 +19,6 @@ const BarChart = dynamic(() => import("recharts").then((mod) => mod.BarChart), {
     <div className="h-[300px] bg-gray-100 animate-pulse rounded" />
   ),
 });
-const PieChart = dynamic(() => import("recharts").then((mod) => mod.PieChart), {
-  loading: () => (
-    <div className="h-[300px] bg-gray-100 animate-pulse rounded" />
-  ),
-});
 
 // Import only required recharts components once dynamically
 const {
@@ -36,7 +31,6 @@ const {
   Tooltip,
   Legend,
   ResponsiveContainer,
-  Pie,
 } = require("recharts");
 
 interface RevenueMetrics {


### PR DESCRIPTION
### Motivation
- Fix a TypeScript unused-declaration error that caused the Next.js build to fail by removing an unused `PieChart` dynamic import and the unused `Pie` reference.

### Description
- Removed the dynamic import `PieChart` and removed `Pie` from the `require('recharts')` destructure in `web/components/RevenueMonitorDashboard.tsx` to eliminate the unused symbol.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977fb93a10883308cf8d5f539dc949c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed pie chart visualization from the Revenue Monitor Dashboard. Bar and line charts remain available for data visualization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->