### PR TITLE
fix(vercel): limit serverless deployment to single region

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,11 +4,7 @@
   "installCommand": "npm i -g pnpm@9.15.0 --prefix $HOME/.local && export PATH=$HOME/.local/bin:$PATH && pnpm -w install --frozen-lockfile",
   "buildCommand": "pnpm -r --filter @infamous-freight/shared build && pnpm --filter web build",
   "outputDirectory": "apps/web/.next",
-  "regions": [
-    "iad1",
-    "sfo1",
-    "cdg1"
-  ],
+  "regions": ["iad1"],
   "git": {
     "deploymentEnabled": {
       "main": true,


### PR DESCRIPTION
### Motivation
- The Vercel configuration listed multiple regions which can trigger the error "Deploying Serverless Functions to multiple regions is restricted to the Pro and Enterprise plans", so the deployment should target a single region to avoid plan restriction failures.

### Description
- Updated `vercel.json` to set the `regions` field to `["iad1"]`, replacing the previous multi-region list (`iad1`, `sfo1`, `cdg1`).

### Testing
- Verified JSON syntax with `python -m json.tool vercel.json`, which succeeded, and committed the change to the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bfcf2973c833080a359969630002c)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limit Vercel Serverless Functions to a single region to prevent multi‑region deployment errors on the current plan. Updated vercel.json to set regions to ["iad1"] instead of the previous multi‑region list.

<sup>Written for commit bf5366f4bf7a303a353e8f883c22e1362bf26b39. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to optimize server region allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->