### PR TITLE
chore(ci): pin Node to 20.20.0 and run `corepack install` in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,11 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: "20.20.0"
           cache: pnpm
 
       - run: corepack enable
+      - run: corepack install
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
       - run: pnpm typecheck

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,9 +45,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: "20.20.0"
           cache: pnpm
       - run: corepack enable
+      - run: corepack install
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
       - run: pnpm typecheck
@@ -84,10 +85,11 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: "20.20.0"
           cache: pnpm
 
       - run: corepack enable
+      - run: corepack install
       - run: pnpm install --frozen-lockfile
 
       - uses: expo/expo-github-action@v8


### PR DESCRIPTION
### Motivation
- Ensure deterministic CI and deploy runs by pinning the Actions Node version and fully activating the `pnpm` package manager via Corepack before installs.

### Description
- Updated `.github/workflows/ci.yml` and `.github/workflows/deploy.yml` to set `node-version` to `"20.20.0"` and add a `corepack install` step after `corepack enable` before running `pnpm install`.

### Testing
- No automated tests were executed because this is a workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f0fcca2c08330b6821a569ae3687d)