### PR TITLE
Add curl failure example for GitHub Actions in CI/CD docs

### DIFF
--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -90,8 +90,8 @@ on:
 **Example: Fail the job on a failed curl test run:**
 ```yaml
 - name: Run Tests
-  run: curl https://example.test/run
-  # If curl returns non-zero (test failed), pipeline stops
+  run: curl -f https://example.test/run
+  # If curl returns non-zero (HTTP 4xx/5xx or network error), pipeline stops
 ```
 
 ## 🧩 GitLab CI Integration


### PR DESCRIPTION
### Motivation
- Clarify how to make a GitHub Actions job fail when a `curl` test returns a non-zero exit status by providing a concrete example in the CI/CD documentation.

### Description
- Add a short YAML snippet to `docs/CI-CD.md` showing a GitHub Actions step (`- name: Run Tests`) that runs `curl https://example.test/run` and fails the job if `curl` exits non-zero.

### Testing
- Documentation-only change; no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697835558bf88330b62ef1867a1074d2)