### PR TITLE
Update Vercel project ID in deployment status

### DIFF
--- a/docs/deployment/DEPLOYMENT_STATUS_LIVE.md
+++ b/docs/deployment/DEPLOYMENT_STATUS_LIVE.md
@@ -24,7 +24,7 @@ fly logs --app infamous-freight-api --no-tail# 🚀 INFAMOUS FREIGHT ENTERPRISES
 
 - **Status**: 🟠 Linked & Configured
 - **Project**: `santorio-miles-projects/web`
-- **Project ID**: `prj_mxEkjo2T89KJJhzy6Y0BzTkRivB0`
+- **Project ID**: `prj_WBSUF1WMF2aX7DRmux7R5Aoabr8a`
 - **Build Command**: npm install (pnpm-lock.yaml)
 - **Output Directory**: `.next`
 - **Environment Variables**: Configured


### PR DESCRIPTION
### Motivation
- Correct the Vercel project identifier in the live deployment status so the documentation reflects the current linked Vercel project (`prj_WBSUF1WMF2aX7DRmux7R5Aoabr8a`).

### Description
- Replace the previous project ID `prj_mxEkjo2T89KJJhzy6Y0BzTkRivB0` with `prj_WBSUF1WMF2aX7DRmux7R5Aoabr8a` in `docs/deployment/DEPLOYMENT_STATUS_LIVE.md`.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697efa4c999c833087ca9a13a027bfd5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal deployment configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->