### PR TITLE
Tighten Netlify plugin config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -11,7 +11,3 @@
 
 [[plugins]]
   package = "@netlify/plugin-nextjs"
-
-# Optional: only keep if you truly use these
-# [[plugins]]
-# package = "@netlify/plugin-lighthouse"


### PR DESCRIPTION
### Motivation
- Ensure the repository is the source of truth for Netlify plugins and prevent UI-added plugins (such as `strapi-plugin-netlify-deployments`) from being referenced by simplifying `netlify.toml` to only declare the Next.js plugin.

### Description
- Remove the commented optional plugin block from `netlify.toml`, leaving only the `[[plugins]]` entry with `package = "@netlify/plugin-nextjs"`.

### Testing
- No automated tests were run because this is a config-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69785b4a3128833093b4fe9b7821034b)