### PR TITLE
chore: align pnpm to 10.2.1 and enable shared workspace lockfile

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,5 @@
 engine-strict=true
+shared-workspace-lockfile=true
 strict-peer-dependencies=false
 auto-install-peers=true
 fund=false

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "infamous-freight",
   "private": true,
-  "packageManager": "pnpm@9.15.4",
+  "packageManager": "pnpm@10.2.1",
   "engines": {
-    "node": "20.20.0"
+    "node": "20.x"
   },
   "scripts": {
     "install:ci": "pnpm install --frozen-lockfile",


### PR DESCRIPTION
### Motivation
- Align the repository to pnpm 10 (lockfile v9 / pnpm 10 compatibility) and ensure monorepo install reliability on Vercel/Corepack by pinning `packageManager` and adding a shared workspace lockfile setting.

### Description
- Update root `package.json` to set `packageManager` to `pnpm@10.2.1` and `engines.node` to `20.x`.
- Add `shared-workspace-lockfile=true` to the root `.npmrc` to stabilize workspace installs and peer dependency handling.

### Testing
- Ran `corepack prepare pnpm@10.2.1 --activate` and `pnpm -v` which returned `10.2.1`, and ran `pnpm install` which failed due to Node mismatch because the environment Node is `v22.21.1` while `engines.node` requires `20.x` (expected behavior until Node is switched to 20.x).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ef932b6008330bb93b0b6d6e34325)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package manager from pnpm 9.15.4 to 10.2.1.
  * Updated Node.js engine requirement to version 20.x.
  * Optimized workspace lockfile configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->