### PR TITLE
Make frontend AI optimization endpoint configurable

### DIFF
--- a/web/lib/api-client.implementation.ts
+++ b/web/lib/api-client.implementation.ts
@@ -8,7 +8,18 @@ import { ApiResponse } from "@infamous-freight/shared";
 
 // API configuration
 const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000/api";
+  process.env.NEXT_PUBLIC_API_URL ||
+  process.env.NEXT_PUBLIC_API_BASE_URL ||
+  "http://localhost:4000/api";
+
+const AI_API_BASE_URL =
+  process.env.NEXT_PUBLIC_AI_API_URL ||
+  process.env.NEXT_PUBLIC_AI_BASE_URL ||
+  API_BASE_URL;
+
+const AI_OPTIMIZATION_ENDPOINT =
+  process.env.NEXT_PUBLIC_AI_OPTIMIZATION_ENDPOINT ||
+  "/ai/shipment-optimization";
 
 interface RequestOptions {
   method?: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
@@ -38,10 +49,22 @@ async function apiRequest<T>(
   endpoint: string,
   options: RequestOptions = {},
 ): Promise<ApiResponse<T>> {
+  return requestWithBase<T>(API_BASE_URL, endpoint, options);
+}
+
+async function requestWithBase<T>(
+  baseUrl: string,
+  endpoint: string,
+  options: RequestOptions = {},
+): Promise<ApiResponse<T>> {
   const { method = "GET", body, params, headers = {} } = options;
 
   // Build URL with query params
-  let url = `${API_BASE_URL}${endpoint}`;
+  const normalizedBaseUrl = baseUrl.replace(/\/+$/, "");
+  const normalizedEndpoint = endpoint.startsWith("/")
+    ? endpoint
+    : `/${endpoint}`;
+  let url = `${normalizedBaseUrl}${normalizedEndpoint}`;
   if (params) {
     const searchParams = new URLSearchParams();
     Object.entries(params).forEach(([key, value]) => {
@@ -345,8 +368,9 @@ interface OptimizationSuggestion {
 async function getShipmentOptimization(
   shipmentId: string,
 ): Promise<OptimizationSuggestion> {
-  const response = await apiRequest<OptimizationSuggestion>(
-    "/ai/shipment-optimization",
+  const response = await requestWithBase<OptimizationSuggestion>(
+    AI_API_BASE_URL,
+    AI_OPTIMIZATION_ENDPOINT,
     { method: "POST", body: { shipmentId } },
   );
 


### PR DESCRIPTION
### Motivation
- The frontend previously hardcoded AI optimization calls to a fixed path under the app API, which breaks optimization when the AI service is hosted separately or behind a different base path.
- Deployments (containers/hosted) need the AI service base URL and endpoint to be configurable from environment variables so browser clients can reach the correct host.

### Description
- Added support for `NEXT_PUBLIC_AI_API_URL` / `NEXT_PUBLIC_AI_BASE_URL` and `NEXT_PUBLIC_AI_OPTIMIZATION_ENDPOINT` with sensible fallbacks in `web/lib/api-client.implementation.ts` so AI requests can target a separate service or custom path.
- Kept and extended the existing API base resolution by adding `process.env.NEXT_PUBLIC_API_BASE_URL` as a fallback for `API_BASE_URL` to make env names consistent.
- Introduced a shared `requestWithBase` helper to normalize base URLs and endpoints and to centralize URL construction and request logic.
- Updated `getShipmentOptimization` to call the configurable AI base + endpoint (`AI_API_BASE_URL` + `AI_OPTIMIZATION_ENDPOINT`) instead of a hardcoded `/ai/shipment-optimization` on the main API.

### Testing
- Attempted an ESLint check via `pnpm exec eslint web/lib/api-client.implementation.ts`, which failed in this environment due to a missing workspace lint dependency (`@eslint/js`).
- No other automated tests were executed in this environment; local typecheck/build or CI should be run to validate integration with the rest of the app.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c4b705f948330aefe1ac3caa792bd)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made the AI optimization request endpoint configurable on the frontend. This lets deployments route to an external service or custom path via environment variables.

- **New Features**
  - Support NEXT_PUBLIC_AI_API_URL or NEXT_PUBLIC_AI_BASE_URL and NEXT_PUBLIC_AI_OPTIMIZATION_ENDPOINT, with fallbacks.
  - Added requestWithBase to normalize base URLs and centralize request logic.
  - getShipmentOptimization now uses the configurable base + endpoint.
  - API base resolution also checks NEXT_PUBLIC_API_BASE_URL.

- **Migration**
  - No changes required for current setups.
  - To use an external service, set NEXT_PUBLIC_AI_API_URL (or NEXT_PUBLIC_AI_BASE_URL) and NEXT_PUBLIC_AI_OPTIMIZATION_ENDPOINT.
  - If unset, it falls back to NEXT_PUBLIC_API_URL/NEXT_PUBLIC_API_BASE_URL and /ai/shipment-optimization.

<sup>Written for commit 0c55c2227529a74a5b1f9f306f5f2f669d50e170. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

