### PR TITLE
Phase 8: Add Go‑To‑Market content and update homepage & onboarding for AI‑first positioning

### DIFF
--- a/docs/customer-onboarding/ONBOARDING_SYSTEM.md
+++ b/docs/customer-onboarding/ONBOARDING_SYSTEM.md
@@ -10,7 +10,7 @@
 
 **Problem**: 40% of free trials never activate (no action in first 7 days)
 **Root Cause**: Confusing setup, unclear value proposition
-**Solution**: Guided onboarding to first "aha moment" in <7 days
+**Solution**: Guided onboarding to first "aha moment" in <7 days, anchored on the AI-first Freight Intelligence Platform promise (dispatch + finance + AI + compliance in one system).
 
 ### Time-to-Value Timeline
 
@@ -45,23 +45,23 @@ TOUCHPOINT 1: Welcome Email (Within 1 hour of signup)
     - What to expect (5-day onboarding journey)
     - Quick start guide link
     - Success manager intro & contact info
-  • CTA: "Log in and create your first shipment"
+  • CTA: "Log in and trigger your first AI audit"
 
 TOUCHPOINT 2: In-App Welcome Modal (On first login)
-  • Headline: "Welcome! Let's get your first shipment tracked"
+  • Headline: "Welcome! Let's activate your first AI audit"
   • Subheading: "It takes 2 minutes. Here's how:"
-  • CTA: "Create first shipment" or "Skip, show me around"
+  • CTA: "Run AI audit" or "Skip, show me around"
   • Video: 60-second product overview
 
-ONBOARDING TASK: Create First Shipment
+ONBOARDING TASK: Run AI Invoice Audit
   • Guided workflow:
-    Step 1: Enter shipment details (origin, destination, weight)
-    Step 2: Select carrier (FedEx, UPS, etc.)
-    Step 3: Track shipment real-time
-    Step 4: View shipment map
+    Step 1: Upload a recent invoice (PDF or CSV)
+    Step 2: AI flags anomalies + compliance risks
+    Step 3: Review savings + profitability impact
+    Step 4: Share branded report with team
   • Estimated time: 5 minutes
-  • Success: "🎉 Shipment created! You're tracking your first delivery"
-  • Incentive: "Now let's invite your team" (next step)
+  • Success: "🎉 Audit complete! You just saved revenue"
+  • Incentive: "Now let's invite your dispatch team" (next step)
 ```
 
 ### Day 2-3: Competency Building
@@ -148,9 +148,9 @@ TOUCHPOINT 8: Expansion Offer Email (Day 7 - Monday, if active)
 ### Critical Activation Events
 
 ```
-MILESTONE 1: Day 1 - "First Shipment"
-  • Metric: 80% of new signups create a shipment within 24 hours
-  • Impact: High correlation with conversion (80% → paid vs 15% no shipment)
+MILESTONE 1: Day 1 - "First AI Audit"
+  • Metric: 80% of new signups run an AI invoice audit within 24 hours
+  • Impact: High correlation with conversion (80% → paid vs 15% no audit)
   • How to measure: Event tracking in GA4 / product analytics
 
 MILESTONE 2: Day 3 - "Team Invite"
@@ -188,7 +188,7 @@ OVERALL:
   • On-track to convert: [X]%
 
 MILESTONE COMPLETION:
-  • Day 1 shipment creation: [X]% (target: 80%)
+  • Day 1 AI audit: [X]% (target: 80%)
   • Day 3 team invite: [X]% (target: 60%)
   • Day 5 report generation: [X]% (target: 50%)
   • Day 7 ROI calculation: [X]% (target: 40%)
@@ -291,4 +291,3 @@ CONVERSION RATE:
 
 Guided 7-day activation journey with milestones, segmented paths, and
 metrics to achieve 60%+ activation rate and 20%+ trial-to-paid conversion.
-

