### PR TITLE
Fix Vercel build validation script pathing

### DIFF
--- a/vercel.config.ts
+++ b/vercel.config.ts
@@ -1,4 +1,4 @@
 export const config = {
   buildCommand:
-    'cd web && bash scripts/validate-build.sh && cd .. && pnpm --filter web build',
+    'if [ -d web ]; then bash web/scripts/validate-build.sh && pnpm --filter web build; else bash scripts/validate-build.sh && pnpm build; fi',
 };

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
-  "buildCommand": "if [ -d web ]; then cd web; fi; bash scripts/validate-build.sh && pnpm build",
+  "buildCommand": "if [ -d web ]; then bash web/scripts/validate-build.sh && pnpm --filter web build; else bash scripts/validate-build.sh && pnpm build; fi",
   "devCommand": "if [ -d web ]; then pnpm --filter web dev; else pnpm dev; fi",
   "installCommand": "if [ -f pnpm-workspace.yaml ]; then pnpm install --frozen-lockfile --filter web...; elif [ -f ../pnpm-workspace.yaml ]; then cd .. && pnpm install --frozen-lockfile --filter web...; else pnpm install --frozen-lockfile; fi",
   "outputDirectory": "web/.next",


### PR DESCRIPTION
### Motivation
- Ensure the Vercel build command works whether the deployment runs from the repository root or from the `web` subdirectory so the pre-build validation script is located and executed correctly.

### Description
- Update the `buildCommand` in `vercel.json` and `vercel.config.ts` to test for a `web` directory and run `bash web/scripts/validate-build.sh` with `pnpm --filter web build` when present, otherwise run `bash scripts/validate-build.sh` with `pnpm build`.

### Testing
- No automated tests were run because this is a configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69786b0a7f84833084788ebd8f31b004)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build configuration to support flexible project layouts. The build system now intelligently adapts based on your repository structure, automatically detecting whether a web subdirectory exists and adjusting the build process accordingly. This ensures consistent deployment behavior across different project configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->