### PR TITLE
Relax Node.js engine range for installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "packageManager": "pnpm@10.2.1+sha512.398035c7bd696d0ba0b10a688ed558285329d27ea994804a52bad9167d8e3a72bcb993f9699585d3ca25779ac64949ef422757a6c31102c12ab932e5cbe5cc92",
   "engines": {
-    "node": "20.x"
+    "node": ">=20 <23"
   },
   "scripts": {
     "install:ci": "pnpm install --frozen-lockfile",


### PR DESCRIPTION
### Motivation
- Broaden the Node.js engine requirement to allow Node 20–22 so installs and CI on supported runtimes succeed.

### Description
- Update `package.json` `engines.node` from `"20.x"` to `">=20 <23"`.

### Testing
- No automated tests were run because this change is metadata-only and does not affect code behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f35bc1ee48330a140ef6180f813c7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated supported Node.js versions to include versions 20 through 22.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->