### PR TITLE
chore: sync pnpm-lock.yaml with package.json

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ importers:
         specifier: ^10.1.8
         version: 10.1.8(eslint@9.39.2(jiti@2.6.1))
       pg:
-        specifier: ^8.13.1
+        specifier: ~8.17.2
         version: 8.17.2
     devDependencies:
       '@21yunbox/netlify-plugin-21yunbox-deploy-to-china-cdn':
@@ -220,6 +220,8 @@ importers:
       supertest:
         specifier: ^7.1.4
         version: 7.2.2
+
+  mobile: {}
 
   packages/shared:
     devDependencies:


### PR DESCRIPTION
### Motivation

- Fix CI build failure caused by `pnpm` running with `--frozen-lockfile` while `pnpm-lock.yaml` and the root `package.json` disagreed, most notably `pg` (`lockfile: ^8.13.1` vs `package.json: ~8.17.2`).
- Ensure deterministic installs across Netlify/CI by keeping the lockfile in sync with declared dependency versions.

### Description

- Regenerated and updated `pnpm-lock.yaml` to match the workspace dependency resolutions, including changing the `pg` specifier to `~8.17.2` and resolving it to `8.17.2`.
- Incorporated lockfile changes for workspace importers (small metadata adjustments such as adding an empty `mobile` importer entry) without altering source code.
- Committed the updated lockfile with the message `chore: sync pnpm-lock.yaml with package.json`.

### Testing

- Ensured environment tooling with `corepack enable` and verified `pnpm` (`9.15.0`) and installed Node `v20.20.0` via `nvm` to match the project `engines.node` requirement.
- Ran `pnpm install --no-frozen-lockfile` successfully to resolve dependencies and then `pnpm install --lockfile-only` to refresh the lockfile, producing the changes committed.
- No unit or integration tests were run because this is an install-only lockfile synchronization change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697822e809a083308c08dfa9455de1bc)