### PR TITLE
Harden public sales lead capture endpoint against abuse

### DIFF
--- a/apps/api/src/routes/sales.ts
+++ b/apps/api/src/routes/sales.ts
@@ -68,12 +68,20 @@ const publicLeadCaptureAttempts = new Map<
 >();
 
 function getRequesterIp(req: any): string {
-  const forwardedFor = req.headers["x-forwarded-for"];
-  if (typeof forwardedFor === "string" && forwardedFor.trim()) {
-    return forwardedFor.split(",")[0].trim();
+  // With `trust proxy` enabled, Express's `req.ip` / `req.ips` already
+  // take `x-forwarded-for` into account according to trusted proxies.
+  if (req.ip) {
+    return req.ip;
   }
 
-  return req.ip || req.socket?.remoteAddress || "unknown";
+  if (Array.isArray(req.ips) && req.ips.length > 0) {
+    return req.ips[0];
+  }
+
+  const remoteAddress =
+    req.socket?.remoteAddress || req.connection?.remoteAddress;
+
+  return remoteAddress || "unknown";
 }
 
 function enforcePublicLeadCaptureProtection(req: any, res: any, next: any): void {


### PR DESCRIPTION
### Motivation
- The public `POST /api/sales/leads` route accepts unauthenticated submissions and could be abused to spam downstream CRMs or exhaust API quotas, so server-side protections are needed before any external writes occur.

### Description
- Added an anti-abuse middleware `enforcePublicLeadCaptureProtection` and wired it into `apps/api/src/routes/sales.ts` to run before lead creation logic.
- Middleware supports optional shared-secret header validation via `SALES_LEAD_CAPTURE_SECRET` and the `x-lead-capture-secret` request header.
- Middleware supports an optional origin allowlist configured with `SALES_LEAD_CAPTURE_ALLOWED_ORIGINS` and will reject requests from disallowed origins.
- Middleware implements a simple in-memory per-IP rate limiter with configurable `SALES_LEAD_CAPTURE_MAX_REQUESTS` and `SALES_LEAD_CAPTURE_WINDOW_MS` to throttle public form submissions.

### Testing
- Ran `npx eslint apps/api/src/routes/sales.ts` which could not complete in this environment because repository lint dependencies/config are not fully installed (ESLint import errors).
- Ran `cd apps/api && npx tsc --noEmit src/routes/sales.ts --skipLibCheck` which failed in this environment due to missing TypeScript/node/@prisma types and project lib configuration, so type-check could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ba4e2bee08330a83753ee661d0faa)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds anti-abuse protections to POST /api/sales/leads to block spam and throttle abusive traffic. Requests are now gated by an optional shared secret, an origin allowlist, and per-IP rate limiting.

- New Features
  - Added enforcePublicLeadCaptureProtection middleware to the /leads route.
  - Optional shared secret via SALES_LEAD_CAPTURE_SECRET and x-lead-capture-secret header.
  - Optional origin allowlist via SALES_LEAD_CAPTURE_ALLOWED_ORIGINS (comma-separated).
  - In-memory per-IP rate limiter configurable with SALES_LEAD_CAPTURE_MAX_REQUESTS (default 10) and SALES_LEAD_CAPTURE_WINDOW_MS (default 15m).

- Migration
  - Set SALES_LEAD_CAPTURE_ALLOWED_ORIGINS to the exact Origin(s) submitting the form.
  - If using a secret, set SALES_LEAD_CAPTURE_SECRET and send x-lead-capture-secret from the client.

<sup>Written for commit 2483e73c50f01cadd980cdb393f411e21b651ac6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Rate limiting enforced on lead creation endpoint (10 requests per 15 minutes per IP)
  * Origin-based access control added for lead capture functionality
  * Secret-based authentication support added for lead capture requests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->