### PR TITLE
docs: add Next.js Sentry wizard guidance

### DIFF
--- a/docs/guides/SENTRY_100_GUIDE.md
+++ b/docs/guides/SENTRY_100_GUIDE.md
@@ -122,7 +122,7 @@ SENTRY_PROJECT=javascript-nextjs
 If Next.js middleware matches all routes, exclude the Sentry tunnel path to avoid 401/403/500 errors:
 ```ts
 export const config = {
-  matcher: ["/((?!monitoring).*)"],
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|public|monitoring).*)"],
 };
 ```
 


### PR DESCRIPTION
### Motivation
- Document the correct, monorepo-safe way to run the Sentry Next.js wizard for the web app and capture the required Vercel settings and middleware exclusions so Sentry setup and source map uploads work reliably in this pnpm monorepo.

### Description
- Added a new section to `docs/guides/SENTRY_100_GUIDE.md` showing the monorepo-safe wizard command (`cd apps/web && npx @sentry/wizard@latest -i nextjs --saas --org infamous-freight-enterprise --project javascript-nextjs`), the expected files/patches the wizard will create, required Vercel environment variables for source maps (`SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT`), and an example Next.js middleware matcher exclusion to allow the Sentry tunnel route.

### Testing
- Docs-only change; no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980b93d0acc8330b774f975b3c7fefd)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added step-by-step wizard setup for pnpm monorepo Next.js projects, including expected generated configuration files and post-wizard actions.
  * Documented recommended config adjustments and a middleware tunnel exclusion example to avoid 401/403/500 errors.
  * Added Vercel source maps environment variable guidance and deployment notes.
  * Minor formatting and checklist clarity improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->