### PR TITLE
Add runtime validation for route-optimization request bodies

### DIFF
--- a/src/apps/api/src/routes/route-optimization.ts
+++ b/src/apps/api/src/routes/route-optimization.ts
@@ -365,12 +365,17 @@ router.post(
 
       if (
         !isPlainObject(currentLocation) ||
-        typeof currentLocation.lat !== "number" ||
-        typeof currentLocation.lng !== "number"
+        !Number.isFinite(currentLocation.lat) ||
+        !Number.isFinite(currentLocation.lng) ||
+        currentLocation.lat < -90 ||
+        currentLocation.lat > 90 ||
+        currentLocation.lng < -180 ||
+        currentLocation.lng > 180
       ) {
         return res.status(400).json({
           success: false,
-          error: "Invalid payload: currentLocation.lat and currentLocation.lng are required",
+          error:
+            "Invalid payload: currentLocation.lat and currentLocation.lng must be finite numbers within valid latitude/longitude ranges",
         });
       }
 


### PR DESCRIPTION
### Motivation
- Prevent handlers from treating non-object `req.body` (strings, arrays, null) as objects which can lead to undefined fields and downstream errors. 
- Ensure the `/optimize` endpoint only proceeds when required fields are present to avoid persisting invalid routes. 
- Ensure the `/:routeId/eta` endpoint receives a well-formed `currentLocation` with numeric `lat`/`lng` to avoid runtime failures in ETA calculations.

### Description
- Added an `isPlainObject` runtime guard function in `src/apps/api/src/routes/route-optimization.ts` to detect true JSON objects. 
- Hardened `POST /api/routes/optimize` to validate that `driverId`, `origin` (string), and a non-empty `waypoints` array are present and return HTTP 400 with a clear error when not. 
- Hardened `POST /api/routes/:routeId/eta` to validate that `currentLocation.lat` and `currentLocation.lng` are numbers and return HTTP 400 with a clear error when not. 
- Made inbound destructured fields optional in the handlers to allow the runtime checks to produce descriptive errors before use.

### Testing
- Ran `pnpm -C src/apps/api typecheck`, which failed due to a pre-existing TypeScript error in `src/services/billing/usage-aggregator.ts` and a missing `node_modules` environment, so the failure is unrelated to these changes. 
- No other automated tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ba5e007d883308971df328cebe5b7)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add runtime validation for POST /api/routes/optimize and POST /api/routes/:routeId/eta to reject malformed payloads with clear 400 errors. This prevents invalid routes from being persisted and avoids ETA calculation failures.

- **Bug Fixes**
  - Added isPlainObject to ensure req.body is a JSON object.
  - /api/routes/optimize: require driverId, string origin, and a non-empty waypoints array.
  - /api/routes/:routeId/eta: require numeric currentLocation.lat and currentLocation.lng.

<sup>Written for commit dbce6f6bb11efbafd27f4fd0ccbb653a40b29237. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

