### PR TITLE
Update daily health check cron schedule

### DIFF
--- a/.github/workflows/daily-health-check.yml
+++ b/.github/workflows/daily-health-check.yml
@@ -1,7 +1,7 @@
 name: Daily Health Check
 on:
   schedule:
-    - cron: "0 14 * * *"
+    - cron: "0 2 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
### Motivation
- Adjust the scheduled time for the health-check workflow to run at 02:00 UTC instead of 14:00 UTC to match the desired maintenance window.

### Description
- Changed the cron expression in ` .github/workflows/daily-health-check.yml` from `"0 14 * * *"` to `"0 2 * * *"` so the Daily Health Check runs at 02:00 UTC.

### Testing
- No automated tests were run because this is a schedule-only change and does not modify runtime code or tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69783382a03c8330b9f782762659e530)