### PR TITLE
docs: add enterprise 100 package documentation

### DIFF
--- a/docs/enterprise-100-package.md
+++ b/docs/enterprise-100-package.md
@@ -501,15 +501,35 @@ export async function stripeWebhook(rawBody: string, sig: string) {
     }
     if (!billing?.company_id) return;
 
-    const status =
-      sub.status === "active"
-        ? "active"
-        : sub.status === "past_due"
-          ? "past_due"
-          : sub.status === "canceled"
-            ? "canceled"
-            : "trial";
+    const mapStripeSubscriptionStatus = (
+      stripeStatus: Stripe.Subscription.Status,
+    ): "active" | "past_due" | "canceled" | "trial" => {
+      switch (stripeStatus) {
+        case "active":
+          return "active";
+        case "past_due":
+          return "past_due";
+        case "canceled":
+          return "canceled";
+        case "trialing":
+        case "incomplete":
+          // Treat these as trial/limited access until fully paid or expired
+          return "trial";
+        case "incomplete_expired":
+          // Subscription never completed; treat as fully canceled
+          return "canceled";
+        case "unpaid":
+          // Keep in degraded state with limited access
+          return "past_due";
+        default:
+          // Surface unexpected or new statuses early instead of granting access
+          throw new Error(
+            `Unhandled Stripe subscription status: ${stripeStatus}`,
+          );
+      }
+    };
 
+    const status = mapStripeSubscriptionStatus(sub.status);
     await supabase
       .from("company_billing")
       .update({


### PR DESCRIPTION
### Motivation
- Provide a single, copy/paste canonical "Enterprise 100%" package that codifies company-level billing, RBAC, RLS, audit logging, AI usage governance, feature flags, and deployment parity.
- Ship a ready-to-run Supabase SQL scaffold plus implementation guidance and server snippets (Stripe webhook, AI usage, feature enforcement) so teams can adopt enterprise-grade controls quickly.

### Description
- Added `docs/enterprise-100-package.md` which contains the full Supabase SQL schema, enums, tables, triggers, helper functions, and RLS policies for companies, memberships, features, billing, AI usage aggregates, ops, comms, and audit logs.
- Implemented helper functions and triggers in the doc such as `public.set_updated_at()`, `public.audit_log()`, and RBAC helpers `public.my_role()`, `public.is_member()`, and `public.is_adminish()` and enabled RLS across all relevant tables.
- Included example server snippets: a drop-in Node/TypeScript Stripe webhook handler and enforcement snippets for feature flags and the `recordAiAction` usage function (80% alert + 200% hard cap) for integration guidance.
- Added a deployment parity checklist and required environment keys to standardize production vs preview deployments.

### Testing
- Pre-commit tasks ran via `lint-staged` including `prettier --write` and completed successfully as part of the commit hook run.
- Commit message hook validated Conventional Commits format and the commit succeeded after adjustment, with no runtime tests executed because this is a documentation-only change.
- No additional automated unit or integration tests were run for the SQL/snippet content; the SQL and snippets are intended to be copy/pasted into environments for further validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983ef342cac83309d80e0e682169bae)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a complete Enterprise 100 package doc with a copy-paste Supabase schema, RBAC/RLS, billing state machine, and governance helpers, plus server snippets for Stripe and usage enforcement. This gives teams a ready-to-run baseline for company-level billing, feature flags, and deployment parity.

- **New Features**
  - Added docs/enterprise-100-package.md with full Supabase SQL (enums, tables, triggers, helper functions) and RLS policies.
  - Included audit logging helpers and RBAC functions (my_role, is_member, is_adminish).
  - Provided a Node/TypeScript Stripe webhook handler that maps subscription events to billing status and feature flags.
  - Added AI usage function with 80% alert and 200% hard cap enforcement.
  - Included deployment parity checklist and required environment keys.

<sup>Written for commit 704fb2909ccf139e57e5e6ee13545bca30395b30. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Enterprise 100% package documentation covering system architecture, database schema, role-based access control, billing configuration, AI usage governance, feature flags, and deployment specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->