### PR TITLE
Add /api/loi Next.js route to post LOIs to Airtable

### DIFF
--- a/src/apps/web/pages/api/loi.ts
+++ b/src/apps/web/pages/api/loi.ts
@@ -43,8 +43,10 @@ export default async function handler(
   const record = body.record ?? body;
 
   try {
+    const encodedBaseId = encodeURIComponent(airtableBaseId);
+    const encodedTableId = encodeURIComponent(airtableTableId);
     const airtableResponse = await fetch(
-      `https://api.airtable.com/v0/${airtableBaseId}/${airtableTableId}`,
+      `https://api.airtable.com/v0/${encodedBaseId}/${encodedTableId}`,
       {
         method: "POST",
         headers: {


### PR DESCRIPTION
### Motivation
- Provide a backend endpoint to capture LOI submissions and write them directly to Airtable with the exact field mapping and default `Status` of `New`.
- Ensure the web app can operate without the unavailable Airtable tool by posting directly to the Airtable REST API using environment variables.

### Description
- Add `src/apps/web/pages/api/loi.ts`, a Next.js API route that accepts `POST` requests and rejects other methods with `405`.
- The route reads `AIRTABLE_TOKEN`, `AIRTABLE_BASE_ID`, and `AIRTABLE_TABLE_ID` from the environment and returns a `500` if any are missing.
- It sends a `POST` to `https://api.airtable.com/v0/${airtableBaseId}/${airtableTableId}` with the exact field mapping: `Name`, `Phone`, `Email`, `State`, `BusinessName`, `MCDOT`, `Trucks`, `WeeklyLoads`, `BetaInterest`, `NonBindingAck`, `Signature`, `Source`, `CreatedAt`, and `Status: "New"`.
- The handler returns Airtable response details on success and normalizes error handling for non-OK Airtable responses and unexpected exceptions.

### Testing
- No automated tests were run as part of this change; please run CI to validate TypeScript, linting, and integration with the Airtable environment.
- The file was added and committed as `src/apps/web/pages/api/loi.ts` and should be validated after setting the required environment variables in Vercel (`AIRTABLE_TOKEN`, `AIRTABLE_BASE_ID`, `AIRTABLE_TABLE_ID`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698918b199908330b67126db6881e812)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a POST /api/loi endpoint to send LOI submissions directly to Airtable with Status set to “New”. This lets the app write to Airtable via REST without the Airtable tool.

- **New Features**
  - Next.js API route at /api/loi accepts POST only; 405 for others.
  - Reads AIRTABLE_TOKEN, AIRTABLE_BASE_ID, AIRTABLE_TABLE_ID; returns 500 if missing.
  - Posts LOIs to Airtable using the exact field mapping and sets Status to “New”; accepts {record: {...}} or a flat body.
  - Returns Airtable JSON on success and forwards Airtable status/errors.

- **Migration**
  - Set AIRTABLE_TOKEN, AIRTABLE_BASE_ID, AIRTABLE_TABLE_ID in Vercel before deploying.

<sup>Written for commit cc236cd4719065ae98c59c2b0b23b26a3936e50a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Letter of Intent (LOI) submission endpoint so users can submit LOI forms and have records stored in the backend.
  * Request inputs are validated and the endpoint returns clear success or error responses when submissions are accepted or fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->