--- a/docs/pitch-deck-content.md
+++ b/docs/pitch-deck-content.md
@@ -1,4 +1,4 @@
-# Infæmous Synthetic Intelligence Platform – Pitch Deck
+# Infæmous Freight Intelligence Platform – Pitch Deck
 
 Below is production-ready content for PDF export. Slides are structured so design can be applied directly.
 
@@ -6,97 +6,103 @@ Below is production-ready content for PDF export. Slides are structured so desig
 
 ## Slide 1 — Title
 
-**Infæmous Synthetic Intelligence Platform**  
-AI Operating System for Logistics & Freight
+**Infæmous Freight**  
+The AI-first Freight Intelligence Platform
 
 ---
 
 ## Slide 2 — Problem
 
-Logistics companies suffer from:
+Freight operators struggle with:
 
-- Reactive dispatch
-- Driver inefficiency
-- No intelligence continuity
-- Fragmented systems
+- Fragmented dispatch, finance, and compliance systems
+- Manual invoice audits and revenue leakage
+- Limited lane pricing intelligence
+- Lack of real-time profitability visibility
 
 ---
 
 ## Slide 3 — Solution
 
-A persistent AI operator with:
+**Dispatch. Finance. AI. Compliance. All in one system.**
 
-- Memory
-- Avatars
-- Coaching
-- Dispatch intelligence
-- Revenue optimization
+Infæmous Freight unifies dispatch automation, financial intelligence, and synthetic AI avatars in a single control plane.
 
 ---
 
 ## Slide 4 — Product
 
-- Driver Avatars
-- Live Coaching AI
-- Autonomous Dispatch
-- Memory-backed decisions
-- Voice-enabled operations
+- AI-powered dispatch + optimization
+- Automated invoice audits + fraud detection
+- Real-time profitability engine
+- Genesis synthetic intelligence avatars
+- Autonomous ops-ready workflows
 
 ---
 
-## Slide 5 — Technology Moat
+## Slide 5 — Differentiators
 
-- Persistent memory graph
-- Avatar evolution layer
-- Freight-specific AI skills
-- Action-first intelligence
-- Vendor-agnostic AI stack
+- AI-native freight intelligence core
+- Fintech-grade financial engine (not bolt-on)
+- Multi-modal SaaS + AI + fintech hybrid
+- Compliance automation with enterprise controls
+- Data network effects across lanes + carriers
 
 ---
 
 ## Slide 6 — Market
 
 - $800B+ global logistics market
-- SMB → Enterprise scalability
-- High automation demand
+- Multi-modal expansion: maritime, rail, air, intermodal
+- US → Canada → EU → LATAM scale path
 
 ---
 
 ## Slide 7 — Business Model
 
-- SaaS subscriptions
-- Usage-based AI billing
-- Per-driver pricing
-- Enterprise contracts
+- SaaS subscriptions by seat + fleet size
+- Usage-based AI credits
+- Fintech revenue via invoicing + payouts
+- Enterprise contracts + pilots
 
 ---
 
-## Slide 8 — Traction (Positioning)
+## Slide 8 — Go-To-Market
 
-- Freight-native architecture
-- Enterprise-ready security
-- Modular deployment
-- White-label capable
-
----
-
-## Slide 9 — Expansion
-
-- Autonomous fleets
-- Predictive maintenance
-- AI dispatch centers
-- Cross-industry licensing
+- B2B: cold email, LinkedIn outbound, factoring + insurance partners
+- B2C: app stores, creator-driven content, referral bonuses
+- Lead magnets: AI Invoice Audit Tool, Profitability Calculator, Compliance Scanner
+- Funnel: landing page → demo → trial → AI wow moment → paid → expansion
 
 ---
 
-## Slide 10 — Vision
+## Slide 9 — Sales Motion
 
