### PR TITLE
Add Phase 9 Autonomous AI Company blueprint (docs)

### DIFF
--- a/ai/README.md
+++ b/ai/README.md
@@ -198,6 +198,12 @@ AI roles are:
 
 ### Phase 3: Advanced Features
 
+## Phase 9: Autonomous AI Company
+
+Phase 9 expands the AI role scaffolding into a self-operating AI enterprise with an orchestrator, domain agents, and governed autonomy. See the Phase 9 blueprint for role mapping, orchestration, and auditability requirements.
+
+- **Phase 9 blueprint:** `docs/PHASE_9_AUTONOMOUS_AI_COMPANY.md`
+
 - Multi-role coordination
 - Learning from human overrides
 - Adaptive confidence thresholds

--- a/docs/PHASE_9_AUTONOMOUS_AI_COMPANY.md
+++ b/docs/PHASE_9_AUTONOMOUS_AI_COMPANY.md
@@ -1,0 +1,215 @@
+# Phase 9: Autonomous AI Company (100%)
+
+## Vision
+
+Infæmous Freight evolves from SaaS + AI tooling into a self-operating AI enterprise. Humans supervise, AI executes, and systems continuously optimize operations, finance, and customer outcomes.
+
+## Deliverables Overview
+
+### 1) AI Organizational Structure (Digital Workforce)
+
+| AI Agent | Function | Authority Scope | Primary Signals |
+| --- | --- | --- | --- |
+| **Genesis ♊️** | Orchestrator (CEO AI) | Dispatches domain agents, enforces policy gates, validates output | Company OKRs, risk tiers, audit history |
+| **Atlas** | Ops Optimization | Improves throughput, utilization, and service levels | Fleet metrics, SLAs, capacity |
+| **Hermes** | Dispatch & Routing | Assigns loads, re-routes, balances constraints | Load data, driver HOS, traffic/ETA |
+| **Aegis** | Security + Compliance | Enforces policy, detects violations | Security events, compliance rules |
+| **Oracle** | Financial Intelligence | Profitability, pricing, margin leak detection | MRR, burn, margin, cost-to-serve |
+| **Sentinel** | Monitoring + Recovery | Detects outages, triggers self-healing | Uptime, latency, error rates |
+| **Echo** | Customer Success | Support automation, churn prevention | Tickets, NPS, churn predictors |
+| **Archivist** | Audit + Reporting | Tamper-evident logs, reporting | Decision logs, outcomes, policy refs |
+
+> **Implementation note:** The current AI role scaffolding lives under `ai/` and `docs/ai-boundaries.md`. Phase 9 adds an orchestration layer (Genesis) and extends governance and auditability to every AI-driven action.
+
+### 2) AI Orchestration Layer
+
+**Command Hierarchy**
+
+```
+Genesis (Orchestrator)
+   ↓
+Domain AI Agents
+   ↓
+Task Executors
+   ↓
+Infrastructure APIs
+```
+
+**Genesis Responsibilities**
+
+- Selects the correct domain agent for the task.
+- Enforces authority scopes and policy checks.
+- Validates outputs with confidence thresholds.
+- Routes escalations to humans when risk exceeds thresholds.
+
+### 3) AI Decision Framework (Safe Autonomy)
+
+Every AI action must pass:
+
+1. **Policy Check** (allowed action + scope validation)
+2. **Risk Threshold Check** (impact-based risk gating)
+3. **Confidence Score Check** (model confidence validation)
+4. **Human Approval** (required for high-risk actions)
+5. **Execution + Audit Log** (immutable trace)
+
+**Outcome:** prevents rogue actions, financial mistakes, and regulatory violations.
+
+### 4) AI-Driven Operations
+
+#### A) Dispatch Autonomy (Hermes)
+
+- Assigns loads to drivers
+- Re-routes in real-time
+- Balances fatigue, fuel, and ETA constraints
+
+**Human involvement:** exception review only.
+
+#### B) AI Invoice + Fraud Engine (Oracle + Aegis)
+
+- Audits invoices
+- Flags anomalies and fraud risks
+- Auto-approves low-risk payments
+
+**Human involvement:** handles flagged edge cases.
+
+### 5) AI-Driven Finance (Oracle)
+
+Oracle tracks:
+
+- MRR
+- Burn
+- Profit per load
+- AI cost vs revenue
+- Payout health
+
+Oracle can:
+
+- Adjust pricing thresholds
+- Recommend tier changes
+- Detect margin leaks
+
+### 6) AI Hiring + Workforce Optimization
+
+#### A) AI Recruiter (Atlas + Oracle)
+
+- Screens candidates
+- Predicts retention likelihood
+- Recommends pay bands
+
+#### B) AI Performance Engine (Atlas)
+
+- Detects underperformance
+- Suggests training
+- Flags burnout risk
+
+Applies to both human employees and AI agents.
+
+### 7) AI Customer Support + Retention (Echo)
+
+- Handles 80–90% of support
+- Escalates complex issues
+- Predicts churn
+- Triggers retention offers
+
+### 8) AI Monitoring + Self-Healing (Sentinel)
+
+Continuously monitors:
+
+- API uptime
+- Latency
+- Error rates
+- Billing failures
+- AI hallucination risk
+
+Can:
+
+- Restart services
+- Roll back releases
+- Reroute traffic
+- Alert humans
+
+### 9) AI Governance + Auditability (Archivist)
+
+Every AI action produces:
+
+- Actor (AI name)
+- Decision reason
+- Confidence score
+- Policy reference
+- Timestamp
+- Outcome
+
+Provides enterprise auditability, legal defensibility, and investor confidence.
+
+### 10) Autonomous Business Loops (The Flywheel)
+
+```
+More Users
+ ↓
+More Data
+ ↓
+Smarter AI
+ ↓
+Better Performance
+ ↓
+Higher Revenue
+ ↓
+More AI Investment
+ ↓
+More Users
+```
+
+## Phase 9 Implementation Blueprint
+
+### A) Role-to-System Mapping
+
+| Phase 9 Role | Current System Anchor | Next Implementation Step |
+| --- | --- | --- |
+| Genesis | `ai/` orchestration + policy layer | Implement an orchestrator router with risk gating |
+| Hermes | `ai/dispatch/` | Expand dispatch decision logic + routing APIs |
+| Atlas | `ai/fleet-intel/` | Add ops optimization models and KPIs |
+| Echo | `ai/customer-ops/` | Integrate churn prediction and retention offers |
+| Oracle | `docs/AI_DECISION_TRACKING.md` + finance APIs | Extend decision tracking to invoices + pricing |
+| Aegis | `docs/ai-boundaries.md` | Add compliance checks & security event inputs |
+| Sentinel | monitoring stack | Add auto-recovery playbooks and alerts |
+| Archivist | decision tracking + audit storage | Expand immutable logging across all AI actions |
+
+### B) Governance Controls
+
+- **Policy registry**: enforce allowed actions per role.
+- **Risk tiers**: classify actions by impact (financial, safety, compliance).
+- **Human override**: always available for high-risk events.
+- **Audit trail**: persistent logs stored by Archivist.
+
+### C) Safe Autonomy Decision Flow
+
+```
+Request → Genesis → Role Policy Check
+                    ↓
+              Risk Assessment
+                    ↓
+          Confidence Validation
+                    ↓
+        [High Risk] → Human Approval
+                    ↓
+             Execute Action
+                    ↓
+               Audit Log
+```
+
+## Phase 9 Completion Criteria (100%)
+
+✅ AI agents mapped to real business roles
+✅ Genesis orchestrates domain AI
+✅ AI controls dispatch + finance + support
+✅ Human oversight only at exception points
+✅ AI actions are governed + audited
+✅ Business runs 24/7 with minimal human input
+
+## Next Actions
+
+- Implement Genesis orchestrator router (policy + risk gating).
+- Extend audit log schema for all AI actions.
+- Activate Hermes real-time reroute workflows.
+- Add Oracle finance intelligence dashboards.
+- Ship Sentinel self-healing automation hooks.


### PR DESCRIPTION
### Motivation

- Capture the Phase 9 vision to evolve the platform into a self-operating AI enterprise and provide a blueprint for orchestration, governance, and role mapping.

### Description

- Add `docs/PHASE_9_AUTONOMOUS_AI_COMPANY.md` containing the Phase 9 blueprint (AI roles, Genesis orchestrator, decision framework, governance, implementation blueprint, and next actions). 
- Link the Phase 9 blueprint from the AI scaffolding roadmap by updating `ai/README.md` to reference `docs/PHASE_9_AUTONOMOUS_AI_COMPANY.md`.

### Testing

- No automated tests were run because this is documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978868c522883308177ebfdfcb30e63)