### PR TITLE
Restrict CI workflow to main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,10 @@
 name: CI - Enterprise Grade
 
 on:
-  push:
-    branches: [main, develop]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - '.vscode/**'
-      - 'archive/**'
   pull_request:
-    branches: [main, develop]
+    branches: [ main ]
+  push:
+    branches: [ main ]
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
### Motivation
- Restrict CI runs to only the `main` branch for both `push` and `pull_request` events to reduce unnecessary CI executions and align with branch policy.

### Description
- Updated `.github/workflows/ci.yml` to set `pull_request` branches to `[ main ]` and `push` branches to `[ main ]`, removing the `develop` branch and the `paths-ignore` block.

### Testing
- No automated tests were executed because this change only modifies workflow triggers.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978336acb70833099cfbbd5cacdb69e)