-Replace fragmented logistics software with one intelligent operating system.
+- SMB: self-serve + inside sales
+- Mid-market: demo + sales rep
+- Enterprise: 30–60 day pilot + SLA + custom AI + integrations
+
+---
+
+## Slide 10 — Data Moat
+
+- Lane pricing data
+- Carrier reliability scores
+- Fraud patterns
+- Delivery performance metrics
+
+This compounds into defensible pricing, automation, and AI superiority.
+
+---
+
+## Slide 11 — Vision
+
+Build the Bloomberg Terminal of Freight AI.
 
 ---
 
 ## PDF Export Notes
 
 - Brand with Infæmous Freight palette.
-- Add route diagrams, memory graph visual, and avatar coaching mockups.
+- Add AI audit dashboard, profitability engine visuals, and Genesis avatar mockups.
 - Export in investor-ready format (print-safe margins, selectable text).

--- a/docs/revenue-operations/GO_TO_MARKET_ENGINE.md
+++ b/docs/revenue-operations/GO_TO_MARKET_ENGINE.md
@@ -1,0 +1,202 @@
+# Phase 8 — Go-To-Market, Growth, and Market Domination Engine
+
+## 1) Market Positioning (How We Win)
+
+**Infæmous Freight — the AI-first Freight Intelligence Platform**
+Dispatch. Finance. AI. Compliance. All in one system.
+
+**Core Differentiators**
+
+- AI-powered dispatch + audit + optimization
+- Real-time financial engine (not bolt-on)
+- Genesis synthetic intelligence avatars
+- Multi-modal SaaS + AI + Fintech hybrid
+- Fully autonomous ops-ready
+
+**Positioning Message**
+
+> We are not another TMS. Infæmous Freight is the AI-native control plane for freight operations and finance, built to compound revenue and operational intelligence.
+
+---
+
+## 2) User Acquisition Engine (B2B + B2C Hybrid)
+
+### A) B2B (Carriers, Brokers, Fleets)
+
+**Primary Channels**
+
+- Cold email → demo → close
+- LinkedIn outbound
+- Partnerships (factoring companies, insurance providers)
+- Freight forums + communities
+
+**Lead Magnets**
+
+- AI Invoice Audit Tool (Free Trial)
+- Freight Profitability Calculator
+- Carrier Compliance Scanner
+
+### B) B2C (Drivers / Owner-Operators)
+
+**Primary Channels**
+
+- App Store + Play Store
+- TikTok / YouTube Shorts
+- Influencer trucking partnerships
+- Referral bonuses
+
+---
+
+## 3) Funnel Architecture (Stranger → Enterprise Client)
+
+Traffic → Landing Page (Value Prop) → Free Tool / Demo → Trial Account → AI wow moment → Paid Plan → Expansion (AI usage, more seats, enterprise)
+
+**AI Wow Moment Definition**
+
+- First AI audit discovers revenue leakage
+- Profitability delta displayed in 60 seconds
+- Shareable report reinforces brand + referral loop
+
+---
+
+## 4) Viral Loops Built Into Product
+
+### A) Referral Engine
+
+- Invite a dispatcher → get 500 AI credits
+- Invite a carrier → get $50 off next invoice
+- Tiered referral rewards (credits + cash)
+
+### B) In-App Sharing
+
+- Share AI audit reports
+- Share dispatch performance dashboards
+- Share invoices with branded footer
+
+Every shared artifact becomes a marketing surface.
+
+---
+
+## 5) Sales System (Enterprise-Ready)
+
+### A) Sales Motion Types
+
+| Client Type | Motion |
+| --- | --- |
+| SMBs | Self-serve + inside sales |
+| Mid-Market | Demo + sales rep |
+| Enterprise | Contract + pilots + SLA |
+
+### B) Enterprise Deal Flow
+
+1. Discovery call
+2. Pilot (30–60 days)
+3. Custom AI + integrations
+4. Contract + rollout
+5. Expansion + upsell
+
+---
+
+## 6) Content + Authority Engine (Brand Power)
+
+### A) Thought Leadership
+
+Publish:
+
+- "AI in Freight" reports
+- Dispatch optimization case studies
+- AI audit results comparisons
+
+### B) Media Formats
+
+- YouTube: "AI runs a freight company"
+- TikTok: AI catching invoice fraud
+- LinkedIn: weekly freight insights
+
+**Positioning**: Become the voice of AI in Freight.
+
+---
+
+## 7) Partnerships + Strategic Moats
+
+**Partner Categories**
+
+- Factoring companies
+- Insurance providers
+- Telematics (ELD, GPS)
+- Fuel card networks
+- Brokerages
+
+**Partner Outcomes**
+
+- Brings users
+- Deepens data moat
+- Blocks competitors
+
+---
+
+## 8) Data Network Effects (Long-Term Advantage)
+
+**Data Accumulation**
+
+- Lane pricing data
+- Carrier reliability scores
+- Fraud patterns
+- Delivery performance metrics
+
+**AI Outcomes**
+
+- Better automation
+- Better pricing
+- Better fraud detection
+- Unbeatable defensibility
+
+**Vision**: The Bloomberg Terminal of Freight AI.
+
+---
+
+## 9) Expansion Strategy
+
+### A) Vertical Expansion
+
+- Maritime
+- Rail
+- Air cargo
+- Intermodal
+
+### B) Geographic Expansion
+
+- US → Canada → EU → LATAM
+
+---
+
+## 10) Funding + Scale Path (Optional)
+
+### Bootstrapped
+
+- Reinvest AI revenue
+- Keep burn low
+- Scale profitably
+
+### Raising Capital
+
+**Story**
+
+> We built the first AI-native Freight Intelligence System with built-in monetization, fintech, and autonomous ops.
+
+**Target**
+
+- Seed / Series A
+- AI + logistics crossover investors
+
+---
+
+## Phase 8 Completion Criteria
+
+✅ Clear market positioning  
+✅ Growth funnel defined  
+✅ Referral engine active  
+✅ Sales motion operational  
+✅ Content authority launched  
+✅ Partner pipeline defined  
+✅ Data moat strategy active

