### PR TITLE
Update Netlify build settings

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,10 +4,12 @@
   # Build from repo root to support pnpm workspaces
   base = "."
   command = "corepack enable && pnpm install --frozen-lockfile && pnpm --filter @infamous-freight/shared build && pnpm --filter web build"
-  # The Next.js Netlify plugin will set the publish/functions outputs
+  publish = "web/.next"
+  # The Next.js Netlify plugin will set the functions output
 
 [build.environment]
   NODE_VERSION = "20"
+  PNPM_VERSION = "9"
   NEXT_PUBLIC_API_URL = "https://api.infamous-freight.com"
   NEXT_PUBLIC_API_BASE = "https://api.infamous-freight.com/api"
 
@@ -56,6 +58,8 @@
 ## Contexts
 [context.production]
   command = "corepack enable && pnpm install --frozen-lockfile && pnpm --filter @infamous-freight/shared build && pnpm --filter web build"
+  [context.production.environment]
+    NODE_ENV = "production"
 
 [context.deploy-preview]
   command = "corepack enable && pnpm install --frozen-lockfile && pnpm --filter @infamous-freight/shared build && pnpm --filter web build"


### PR DESCRIPTION
### Motivation
- Make Netlify builds explicit and monorepo-safe by declaring the Next.js publish output and pinning the pnpm version, and ensure production runtime uses `NODE_ENV=production`.

### Description
- Updated `netlify.toml` to set `publish = "web/.next"` so Netlify knows the Next.js output directory.
- Added `PNPM_VERSION = "9"` to `[build.environment]` to pin the pnpm version used during builds.
- Added `[context.production.environment]` with `NODE_ENV = "production"` to ensure production context runs with the correct environment.

### Testing
- No automated tests were run because this is a configuration-only change and does not modify application code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69782013737c83309d9b477f99a79fed)