### PR TITLE
Fix Netlify build command to run Next.js build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
 [build]
   # Build from repo root to support pnpm workspaces
   base = "."
-  command = "corepack enable && pnpm install --frozen-lockfile --prod && pnpm --filter @infamous-freight/shared build && pnpm --filter web build"
+  command = "corepack enable && pnpm install --frozen-lockfile && pnpm --dir web run build"
   publish = "web/.next"
   # The Next.js Netlify plugin will set the functions output
 
@@ -57,12 +57,12 @@
 
 ## Contexts
 [context.production]
-  command = "corepack enable && pnpm install --frozen-lockfile --prod && pnpm --filter @infamous-freight/shared build && pnpm --filter web build"
+  command = "corepack enable && pnpm install --frozen-lockfile && pnpm --dir web run build"
   [context.production.environment]
     NODE_ENV = "production"
 
 [context.deploy-preview]
-  command = "corepack enable && pnpm install --frozen-lockfile --prod && pnpm --filter @infamous-freight/shared build && pnpm --filter web build"
+  command = "corepack enable && pnpm install --frozen-lockfile && pnpm --dir web run build"
 
 [context.branch-deploy]
-  command = "corepack enable && pnpm install --frozen-lockfile && pnpm --filter @infamous-freight/shared build && pnpm --filter web build"
+  command = "corepack enable && pnpm install --frozen-lockfile && pnpm --dir web run build"


### PR DESCRIPTION
### Motivation
- The Netlify build command was only installing dependencies and never ran the Next.js build, so `web/.next` was not generated and the Netlify Next.js plugin failed. 
- The build command needs to install workspace dependencies and then explicitly run the Next.js build from the `web` directory.

### Description
- Updated `netlify.toml` top-level `[build]` `command` to `corepack enable && pnpm install --frozen-lockfile && pnpm --dir web run build` so dependencies are installed and the `web` build runs. 
- Aligned the `production`, `deploy-preview`, and `branch-deploy` context `command` values to the same `pnpm --dir web run build` flow and removed the previous `--prod`/workspace-filtered build steps. 
- Target output (`publish = "web/.next"`) and plugin configuration were left unchanged.

### Testing
- No automated tests were run for this configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69783baad5f4833091233cfdae3d0171)