--- a/docs/sales-operations/SALES_OPERATIONS_PLAYBOOK.md
+++ b/docs/sales-operations/SALES_OPERATIONS_PLAYBOOK.md
@@ -7,6 +7,36 @@
 
 ---
 
+## Phase 8 Positioning & Outreach Messaging
+
+**Positioning Statement**
+
+Infæmous Freight is the AI-first Freight Intelligence Platform — dispatch, finance, AI, and compliance in one system. We are not another TMS.
+
+**Outbound Email (B2B)**
+
+Subject: Cut freight leakage with AI-first audits + dispatch
+
+Hi {{FirstName}},
+
+Infæmous Freight replaces fragmented dispatch, finance, and compliance tools with one AI-first Freight Intelligence Platform. We automate dispatch optimization and invoice audits while surfacing real-time profitability.
+
+Would a 15-minute walkthrough help you see where AI can recover margin this quarter?
+
+– {{SenderName}}
+
+**LinkedIn Connection Note (B2B)**
+
+Hi {{FirstName}} — we built an AI-first freight intelligence platform that unifies dispatch + finance + compliance. Open to share a 3-minute AI audit demo?
+
+**Call Talk Track (Discovery)**
+
+- Identify revenue leakage in dispatch + invoicing
+- Show AI audit report with savings estimate
+- Map integration timeline + pilot scope
+
+---
+
 ## Current Sales State (Jan 2026)
 
 ### Baseline Metrics
@@ -718,4 +748,3 @@ KR4: Reduce sales cycle from 14 → 10 days
 
 Comprehensive sales process with BANT/MEDDIC qualification, 5-stage pipeline,
 CRM workflows, and sales enablement to scale ARR from $1.8M to $5.4M in 2026.
-

--- a/docs/website/SALES_WEBSITE_COPY.md
+++ b/docs/website/SALES_WEBSITE_COPY.md
@@ -4,39 +4,104 @@
 
 **Headline**
 
