### PR TITLE
docs: clarify Autonoma curl placeholders and add env var example

### DIFF
--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -149,6 +149,22 @@ curl -X POST \
   --header 'Content-Type: application/json' || true
 ```
 
+Replace the placeholders above with your real values. If you prefer environment
+variables, set them and run:
+```bash
+FOLDER_ID="your-folder-id" \
+CLIENT_ID="your-client-id" \
+CLIENT_SECRET="your-client-secret" \
+curl -X POST \
+  --silent \
+  --retry 3 \
+  --retry-connrefused \
+  --location "https://api.prod.autonoma.app/v1/run/folder/$FOLDER_ID" \
+  --header "autonoma-client-id: $CLIENT_ID" \
+  --header "autonoma-client-secret: $CLIENT_SECRET" \
+  --header "Content-Type: application/json" || true
+```
+
 ## 🧠 Best Practices
 
 1. **Run different tests at different stages**


### PR DESCRIPTION
### Motivation
- Clarify how to replace the placeholder values in the Autonoma cURL snippet and provide an optional environment-variable usage pattern for CI pipelines.

### Description
- Add a short paragraph and example showing how to set `FOLDER_ID`, `CLIENT_ID`, and `CLIENT_SECRET` as environment variables and use `curl` with those variables in `docs/CI-CD.md`.

### Testing
- Documentation-only change; no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697834cfd82c8330a54da002d3f87c42)