### PR TITLE
Add Netlify Neon example snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ Infamous Freight operates a multi-platform, enterprise-grade CI/CD pipeline desi
    - `YUNBOX_TOKEN` and `YUNBOX_SITE_ID` (per plugin docs)
    - Optionally set `NEXT_PUBLIC_API_URL` and `NEXT_PUBLIC_API_BASE` to your public API.
 
+### 🗄️ Netlify + Neon Database Access
+- Netlify can auto-provide `NETLIFY_DATABASE_URL` for Neon.
+- Example query using the Netlify Neon client:
+
+```js
+import { neon } from '@netlify/neon';
+const sql = neon(); // automatically uses env NETLIFY_DATABASE_URL
+
+const [post] = await sql`SELECT * FROM posts WHERE id = ${postId}`;
+```
+
 > **🎉 100% AUTO-DEPLOYMENT READY!** All platforms configured with smart change detection. Push to `main` to deploy automatically!
 
 **Quick Start:**


### PR DESCRIPTION
### Motivation
- Document how to access a Neon database on Netlify via the auto-provided `NETLIFY_DATABASE_URL` and provide a small usage example for developers.

### Description
- Added a new README section `Netlify + Neon Database Access` that notes `NETLIFY_DATABASE_URL` availability and includes a concise `@netlify/neon` client example snippet.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69785926891c8330b3ac6f689071a6dc)