### PR TITLE
Codex-generated pull request

### DIFF
--- a/apps/api/src/sales/leadCapture.ts
+++ b/apps/api/src/sales/leadCapture.ts
@@ -28,11 +28,36 @@ export interface CreateLeadInput {
   metadata?: Record<string, any>;
 }
 
+function normalizeLeadMetadata(
+  metadata: Record<string, any> | undefined,
+  serverCreatedAtIso: string
+): Record<string, any> {
+  const source = metadata && typeof metadata === "object" ? { ...metadata } : {};
+
+  // CreatedAt must be generated server-side to avoid spoofed or malformed
+  // client timestamps breaking downstream consumers (e.g. date parsers).
+  const clientCreatedAt = source.CreatedAt ?? source.createdAt;
+  if (typeof clientCreatedAt === "string" && clientCreatedAt.trim().length > 0) {
+    source.clientProvidedCreatedAt = clientCreatedAt;
+  }
+
+  delete source.CreatedAt;
+  delete source.createdAt;
+
+  return {
+    ...source,
+    CreatedAt: serverCreatedAtIso,
+  };
+}
+
 /**
  * Create a new lead and sync to CRM systems
  */
 export async function createLead(input: CreateLeadInput): Promise<any> {
   try {
+    const serverCreatedAtIso = new Date().toISOString();
+    const normalizedMetadata = normalizeLeadMetadata(input.metadata, serverCreatedAtIso);
+
     // Check if lead already exists
     const existingLead = await prisma.lead.findUnique({
       where: { email: input.email },
@@ -56,7 +81,9 @@ export async function createLead(input: CreateLeadInput): Promise<any> {
         estimatedMonthlyBudget: input.estimatedMonthlyBudget,
         currentProvider: input.currentProvider,
         painPoints: input.painPoints,
-        metadata: input.metadata ? JSON.stringify(input.metadata) : null,
+        metadata: Object.keys(normalizedMetadata).length > 0
+          ? JSON.stringify(normalizedMetadata)
+          : null,
         status: "new",
       },
     });


### PR DESCRIPTION
Codex generated this pull request, but encountered an unexpected error after generation. This is a placeholder PR message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ba54335788330b145beba4a1cf8cc)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforce server-generated CreatedAt in lead metadata to prevent spoofed or malformed client timestamps. Normalize and store the server timestamp, while preserving any client-provided timestamp separately.

- **Bug Fixes**
  - Generate CreatedAt on the server and remove client CreatedAt/createdAt.
  - Preserve client timestamp as clientProvidedCreatedAt; store normalized metadata JSON or null when empty.

- **Migration**
  - Read CreatedAt as the server timestamp; use clientProvidedCreatedAt if the original client value is needed.

<sup>Written for commit 7c45b2e68e2160c345f067ad43a4f3e9d046ea22. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

