### PR TITLE
Guard fuel-cost math from invalid MPG inputs in route optimization service

### DIFF
--- a/src/apps/api/src/routes/route-optimization.ts
+++ b/src/apps/api/src/routes/route-optimization.ts
@@ -221,13 +221,31 @@ async function getOptimizedDirections(
 /**
  * Calculate fuel cost based on distance
  */
-function calculateFuelCost(distanceMeters: number): number {
-  const distanceMiles = distanceMeters * 0.000621371; // meters to miles
-  const mpg = 8; // Truck fuel efficiency
-  const gasPrice = 3.5; // USD per gallon
+function calculateFuelCost(
+  distanceMeters: number,
+  options?: { mpg?: number; gasPricePerGallon?: number },
+): number {
+  const distanceMiles = Math.max(0, distanceMeters) * 0.000621371; // meters to miles
+  const mpg = normalizeMpg(options?.mpg ?? 8); // Truck fuel efficiency
+  const gasPrice = options?.gasPricePerGallon ?? 3.5; // USD per gallon
 
   const gallons = distanceMiles / mpg;
   return gallons * gasPrice;
+}
+
+/**
+ * Guard MPG inside the service layer so internal callers cannot accidentally
+ * produce Infinity/-Infinity fuel costs.
+ */
+function normalizeMpg(mpg: number): number {
+  const DEFAULT_MPG = 8;
+  const MIN_MPG = 1;
+
+  if (!Number.isFinite(mpg) || mpg <= 0) {
+    return DEFAULT_MPG;
+  }
+
+  return Math.max(MIN_MPG, mpg);
 }
 
 /**


### PR DESCRIPTION
### Motivation
- Prevent `calculateFuelCost` from returning `Infinity`/`-Infinity` when callers pass `mpg` values that are `0`, negative, `NaN`, or `Infinity` outside the route-level validation.
- Ensure internal callers that bypass HTTP validation get safe, sane defaults so downstream math (costs, savings, profits) is not poisoned by invalid inputs.

### Description
- Changed `calculateFuelCost` signature to `calculateFuelCost(distanceMeters: number, options?: { mpg?: number; gasPricePerGallon?: number })` to accept runtime overrides while preserving existing defaults.
- Clamped `distanceMeters` with `Math.max(0, distanceMeters)` to avoid negative distance producing negative fuel/cost values.
- Added `normalizeMpg(mpg: number)` which returns a safe `DEFAULT_MPG` when `mpg` is non-finite or non-positive and enforces a `MIN_MPG` floor (1 mpg) otherwise.
- Exposed optional `gasPricePerGallon` through `options` so internal callers can supply runtime pricing without changing existing behavior.

### Testing
- Ran TypeScript typecheck with `pnpm -C src/apps/api typecheck`; it failed due to a pre-existing, unrelated TypeScript syntax error in `src/services/billing/usage-aggregator.ts` and missing local dependencies in the environment, so the failure is not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698befbc47ac833084e4c93c1d3bb388)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents invalid MPG and negative distance from producing Infinity or negative fuel costs in route optimization. Adds safe defaults and optional overrides without changing existing behavior.

- **Bug Fixes**
  - Clamp distanceMeters to 0+.
  - Normalize MPG: default to 8 when non-finite or <= 0; enforce min 1 mpg.

- **New Features**
  - calculateFuelCost(distanceMeters, { mpg?, gasPricePerGallon? }) to allow runtime overrides with existing defaults preserved.

<sup>Written for commit dcc0e8c95589c90751cb50565f880f7e2115cd33. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

