### PR TITLE
Ensure Netlify installs devDependencies during builds

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
 [build]
   # Build from repo root to support pnpm workspaces
   base = "."
-  command = "corepack enable && pnpm install --frozen-lockfile && pnpm --filter @infamous-freight/shared build && pnpm --filter web build"
+  command = "corepack enable && pnpm install --frozen-lockfile --prod=false && pnpm --filter @infamous-freight/shared build && pnpm --filter web build"
   publish = "web/.next"
   # The Next.js Netlify plugin will set the functions output
 
@@ -57,12 +57,12 @@
 
 ## Contexts
 [context.production]
-  command = "corepack enable && pnpm install --frozen-lockfile && pnpm --filter @infamous-freight/shared build && pnpm --filter web build"
+  command = "corepack enable && pnpm install --frozen-lockfile --prod=false && pnpm --filter @infamous-freight/shared build && pnpm --filter web build"
   [context.production.environment]
     NODE_ENV = "production"
 
 [context.deploy-preview]
-  command = "corepack enable && pnpm install --frozen-lockfile && pnpm --filter @infamous-freight/shared build && pnpm --filter web build"
+  command = "corepack enable && pnpm install --frozen-lockfile --prod=false && pnpm --filter @infamous-freight/shared build && pnpm --filter web build"
 
 [context.branch-deploy]
-  command = "corepack enable && pnpm install --frozen-lockfile && pnpm --filter @infamous-freight/shared build && pnpm --filter web build"
+  command = "corepack enable && pnpm install --frozen-lockfile --prod=false && pnpm --filter @infamous-freight/shared build && pnpm --filter web build"


### PR DESCRIPTION
### Motivation
- Netlify sets `NODE_ENV=production` during builds which causes `pnpm` to skip `devDependencies`, and some Next.js build-time tooling must be available during the build.

### Description
- Add the `--prod=false` flag to `pnpm install --frozen-lockfile` in `netlify.toml` so devDependencies are installed during the build command.
- Apply the change to the main build command and to the `production`, `deploy-preview`, and `branch-deploy` context commands while keeping the `@infamous-freight/shared` and `web` build steps unchanged.

### Testing
- No automated tests were run because this is a configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69782938424883308ce69b1c4b24dfa2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to include development dependencies during deployment builds across all environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->