### PR TITLE
CI: use pnpm/action-setup@v4 and add `pnpm -r rebuild`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,13 @@ jobs:
           node-version: 20
           cache: pnpm
 
-      - run: corepack enable
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.0
+          run_install: false
+
       - run: pnpm install --frozen-lockfile
+      - run: pnpm -r rebuild
       - run: pnpm lint
       - run: pnpm typecheck
       - run: pnpm -r --topological --if-present run build


### PR DESCRIPTION
### Motivation
- Ensure the CI workflow uses the official pnpm action with a pinned pnpm version and that native dependencies are rebuilt after installation to avoid platform-specific issues.

### Description
- Replace the `corepack enable` step with `pnpm/action-setup@v4` pinned to `9.15.0` (with `run_install: false`) and add `pnpm -r rebuild` after `pnpm install --frozen-lockfile` in `.github/workflows/ci.yml`.

### Testing
- No automated tests were run because this change modifies a GitHub Actions workflow file only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f205b0c588330a82392e85dcb52bd)