### PR TITLE
Add pull request branch filter to compliance-check workflow

### DIFF
--- a/.github/workflows/compliance-check.yml
+++ b/.github/workflows/compliance-check.yml
@@ -2,6 +2,7 @@ name: Compliance Check
 
 on:
   pull_request:
+    branches: [main, develop]
     paths:
       - 'compliance/policies/**'
       - '.github/workflows/compliance-check.yml'


### PR DESCRIPTION
### Motivation
- Limit the `compliance-check` workflow so it only runs for pull requests targeting `main` and `develop` to reduce unnecessary runs.

### Description
- Added `branches: [main, develop]` under the `pull_request` trigger in `.github/workflows/compliance-check.yml` so the workflow is scoped to those branches.

### Testing
- No automated tests were run because this is a CI configuration change only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69783348fec0833096acdd2621329d3f)