### PR TITLE
chore(netlify): simplify build command for monorepo

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "corepack enable && pnpm install --frozen-lockfile && pnpm -r --filter @infamous-freight/shared build && pnpm --filter web build"
+  command = "pnpm -r --filter @infamous-freight/shared build && pnpm --filter web build"
   publish = "web/.next"
 
 [build.environment]


### PR DESCRIPTION
### Motivation
- Avoid redundant package installs during Netlify builds by simplifying the build command to run only the monorepo build steps, improving speed and reducing potential build instability.

### Description
- Updated `netlify.toml` to set the build command to `pnpm -r --filter @infamous-freight/shared build && pnpm --filter web build` (removed the extra `corepack enable` and `pnpm install` steps).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697876899374833085cac0d3d35c305b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Netlify build configuration to streamline the deployment process while maintaining existing build targets and environment settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->