### PR TITLE
Allow Vercel to access api directory

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -9,7 +9,6 @@ pnpm-lock.yaml.orig
 
 src/apps/api
 src/apps/mobile
-api
 mobile
 
 # Build outputs (keep web .next)


### PR DESCRIPTION
### Motivation
- Remove `api` from `.vercelignore` so Vercel project roots set to `api` are available during builds.

### Description
- Update ` .vercelignore` by deleting the `api` entry so the repository's `api` directory is not excluded from Vercel deployments.

### Testing
- No automated tests were run for this change since it only updates the ignore list for deployments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697879a1d8a083309fd232394efa59af)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to modify how application resources are bundled during the build process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->