### PR TITLE
test: remove unused server parameter in legacy API test helper

### DIFF
--- a/apps/api/__tests__/api.test.js
+++ b/apps/api/__tests__/api.test.js
@@ -11,7 +11,7 @@ describe("Legacy API Test Suite", () => {
   });
 
   // Test utilities
-  function makeRequest(server, method, path, body = null, headers = {}) {
+  function makeRequest(method, path, body = null, headers = {}) {
     return new Promise((resolve, reject) => {
       const options = {
         hostname: "localhost",


### PR DESCRIPTION
### Motivation
- Fix a lint warning caused by an unused `server` parameter in the test helper to keep the test code clean and warning-free.

### Description
- Remove the unused `server` parameter from the `makeRequest` helper signature in `apps/api/__tests__/api.test.js` so the function is now `makeRequest(method, path, body = null, headers = {})` without changing its behavior.

### Testing
- Ran `node --check apps/api/__tests__/api.test.js`, which succeeded. 
- Attempted `pnpm -r lint` but it failed in this environment due to an incompatible Node version (`v22.21.1` vs the package `engines.node` requirement `>=20.11.1 <21`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cf1b6677483309e84337fbd4cdb7c)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused server parameter from the makeRequest helper in apps/api/__tests__/api.test.js to clear a lint warning. Updated signature to makeRequest(method, path, body = null, headers = {}); no behavior change.

<sup>Written for commit 3606982876293d0c857b25adac1431a157c5b74a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