-Infæmous Freight — The AI-Native Operating System for Logistics
+Infæmous Freight — The AI-first Freight Intelligence Platform
 
 **Subheading**
 
-Automate dispatch, billing, fleet management, and AI decision-making in one enterprise-ready platform.
+Dispatch. Finance. AI. Compliance. All in one system. AI-powered dispatch, audit, and optimization with a real-time financial engine.
 
 **CTA**
 
 - 🚀 Request a Demo
 - 📞 Talk to Sales
+- ⚡️ Try the AI Invoice Audit Tool (Free)
+
+---
+
+## Positioning Strip
+
+**You are not "another TMS."**
+Infæmous Freight unifies AI dispatch, finance, compliance, and synthetic intelligence avatars (Genesis) into a multimodal SaaS + AI + fintech platform.
+
+**Core Differentiators**
+
+- AI-powered dispatch + audit + optimization
+- Real-time financial engine (not bolt-on)
+- Genesis synthetic intelligence avatars
+- Fully autonomous ops readiness
+- Multi-modal SaaS + AI + Fintech hybrid
+
+---
 
 ## Product Page
 
 **What We Do**
 
-Infæmous Freight replaces fragmented logistics software with a single AI-powered operating system built for scale, compliance, and profitability.
+Infæmous Freight replaces fragmented logistics software with a single AI-first freight intelligence system that compounds revenue and performance.
 
 **Core Capabilities**
 
-- AI Routing & Dispatch
-- Automated Billing
-- Voice-Driven Operations
-- Enterprise Security
-- AI Cost Controls
-- Global Deployments
+- AI Dispatch Optimization
+- Automated Invoice Audits & Fraud Detection
+- Real-Time Profitability Intelligence
+- Compliance Automation
+- Synthetic Intelligence Avatars (Genesis)
+- Enterprise Security & Governance
+
+---
+
+## Growth & Acquisition
+
+**B2B Channels (Carriers, Brokers, Fleets)**
+
+- Cold email → demo → close
+- LinkedIn outbound
+- Partnerships (factoring + insurance)
+- Freight forums + communities
+
+**B2C Channels (Drivers & Owner-Operators)**
+
+- App Store + Play Store
+- TikTok / YouTube Shorts
+- Influencer trucking partnerships
+- Referral bonuses + in-app rewards
+
+**Lead Magnets**
+
+- AI Invoice Audit Tool (Free Trial)
+- Freight Profitability Calculator
+- Carrier Compliance Scanner
+
+---
+
+## Funnel Architecture
+
+Traffic → Landing Page → Free Tool / Demo → Trial Account → AI wow moment → Paid Plan → Expansion (AI usage, more seats, enterprise)
+
+---
+
+## Viral Loops & Referral Engine
+
+- Invite a dispatcher → get 500 AI credits
+- Invite a carrier → get $50 off next invoice
+- Tiered rewards by usage
+- In-app sharing of AI audit reports, dispatch dashboards, and branded invoices
+
+---
 
 ## Enterprise Page
 
 **Why Enterprises Choose Infæmous Freight**
 
-- SOC2-ready
+- SOC2-ready controls
 - AI-native architecture
-- White-label support
 - Audit logs & RBAC
-- Custom AI agents
-- Dedicated support
+- Custom AI agents + integrations
+- Dedicated enterprise support
+- Pilot → contract → expansion motion
+
+---
+
+## Data Network Effects
+
+As Infæmous Freight scales, it accumulates lane pricing, carrier reliability scores, fraud patterns, and delivery performance metrics. This becomes the intelligence moat that powers superior pricing, automation, and AI decisioning — the Bloomberg Terminal of Freight AI.

--- a/src/apps/web/pages/index.tsx
+++ b/src/apps/web/pages/index.tsx
@@ -3,8 +3,24 @@ import Link from "next/link";
 import { track } from "@vercel/analytics";
 import { AvatarGrid } from "../components/AvatarGrid";
 
