### PR TITLE
Add @vercel/analytics dependency to root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
     "build:api": "pnpm --filter api build",
     "build:mobile": "pnpm --filter mobile build",
     "build:ai": "pnpm --filter ai build"
+  },
+  "dependencies": {
+    "@vercel/analytics": "^1.6.1"
   }
 }


### PR DESCRIPTION
### Motivation
- Enable use of Vercel Analytics across the repository by adding the `@vercel/analytics` package to the monorepo root.

### Description
- Add the `@vercel/analytics` dependency entry to the root `package.json`.

### Testing
- No automated tests were run for this dependency-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697eff96d64c8330a3d9df0eddd51d53)