### PR TITLE
Remove unused getTrendIcon helper from RevenueMonitorDashboard

### DIFF
--- a/web/components/RevenueMonitorDashboard.tsx
+++ b/web/components/RevenueMonitorDashboard.tsx
@@ -128,10 +128,6 @@ export const RevenueMonitorDashboard: React.FC = () => {
     return `${(value * 100).toFixed(1)}%`;
   };
 
-  const getTrendIcon = (value: number) => {
-    return value >= 0 ? "↑" : "↓";
-  };
-
   return (
     <div className="min-h-screen bg-gray-50 p-6">
       {/* Header */}


### PR DESCRIPTION
### Motivation
- Remove dead/unused helper to keep the component lean and avoid unused symbol noise in `RevenueMonitorDashboard.tsx`.

### Description
- Deleted the unused `getTrendIcon` helper function from `web/components/RevenueMonitorDashboard.tsx` and updated the file accordingly.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978683e268c8330a3ec18f4e3554c45)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed unused internal code in the Revenue Monitor Dashboard to streamline the codebase. No visible changes to functionality or user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->