### PR TITLE
fix: align Vercel config with apps/web

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,10 +1,10 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
-  "buildCommand": "if [ -d web ]; then bash web/scripts/validate-build.sh && pnpm --filter web build; else bash scripts/validate-build.sh && pnpm build; fi",
-  "devCommand": "if [ -d web ]; then pnpm --filter web dev; else pnpm dev; fi",
-  "installCommand": "if [ -f pnpm-workspace.yaml ]; then pnpm install --frozen-lockfile --filter web...; elif [ -f ../pnpm-workspace.yaml ]; then cd .. && pnpm install --frozen-lockfile --filter web...; else pnpm install --frozen-lockfile; fi",
-  "outputDirectory": "web/.next",
+  "buildCommand": "if [ -d apps/web ]; then bash apps/web/scripts/validate-build.sh && pnpm --filter web build; else bash scripts/validate-build.sh && pnpm build; fi",
+  "devCommand": "if [ -d apps/web ]; then pnpm --filter web dev; else pnpm dev; fi",
+  "installCommand": "pnpm install --frozen-lockfile --filter web...",
+  "outputDirectory": "apps/web/.next",
   "ignoreCommand": "git diff --quiet HEAD^ HEAD ./",
   "crons": [],
   "github": {


### PR DESCRIPTION
### Motivation
- Vercel was guessing the project root as `web` and using a `cd ..` install fallback which can cause PNPM workspace/lockfile mismatches and failed installs. 
- The Next app actually lives in `apps/web`, so the deployment configuration must reference that path to build and install reliably.

### Description
- Update `buildCommand` to check `apps/web` and run `bash apps/web/scripts/validate-build.sh && pnpm --filter web build` when present. 
- Update `devCommand` to use the `apps/web` path when available. 
- Simplify `installCommand` to `pnpm install --frozen-lockfile --filter web...` to remove the `cd ..` fallback. 
- Change `outputDirectory` to `apps/web/.next` so Vercel picks up the correct build output.

### Testing
- No automated tests were run for this configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697efd61a18c8330a12f0842c2175b2b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to align with the current project structure, ensuring consistent builds and deployments across development and production environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->