### PR TITLE
Build shared workspace before web in Netlify config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
 [build]
   # Build from repo root to support pnpm workspaces
   base = "."
-  command = "corepack enable && pnpm install --frozen-lockfile && pnpm --filter web build"
+  command = "corepack enable && pnpm install --frozen-lockfile && pnpm -r --filter @infamous-freight/shared build && pnpm --filter web build"
   publish = "web/.next"
   # The Next.js Netlify plugin will set the functions output
 
@@ -57,12 +57,12 @@
 
 ## Contexts
 [context.production]
-  command = "corepack enable && pnpm install --frozen-lockfile && pnpm --filter web build"
+  command = "corepack enable && pnpm install --frozen-lockfile && pnpm -r --filter @infamous-freight/shared build && pnpm --filter web build"
   [context.production.environment]
     NODE_ENV = "production"
 
 [context.deploy-preview]
-  command = "corepack enable && pnpm install --frozen-lockfile && pnpm --filter web build"
+  command = "corepack enable && pnpm install --frozen-lockfile && pnpm -r --filter @infamous-freight/shared build && pnpm --filter web build"
 
 [context.branch-deploy]
-  command = "corepack enable && pnpm install --frozen-lockfile && pnpm --filter web build"
+  command = "corepack enable && pnpm install --frozen-lockfile && pnpm -r --filter @infamous-freight/shared build && pnpm --filter web build"


### PR DESCRIPTION
### Motivation
- Ensure the `@infamous-freight/shared` workspace is built before the `web` package during Netlify builds so the web app has the latest shared artifacts.

### Description
- Update `netlify.toml` build commands (root `[build]`, `[context.production]`, `[context.deploy-preview]`, and `[context.branch-deploy]`) to run `corepack enable && pnpm install --frozen-lockfile && pnpm -r --filter @infamous-freight/shared build && pnpm --filter web build`.

### Testing
- No automated tests were run because this is a configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978511841248330b6f0f649ccb1cdb6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to ensure complete compilation of all interdependent components during deployment, enhancing consistency and reliability across all deployment environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->