### PR TITLE
chore: sync pnpm lockfile with workspace

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ importers:
         specifier: ^10.1.8
         version: 10.1.8(eslint@9.39.2(jiti@2.6.1))
       pg:
-        specifier: ^8.13.1
+        specifier: ~8.17.2
         version: 8.17.2
     devDependencies:
       '@21yunbox/netlify-plugin-21yunbox-deploy-to-china-cdn':
@@ -220,6 +220,8 @@ importers:
       supertest:
         specifier: ^7.1.4
         version: 7.2.2
+
+  mobile: {}
 
   packages/shared:
     devDependencies:


### PR DESCRIPTION
### Motivation
- Sync the workspace lockfile so installs are deterministic in CI/Netlify and to eliminate the `ERR_PNPM_OUTDATED_LOCKFILE` failure seen during installs.

### Description
- Regenerated and updated `pnpm-lock.yaml` to reflect the current workspace dependency graph (updated specifiers such as `pg` and added implicit workspace entries) without changing package manifests.

### Testing
- Ran `nvm install 20 && nvm use 20 && corepack enable && pnpm install --lockfile-only` and `pnpm -v`, which completed successfully with only non-fatal peer dependency warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978278a081083309d4684c2b4f49d7e)