### PR TITLE
Use environment-driven API base URL in web API client

### DIFF
--- a/web/lib/api-client.implementation.ts
+++ b/web/lib/api-client.implementation.ts
@@ -7,8 +7,39 @@
 import { ApiResponse } from "@infamous-freight/shared";
 
 // API configuration
-const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000/api";
+function resolveApiBaseUrl(): string {
+  const raw =
+    process.env.NEXT_PUBLIC_API_URL || process.env.NEXT_PUBLIC_API_BASE_URL;
+
+  // Default to same-origin API routing so production, Docker, and reverse
+  // proxies can route API traffic without hard-coded hosts or CORS issues.
+  if (!raw) {
+    return "/api";
+  }
+
+  const trimmed = raw.replace(/\/+$/, "");
+
+  try {
+    const url = new URL(trimmed);
+    if (url.pathname === "/" || !url.pathname) {
+      url.pathname = "/api";
+    }
+
+    return url.toString().replace(/\/+$/, "");
+  } catch {
+    if (trimmed === "" || trimmed === "/") {
+      return "/api";
+    }
+
+    if (trimmed.endsWith("/api") || trimmed.includes("/api/")) {
+      return trimmed;
+    }
+
+    return `${trimmed}/api`;
+  }
+}
+
+const API_BASE_URL = resolveApiBaseUrl();
 
 interface RequestOptions {
   method?: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";


### PR DESCRIPTION
### Motivation

- Remove a hard-coded localhost fallback so the frontend API client works correctly in production, Docker, and behind reverse proxies without CORS/host issues.

### Description

- Added `resolveApiBaseUrl()` to `web/lib/api-client.implementation.ts` to derive the API base from `NEXT_PUBLIC_API_URL` or `NEXT_PUBLIC_API_BASE_URL` and normalize the result.
- Default to same-origin `/api` when no env var is provided, and handle absolute and relative values (append `/api` when appropriate) to prevent host-specific fallbacks.
- Replaced the previous `API_BASE_URL` constant with the resolver so all client requests follow the environment-driven base URL.

### Testing

- Ran `pnpm -C web lint`, which was not executed due to repository layout (no `package.json` in `web/`) and therefore did not succeed.
- Ran `pnpm -C apps/web lint`, which failed in the environment because dependencies are not installed (`next: not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ceef873ac833094bcefc55b5220b8)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the web API client to an environment-driven base URL and default to same-origin /api. This removes the localhost fallback and prevents CORS/host issues in production, Docker, and reverse proxies.

- **Bug Fixes**
  - Added resolveApiBaseUrl() to read NEXT_PUBLIC_API_URL or NEXT_PUBLIC_API_BASE_URL and normalize absolute/relative values.
  - Trim trailing slashes and append /api when the base lacks it.
  - Replace the API_BASE_URL constant to use the resolver for all client requests.

<sup>Written for commit bec16f47dd13e6c2b1d1c5cbc95e390b60996063. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

