### PR TITLE
Codex-generated pull request

### DIFF
--- a/apps/api/src/marketplace/pricing.ts
+++ b/apps/api/src/marketplace/pricing.ts
@@ -72,7 +72,7 @@ function computePriceUsd(input) {
   };
 
   const discount = discountsByPlan[shipperPlanTier] || 0;
-  const finalPrice = clamp(subtotal * (1 - discount), 0, 50000);
+  const finalPrice = Math.min(subtotal * (1 - discount), 50000);
 
   // Enforce minimum (base rate) and round to nearest cent
   return Math.max(base, Math.round(finalPrice * 100) / 100);


### PR DESCRIPTION
Codex generated this pull request, but encountered an unexpected error after generation. This is a placeholder PR message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bef79be5c83309e12cd13e6e6ca6d)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened marketplace pricing by sanitizing and clamping numeric inputs so invalid or extreme values can’t skew calculations. Prevents NaN/Infinity and caps totals to safe bounds.

- **Bug Fixes**
  - Normalize estimatedMiles, weightLbs, and volumeCuFt using toFiniteNumber and clamp (0–3000, 0–120000, 0–5000).
  - Use safe values for distance, weight, and volume fees; clamp subtotal and discounted price, with a max of $50,000 and minimum base rate enforced.
  - Keeps existing discount logic; adds small helpers for safer computePriceUsd behavior outside validated API paths.

<sup>Written for commit 1e5c5c39cd5459107dcb4657b90c3c3ef9a8bba0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

