### PR TITLE
Update example DATABASE_URL to Supabase connection string

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,7 +31,7 @@ API_URL=http://localhost:4000
 # Docker: postgresql://infamous:infamouspass@postgres:5432/infamous_freight
 # Fly.io (fill in real user/password/db):
 # Example: postgresql://USERNAME:PASSWORD@infamous-freight-db.flycast:5432/infamous_freight
-DATABASE_URL=postgresql://postgres:[PASSWORD]@db.wnaievjffghrztjuvutp.supabase.co:6543/postgres?pgbouncer=true
+DATABASE_URL=postgresql://postgres:[PASSWORD]@xxxxxxxxxxx.supabase.co:6543/postgres?pgbouncer=true
 
 # Test database (optional, for running tests)
 TEST_DATABASE_URL=postgresql://infamous:infamouspass@localhost:5432/infamous_freight_test


### PR DESCRIPTION
### Motivation
- Provide a concrete Supabase example for the repository `DATABASE_URL` so maintainers can copy a working connection pattern into local or deployment `.env` files.

### Description
- Replace the `DATABASE_URL` line in `.env.example` with the provided Supabase connection string (`postgresql://postgres:[PASSWORD]@db.wnaievjffghrztjuvutp.supabase.co:6543/postgres?pgbouncer=true`).

### Testing
- No automated tests were run because this is a configuration-only change to an example environment file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f816183508330bea90470e998ffdb)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database configuration to use a cloud-hosted endpoint for improved infrastructure management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->