### PR TITLE
fix(web): remove unused getTrendColor helper

### DIFF
--- a/web/components/RevenueMonitorDashboard.tsx
+++ b/web/components/RevenueMonitorDashboard.tsx
@@ -128,10 +128,6 @@ export const RevenueMonitorDashboard: React.FC = () => {
     return `${(value * 100).toFixed(1)}%`;
   };
 
-  const getTrendColor = (value: number) => {
-    return value >= 0 ? "text-green-600" : "text-red-600";
-  };
-
   const getTrendIcon = (value: number) => {
     return value >= 0 ? "↑" : "↓";
   };


### PR DESCRIPTION
### Motivation
- Remove an unused helper that caused a TypeScript "declared but its value is never read" error which was blocking the Netlify build.

### Description
- Deleted the `getTrendColor` function from `web/components/RevenueMonitorDashboard.tsx` to resolve the unused-symbol TypeScript error and unblocks CI/build.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978650b7cf483308e0c729251f934fc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed unused utility function from the Revenue Monitor Dashboard. Color handling for trend indicators is now managed through existing inline logic, resulting in cleaner code with no impact on user-facing behavior or functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->