### PR TITLE
Harden Supabase health_check RPC (security invoker + explicit search_path)

### DIFF
--- a/scripts/supabase-health-check.sql
+++ b/scripts/supabase-health-check.sql
@@ -6,6 +6,8 @@ create or replace function public.health_check()
 returns jsonb
 language sql
 stable
+security invoker
+set search_path = public
 as $$
   select jsonb_build_object(
     'ok', true,


### PR DESCRIPTION
### Motivation
- Ensure the Supabase `public.health_check()` RPC runs with caller privileges and a deterministic search path to prevent accidental privilege escalation and ambiguous schema resolution during migrations.

### Description
- Added `security invoker` and `set search_path = public` to the `public.health_check()` definition in `scripts/supabase-health-check.sql` so the function runs with the caller's rights and explicitly targets the `public` schema.

### Testing
- No automated tests were run for this SQL-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697da48350188330b0db4fc9cda70a6d)