### PR TITLE
Add Autonoma GitHub Actions workflow

### DIFF
--- a/.github/workflows/autonoma-tests.yml
+++ b/.github/workflows/autonoma-tests.yml
@@ -22,6 +22,6 @@ jobs:
       - name: Show cmbi807au0172xv01dqu4drhi results
         if: always()
         run: |
-          echo "Test status: ${{ steps.step-1.outputs.final-status }}"
-          echo "Message: ${{ steps.step-1.outputs.message }}"
-          echo "View results at: ${{ steps.step-1.outputs.url }}"
+          echo "Test status: ${{ steps['step-1'].outputs['final-status'] }}"
+          echo "Message: ${{ steps['step-1'].outputs['message'] }}"
+          echo "View results at: ${{ steps['step-1'].outputs['url'] }}"


### PR DESCRIPTION
### Motivation
- Add a dedicated GitHub Actions workflow to run an Autonoma test runner so the repository can execute the specified Autonoma test and surface results on PRs or via manual dispatch.

### Description
- Added ` .github/workflows/autonoma-tests.yml` which defines a `run_autonoma_tests` job that uses `autonoma-ai/actions/test-runner@v1` with `test-id: 'cmbi807au0172xv01dqu4drhi'`, reads `AUTONOMA_CLIENT_ID` and `AUTONOMA_CLIENT_SECRET` from secrets, and echoes the runner outputs; the workflow triggers on `workflow_dispatch` and `pull_request` against `main` and `develop`.

### Testing
- Not run (workflow definition only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978331e864c8330886f7af557f91942)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added automated test execution and status reporting for pull request workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->