### PR TITLE
Add CircleCI Autonoma test example to CI-CD docs

### DIFF
--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -113,6 +113,29 @@ autonoma_tests:
     - main
 ```
 
+## 🧩 CircleCI Integration
+
+1. Add credentials in CircleCI: **Project Settings → Environment Variables**
+   - `CLIENT_ID`
+   - `CLIENT_SECRET`
+2. Add this to `.circleci/config.yml`:
+```yaml
+jobs:
+  test:
+    steps:
+      - run:
+          name: Run Autonoma Tests
+          command: |
+            curl -X POST \
+              --silent \
+              --retry 3 \
+              --retry-connrefused \
+              --location "https://api.prod.autonoma.app/v1/run/folder/$FOLDER_ID" \
+              --header "autonoma-client-id: $CLIENT_ID" \
+              --header "autonoma-client-secret: $CLIENT_SECRET" \
+              --header "Content-Type: application/json" || true
+```
+
 ## 🧩 Bitbucket Pipelines Integration
 
 1. Add repository variables in Bitbucket:


### PR DESCRIPTION
### Motivation
- Add a CircleCI example to the CI/CD documentation so teams using CircleCI have a ready pattern to trigger Autonoma test runs.

### Description
- Add a new "CircleCI Integration" section to `docs/CI-CD.md` that documents adding `CLIENT_ID`/`CLIENT_SECRET` and includes a `.circleci/config.yml` snippet that runs an Autonoma `curl` request.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978350f4e1c8330880ac2bf613a065f)