+const sectionStyle = {
+  marginTop: "3rem",
+  padding: "1.5rem",
+  borderRadius: "1.5rem",
+  background: "rgba(15, 23, 42, 0.45)",
+  border: "1px solid rgba(148, 163, 184, 0.2)",
+} as const;
+
+const listStyle = {
+  margin: "0.75rem 0 0",
+  paddingLeft: "1.2rem",
+  lineHeight: 1.7,
+} as const;
+
 export default function Home() {
-  const appName = process.env.NEXT_PUBLIC_APP_NAME || "Infamous Freight AI";
+  const appName =
+    process.env.NEXT_PUBLIC_APP_NAME ||
+    "Infæmous Freight — AI Freight Intelligence Platform";
 
   useEffect(() => {
     // Track homepage visit
@@ -31,8 +47,9 @@ export default function Home() {
       style={{
         minHeight: "100vh",
         padding: "3rem",
-        maxWidth: "960px",
+        maxWidth: "980px",
         margin: "0 auto",
+        color: "#e2e8f0",
       }}
     >
       <header>
@@ -46,10 +63,11 @@ export default function Home() {
           {process.env.NEXT_PUBLIC_ENV || "Development"}
         </p>
         <h1 style={{ fontSize: "3rem", marginBottom: "0.5rem" }}>{appName}</h1>
-        <p style={{ maxWidth: "540px", lineHeight: 1.6 }}>
-          Command the Infamous Freight synthetic intelligence stack. Voice
-          automation, billing orchestration, fleet telemetry, and AI copilots
-          converge in a single control tower.
+        <p style={{ maxWidth: "620px", lineHeight: 1.7 }}>
+          Dispatch. Finance. AI. Compliance. All in one system. Infæmous Freight
+          orchestrates AI-powered dispatch, invoice audit automation, and
+          real-time financial intelligence so carriers, brokers, and fleets can
+          scale faster with autonomous ops readiness.
         </p>
         <div style={{ marginTop: "1.5rem", display: "flex", gap: "1rem" }}>
           <Link
@@ -75,10 +93,87 @@ export default function Home() {
               color: "#f9fafb",
             }}
           >
-            Billing
+            View Pricing
           </Link>
         </div>
       </header>
+
+      <section style={sectionStyle}>
+        <h2 style={{ margin: 0 }}>Market Positioning</h2>
+        <p style={{ marginTop: "0.75rem", lineHeight: 1.7 }}>
+          You are not "another TMS." Infæmous Freight is the AI-first Freight
+          Intelligence Platform — a multimodal SaaS + AI + fintech hybrid built
+          for fully autonomous operations.
+        </p>
+        <ul style={listStyle}>
+          <li>AI-powered dispatch, audit, and lane optimization.</li>
+          <li>Real-time financial engine with cash-flow visibility.</li>
+          <li>Genesis synthetic intelligence avatars for every role.</li>
+          <li>Compliance automation with enterprise-grade controls.</li>
+        </ul>
+      </section>
+
+      <section style={sectionStyle}>
+        <h2 style={{ margin: 0 }}>Acquisition Engine</h2>
+        <div style={{ display: "grid", gap: "1.5rem", marginTop: "1rem" }}>
+          <div>
+            <h3 style={{ margin: 0 }}>B2B: Carriers, Brokers, Fleets</h3>
+            <ul style={listStyle}>
+              <li>Cold email → demo → close sequences.</li>
+              <li>LinkedIn outbound and founder-led content.</li>
+              <li>Partnerships with factoring + insurance providers.</li>
+              <li>Freight communities, forums, and trade groups.</li>
+            </ul>
+          </div>
+          <div>
+            <h3 style={{ margin: 0 }}>B2C: Drivers & Owner-Operators</h3>
+            <ul style={listStyle}>
+              <li>App Store & Play Store acquisition loops.</li>
+              <li>TikTok / YouTube Shorts showing AI catching fraud.</li>
+              <li>Influencer trucking partnerships + referral bonuses.</li>
+              <li>In-app profit calculators and AI dispatch tips.</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section style={sectionStyle}>
+        <h2 style={{ margin: 0 }}>Funnel Architecture</h2>
+        <ol style={listStyle}>
+          <li>Traffic → landing page with crisp value prop.</li>
+          <li>Free tool or demo (AI audit, profitability calculator).</li>
+          <li>Trial account with a guided AI wow moment.</li>
+          <li>Paid plan → expansion into more seats + AI usage.</li>
+        </ol>
+      </section>
+
+      <section style={sectionStyle}>
+        <h2 style={{ margin: 0 }}>Viral Loops & Referral Engine</h2>
+        <ul style={listStyle}>
+          <li>Invite a dispatcher → earn 500 AI credits.</li>
+          <li>Invite a carrier → $50 off next invoice.</li>
+          <li>Share AI audit reports + branded invoices to spread the brand.</li>
+        </ul>
+      </section>
+
+      <section style={sectionStyle}>
+        <h2 style={{ margin: 0 }}>Enterprise-Ready Sales System</h2>
+        <ul style={listStyle}>
+          <li>SMBs: self-serve + inside sales.</li>
+          <li>Mid-market: demo + sales rep.</li>
+          <li>Enterprise: pilots, SLA, custom AI + integrations.</li>
+        </ul>
+      </section>
+
+      <section style={sectionStyle}>
+        <h2 style={{ margin: 0 }}>Data Network Effects</h2>
+        <p style={{ marginTop: "0.75rem", lineHeight: 1.7 }}>
+          Every shipment compounds intelligence: lane pricing, carrier
+          reliability, fraud signals, and delivery performance. This data moat
+          powers better AI, better pricing, and the Bloomberg Terminal of Freight
+          AI.
+        </p>
+      </section>
 
       <AvatarGrid />
     </main>


### PR DESCRIPTION
### Motivation
- Align product messaging and sales enablement with Phase 8: an AI‑first Freight Intelligence Platform positioning (dispatch + finance + AI + compliance). 
- Turn the onboarding funnel toward an immediate AI "wow moment" (AI invoice audit) to increase trial activation and trial→paid conversion. 
- Provide a single reference for the Go‑To‑Market playbook so sales, partnerships, and marketing can execute consistent outreach and growth motions.

### Description
- Updated web homepage to surface Phase 8 positioning, acquisition channels, funnel architecture, referral loops, sales motion, and data moat messaging in `src/apps/web/pages/index.tsx`.
- Revised public website copy in `docs/website/SALES_WEBSITE_COPY.md` and pitch deck content in `docs/pitch-deck-content.md` to reflect the AI‑first Freight Intelligence Platform narrative and lead magnets (e.g., AI Invoice Audit Tool).
- Reworked onboarding activation flow in `docs/customer-onboarding/ONBOARDING_SYSTEM.md` to prioritize an initial `Run AI Invoice Audit` task, updated milestones (Day 1 AI audit), and adjusted CTAs.
- Added a Phase 8 Go‑To‑Market engine doc at `docs/revenue-operations/GO_TO_MARKET_ENGINE.md` and inserted outbound messaging and talk tracks into `docs/sales-operations/SALES_OPERATIONS_PLAYBOOK.md` for B2B outreach.

### Testing
- Attempted to run the frontend dev server with `pnpm --filter infamous-freight-web dev -- --hostname 0.0.0.0 --port 3000`, which failed due to a local Node.js engine mismatch (package expects Node 20.x; environment had v22.21.1), so the site could not be validated locally.
- No unit or integration tests were executed because the local Node environment prevented starting the dev server; no code-level test runners were invoked in this rollout.
- Static/manual checks performed: files saved, syntax kept TypeScript/JSX valid for the edited files and new documentation added; no automated test failures were produced because tests were not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978865f7234833094789a553497ea23)