### PR TITLE
chore: align Node and pnpm engines for DigitalOcean builds

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -2,6 +2,11 @@
   "name": "web",
   "version": "2.2.0",
   "private": true,
+  "packageManager": "pnpm@9.15.0",
+  "engines": {
+    "node": "22.x",
+    "pnpm": "9.15.0"
+  },
   "type": "module",
   "license": "Proprietary",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "infamous-freight",
   "private": true,
-  "packageManager": "pnpm@9.15.4",
+  "packageManager": "pnpm@9.15.0",
   "engines": {
-    "node": "20.20.0"
+    "node": "22.x",
+    "pnpm": "9.15.0"
   },
   "scripts": {
     "install:ci": "pnpm install --frozen-lockfile",


### PR DESCRIPTION
### Motivation
- Ensure the repository uses the Node and pnpm versions that DigitalOcean App Platform builds with to avoid runtime or installer drift.

### Description
- Update root `package.json` to set `packageManager` to `pnpm@9.15.0` and `engines` to `{"node": "22.x", "pnpm": "9.15.0"}`.
- Add matching `packageManager` and `engines` entries to `apps/web/package.json` to make the web app explicit about Node `22.x` and `pnpm@9.15.0`.
- Files modified: `package.json`, `apps/web/package.json`.

### Testing
- No automated tests were run because these are configuration-only metadata changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697da1b7db9c8330800cfccfef2b7080)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js version requirement to 22.x
  * Updated package manager specification to pnpm 9.15.0

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->