### PR TITLE
Remove memory_mb from Fly VM config

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -19,7 +19,7 @@ primary_region = 'iad'
 [[vm]]
   cpu_kind = 'shared'
   cpus = 1
-  memory_mb = 1024
+  memory = '1gb'
 
 [[services]]
   protocol = "tcp"


### PR DESCRIPTION
### Motivation
- Remove the unsupported `memory_mb` key from the Fly `[[vm]]` block and rely on the supported `memory = '1gb'` field to configure VM RAM.

### Description
- Deleted `memory_mb = 1024` and added `memory = '1gb'` in `fly.toml` within the `[[vm]]` table; no other changes were made.

### Testing
- No automated tests were run because this is a configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697814f037148330ab1fc329b4cd6b55)