### PR TITLE
ci: fix pnpm bootstrap failure in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "pnpm"
 
       - name: Install pnpm
         run: corepack enable && corepack prepare pnpm@9.15.0 --activate


### PR DESCRIPTION
### Motivation
- Prevent `actions/setup-node` from failing early when using `cache: "pnpm"` because `pnpm` is only activated later via Corepack in the workflow.

### Description
- Removed the `cache: "pnpm"` setting from the `actions/setup-node@v4` step in `.github/workflows/ci.yml` and left the subsequent `corepack prepare pnpm...` and `actions/cache` restore steps intact.

### Testing
- Verified the change by running `git diff -- .github/workflows/ci.yml` to confirm the line removal, `sed -n '1,80p' .github/workflows/ci.yml` to inspect the updated file, and `nl -ba .github/workflows/ci.yml | sed -n '1,70p'` to validate line layout, and all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c007f630083308f30c2b06c8e62ce)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI pnpm bootstrap failure by removing cache: "pnpm" from actions/setup-node, which ran before pnpm was activated via Corepack. Corepack install and actions/cache restore remain, so the workflow starts reliably.

<sup>Written for commit 91c5b04fefe7f9b7cbfbb4c89c676e2730cc01d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

