### PR TITLE
Update GitLab CI merge request trigger

### DIFF
--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -110,7 +110,6 @@ autonoma_tests:
         --header "Content-Type: application/json" || true
   only:
     - merge_requests
-    - main
 ```
 
 ## 🧩 Bitbucket Pipelines Integration


### PR DESCRIPTION
### Motivation
- Limit the example GitLab CI job to run only for merge requests rather than also triggering on the `main` branch.

### Description
- Removed `- main` from the `only:` list in the GitLab CI example inside `docs/CI-CD.md` so the example job runs exclusively for `merge_requests`.

### Testing
- Documentation-only change so no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697834a252688330aae844804bdef652)