### PR TITLE
Guard webhook routes against undefined request bodies

### DIFF
--- a/src/apps/api/src/routes/webhooks.ts
+++ b/src/apps/api/src/routes/webhooks.ts
@@ -159,7 +159,16 @@ router.post(
   authenticate,
   requireScope("webhooks:write"),
   (req: Request, res: Response) => {
-    const { url, events } = req.body;
+    if (!req.body || typeof req.body !== "object") {
+      return res.status(400).json({
+        error: "Invalid request body. Send JSON with url and events.",
+      });
+    }
+
+    const { url, events } = req.body as {
+      url?: string;
+      events?: string[];
+    };
 
     if (!url || !events || events.length === 0) {
       return res.status(400).json({ error: "URL and events required" });
@@ -263,7 +272,17 @@ router.patch(
       return res.status(403).json({ error: "Forbidden" });
     }
 
-    const { url, events, active } = req.body;
+    if (!req.body || typeof req.body !== "object") {
+      return res.status(400).json({
+        error: "Invalid request body. Send JSON to update webhook fields.",
+      });
+    }
+
+    const { url, events, active } = req.body as {
+      url?: string;
+      events?: string[];
+      active?: boolean;
+    };
 
     if (url) {
       try {


### PR DESCRIPTION
### Motivation
- Prevent runtime TypeErrors and unhandled 500s when a client POST/PATCHs the webhooks endpoints without a parsed JSON body by validating `req.body` before destructuring.

### Description
- Add a defensive check in `POST /api/webhooks` to return `400` with a clear message when `req.body` is missing or not an object, then safely cast and read `url` and `events`.
- Add the same defensive check in `PATCH /api/webhooks/:id` to return `400` for missing/invalid JSON before reading `url`, `events`, and `active`.
- Preserve existing validation, SSRF protections, and behavior for valid payloads; changes are limited to input validation branches in `src/apps/api/src/routes/webhooks.ts`.

### Testing
- Ran `pnpm --dir src/apps/api typecheck`, which failed due to environment/pre-existing issues (missing `node_modules` and an unrelated TypeScript parse error in `src/services/billing/usage-aggregator.ts`), not caused by these webhook changes.
- No other automated tests were run in this environment; changes are small and low risk (only added input guards).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ba44cd9b083308aaa816a4f04cd4b)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents runtime errors in webhook routes by validating request bodies. POST and PATCH now return 400 with clear messages when JSON is missing or invalid; valid payloads behave as before.

- **Bug Fixes**
  - POST /api/webhooks: 400 when body is missing or not an object; existing url/events validation unchanged.
  - PATCH /api/webhooks/:id: 400 when body is missing or not an object; existing url/events/active validation unchanged.
  - Preserves existing SSRF protections and behavior for valid requests.

<sup>Written for commit e7bf9f6db517cebf442227139cc736051c6d761a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook endpoints now validate request bodies and return 400 errors for malformed requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->