### PR TITLE
Add Bitbucket pipeline to trigger Autonoma deployment

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -9,5 +9,4 @@ pipelines:
               --retry-connrefused \
               --location "https://api.prod.autonoma.app/v1/run/folder/$FOLDER_ID" \
               --header "autonoma-client-id: $CLIENT_ID" \
-              --header "autonoma-client-secret: $CLIENT_SECRET" \
-              --header "Content-Type: application/json" || true
+              --header "autonoma-client-secret: $CLIENT_SECRET" || true


### PR DESCRIPTION
### Motivation
- Provide a Bitbucket Pipelines configuration that allows CI to trigger the Autonoma deployment endpoint using repository environment variables for `CLIENT_ID` and `CLIENT_SECRET` and resilient `curl` flags for retries and connection handling.

### Description
- Add `bitbucket-pipelines.yml` which defines a `default` pipeline with a `Deploy` step that runs a `curl -X POST` against `https://api.prod.autonoma.app/v1/run/folder/$FOLDER_ID` and supplies `autonoma-client-id` and `autonoma-client-secret` headers sourced from `CLIENT_ID` and `CLIENT_SECRET` environment variables.
- The `curl` invocation includes `--silent`, `--retry 3`, `--retry-connrefused`, `--location`, and `|| true` to avoid failing the pipeline on non-critical errors.

### Testing
- No automated tests were executed for this configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697834be360483309640d14235de6002)