### PR TITLE
Fix Netlify build command to run web build via pnpm --filter

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
 [build]
   # Build from repo root to support pnpm workspaces
   base = "."
-  command = "corepack enable && pnpm install --frozen-lockfile && pnpm --dir web run build"
+  command = "corepack enable && pnpm install --frozen-lockfile && pnpm --filter web build"
   publish = "web/.next"
   # The Next.js Netlify plugin will set the functions output
 
@@ -57,12 +57,12 @@
 
 ## Contexts
 [context.production]
-  command = "corepack enable && pnpm install --frozen-lockfile && pnpm --dir web run build"
+  command = "corepack enable && pnpm install --frozen-lockfile && pnpm --filter web build"
   [context.production.environment]
     NODE_ENV = "production"
 
 [context.deploy-preview]
-  command = "corepack enable && pnpm install --frozen-lockfile && pnpm --dir web run build"
+  command = "corepack enable && pnpm install --frozen-lockfile && pnpm --filter web build"
 
 [context.branch-deploy]
-  command = "corepack enable && pnpm install --frozen-lockfile && pnpm --dir web run build"
+  command = "corepack enable && pnpm install --frozen-lockfile && pnpm --filter web build"


### PR DESCRIPTION
### Motivation
- Netlify builds were failing because the configured build command did not actually run a `pnpm` build subcommand; the change ensures the final step executes the `web` package build.

### Description
- Update `netlify.toml` to replace `pnpm --dir web run build` with `pnpm --filter web build` in the root `[build]` section and in the `production`, `deploy-preview`, and `branch-deploy` contexts, while leaving `publish = "web/.next"` intact.

### Testing
- No automated tests were run because this is a configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69783d38ddf08330b360f50012520db5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build configuration for improved consistency across deployment contexts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->