### PR TITLE
Codex-generated pull request

### DIFF
--- a/apps/web/src/lib/auth-server.ts
+++ b/apps/web/src/lib/auth-server.ts
@@ -1,12 +1,22 @@
 import { supabaseAnon, supabaseAdmin } from "@/lib/supabase";
 
+export class AuthError extends Error {
+  status: number;
+
+  constructor(message: string, status = 401) {
+    super(message);
+    this.name = "AuthError";
+    this.status = status;
+  }
+}
+
 export async function requireUser(req: Request) {
   const auth = req.headers.get("authorization") || "";
   const token = auth.startsWith("Bearer ") ? auth.slice(7) : null;
-  if (!token) throw new Error("Missing Authorization bearer token");
+  if (!token) throw new AuthError("Authentication required", 401);
 
   const { data, error } = await supabaseAnon.auth.getUser(token);
-  if (error || !data?.user) throw new Error("Invalid token");
+  if (error || !data?.user) throw new AuthError("Invalid or expired token", 401);
   return data.user;
 }
 
@@ -50,6 +60,8 @@ export async function getActiveCompanyId(userId: string) {
 export async function requireActiveCompany(req: Request) {
   const user = await requireUser(req);
   const activeCompanyId = await getActiveCompanyId(user.id);
-  if (!activeCompanyId) throw new Error("No company membership");
+  if (!activeCompanyId) {
+    throw new AuthError("No active company membership", 403);
+  }
   return { user, activeCompanyId };
 }

--- a/apps/web/tests/auth-server.test.ts
+++ b/apps/web/tests/auth-server.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getUserMock = vi.fn();
+const profileMaybeSingleMock = vi.fn();
+const usersMaybeSingleMock = vi.fn();
+const profilesUpsertMock = vi.fn();
+
+vi.mock("@/lib/supabase", () => ({
+  supabaseAnon: {
+    auth: {
+      getUser: getUserMock,
+    },
+  },
+  supabaseAdmin: {
+    from: vi.fn((table: string) => {
+      if (table === "profiles") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: profileMaybeSingleMock,
+            })),
+          })),
+          upsert: profilesUpsertMock,
+        };
+      }
+
+      if (table === "users") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: usersMaybeSingleMock,
+            })),
+          })),
+        };
+      }
+
+      throw new Error(`Unexpected table: ${table}`);
+    }),
+  },
+}));
+
+import { AuthError, requireActiveCompany, requireUser } from "@/lib/auth-server";
+
+describe("auth-server", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    profilesUpsertMock.mockResolvedValue({ error: null });
+  });
+
+  it("returns 401 when Authorization bearer token is missing", async () => {
+    const req = new Request("https://example.com/api/loads");
+
+    await expect(requireUser(req)).rejects.toMatchObject<AuthError>({
+      status: 401,
+      message: "Authentication required",
+    });
+  });
+
+  it("returns 401 for invalid tokens", async () => {
+    const req = new Request("https://example.com/api/loads", {
+      headers: { authorization: "Bearer bad-token" },
+    });
+
+    getUserMock.mockResolvedValueOnce({
+      data: { user: null },
+      error: { message: "JWT expired" },
+    });
+
+    await expect(requireUser(req)).rejects.toMatchObject<AuthError>({
+      status: 401,
+      message: "Invalid or expired token",
+    });
+  });
+
+  it("returns 403 when the user has no active company", async () => {
+    const req = new Request("https://example.com/api/loads", {
+      headers: { authorization: "Bearer valid-token" },
+    });
+
+    getUserMock.mockResolvedValueOnce({
+      data: { user: { id: "user-1" } },
+      error: null,
+    });
+    profileMaybeSingleMock.mockResolvedValueOnce({
+      data: { active_company_id: null },
+    });
+    usersMaybeSingleMock.mockResolvedValueOnce({
+      data: null,
+      error: null,
+    });
+
+    await expect(requireActiveCompany(req)).rejects.toMatchObject<AuthError>({
+      status: 403,
+      message: "No active company membership",
+    });
+  });
+});


### PR DESCRIPTION
Codex generated this pull request, but encountered an unexpected error after generation. This is a placeholder PR message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c4b0b69e08330937c3c24e1020a76)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforced auth on loads routes with explicit 401/403 errors to improve middleware handling and clearer API responses.

- **Bug Fixes**
  - Added AuthError with status codes; requireUser now throws 401 for missing/invalid tokens, requireActiveCompany throws 403 when no active company.
  - Added Vitest coverage for missing token (401), invalid token (401), and no active company (403).

<sup>Written for commit 1e2ba6139f24bb3f1a9862be5f2aed3c1d6362ff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for authentication and authorization failures, ensuring proper HTTP status codes are returned: 401 for missing or invalid credentials, 403 for insufficient account permissions.

* **Tests**
  * Added comprehensive unit tests validating authentication and authorization error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->