### PR TITLE
chore: sync pnpm lockfile with workspace

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ importers:
         specifier: ^10.1.8
         version: 10.1.8(eslint@9.39.2(jiti@2.6.1))
       pg:
-        specifier: ^8.13.1
+        specifier: ~8.17.2
         version: 8.17.2
     devDependencies:
       '@21yunbox/netlify-plugin-21yunbox-deploy-to-china-cdn':
@@ -220,6 +220,8 @@ importers:
       supertest:
         specifier: ^7.1.4
         version: 7.2.2
+
+  mobile: {}
 
   packages/shared:
     devDependencies:


### PR DESCRIPTION
### Motivation
- Ensure the repository root `pnpm-lock.yaml` matches workspace manifests to prevent CI (Netlify) failure `ERR_PNPM_OUTDATED_LOCKFILE` during installs.

### Description
- Regenerated the root `pnpm-lock.yaml` from the monorepo so dependency resolutions align with the `package.json` workspaces and package specifiers (notably `pg` updated to `~8.17.2`).
- Added an empty `mobile` importer entry and synchronized `packages/shared`, `tests/e2e`, and `web` workspace entries in the lockfile.
- Performed the lockfile refresh while allowing engine checks to be relaxed locally to accommodate the environment mismatch encountered during the run.

### Testing
- Ran `corepack enable` which succeeded. 
- Attempted `pnpm install --lockfile-only` which failed due to a Node engine mismatch (expected `20.x`, got `v22.21.1`).
- Ran `pnpm install --lockfile-only --config.engine-strict=false` which completed successfully (the run produced warnings about peer deps and engine expectations but finished and wrote the updated `pnpm-lock.yaml`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69782420d9788330b74a6d6492e7de81)