### PR TITLE
docs: add GitHub OAuth + Supabase Auth setup

### DIFF
--- a/docs/GITHUB_SETTINGS.md
+++ b/docs/GITHUB_SETTINGS.md
@@ -182,6 +182,71 @@ NODE_VERSION=20
 PNPM_VERSION=8
 ```
 
+## 🔐 GitHub OAuth App (Supabase Auth)
+
+Use this when configuring GitHub OAuth for Supabase Auth.
+
+### GitHub OAuth App Settings
+
+**Application name**
+
+Infæmous Freight Enterprises  
+(If GitHub rejects “Æ”, use **Infamous Freight Enterprises**.)
+
+**Homepage URL (Website URL)**
+
+Use your production site URL:
+- https://infamous-freight.netlify.app
+- https://infamous-freight.vercel.app
+
+**Authorization callback URL (must match exactly)**
+
+```
+https://<YOUR-PROJECT-REF>.supabase.co/auth/v1/callback
+```
+
+Replace `<YOUR-PROJECT-REF>` with your Supabase project ref (the ID in your Supabase URL).
+
+**Example**
+
+```
+https://abcd1234efgh5678.supabase.co/auth/v1/callback
+```
+
+### Supabase Dashboard Settings (Must Match)
+
+Go to **Supabase → Authentication → Providers → GitHub** and add:
+- **Client ID** = from GitHub OAuth App
+- **Client Secret** = from GitHub OAuth App
+
+Then go to **Authentication → URL Configuration** and set:
+
+**Site URL**
+- https://infamous-freight.netlify.app
+- https://infamous-freight.vercel.app
+
+**Redirect URLs**
+- http://localhost:3000/**
+- https://infamous-freight.netlify.app/**
+- https://infamous-freight.vercel.app/**
+
+### Frontend Supabase JS Usage
+
+```ts
+await supabase.auth.signInWithOAuth({
+  provider: "github",
+  options: {
+    redirectTo: `${window.location.origin}/auth/callback`,
+  },
+});
+```
+
+On your `/auth/callback` page, call:
+
+```ts
+await supabase.auth.getSession();
+```
+
 ## 📊 Insights Settings
 
 Enable insights for better project visibility:


### PR DESCRIPTION
### Motivation

- Provide a paste-ready, copyable configuration for setting up GitHub OAuth to work with Supabase Auth and eliminate callback URL mismatches.

### Description

- Added a new `GitHub OAuth App (Supabase Auth)` section to `docs/GITHUB_SETTINGS.md` with recommended `Application name` and `Homepage URL` entries.
- Documented the exact `Authorization callback URL` format `https://<YOUR-PROJECT-REF>.supabase.co/auth/v1/callback` and an example URL.
- Added matching Supabase Dashboard instructions for the GitHub provider and required `Site URL` / `Redirect URLs` entries.
- Included a frontend usage snippet showing `supabase.auth.signInWithOAuth` and the `/auth/callback` flow with `supabase.auth.getSession()`.

### Testing

- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e461856f08330ae33f6c2d5e551c6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for configuring GitHub OAuth with Supabase Auth, covering application setup, authorization callbacks, dashboard configuration, and frontend integration examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->