### PR TITLE
Remove unused `Cell` import to fix Next.js type error

### DIFF
--- a/web/components/RevenueMonitorDashboard.tsx
+++ b/web/components/RevenueMonitorDashboard.tsx
@@ -24,7 +24,6 @@ const BarChart = dynamic(() => import("recharts").then((mod) => mod.BarChart), {
 const {
   Line,
   Bar,
-  Cell,
   XAxis,
   YAxis,
   CartesianGrid,


### PR DESCRIPTION
### Motivation
- The Docker build was failing because Next.js TypeScript reported a compiler error: `'Cell' is declared but its value is never read` in `web/components/RevenueMonitorDashboard.tsx`, which blocked the `pnpm --filter web build` step.

### Description
- Remove the unused `Cell` import from `web/components/RevenueMonitorDashboard.tsx` to clear the TypeScript no-unused-variable error so the Next.js build can proceed.

### Testing
- No automated tests were run for this change; the edit is a minimal compile-time fix intended to unblock the `pnpm --filter web build` step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977fe6cb5188330a5d1230cb28f1b3f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused dependencies to improve code quality and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->