### PR TITLE
Codex-generated pull request

### DIFF
--- a/apps/api/src/middleware/security.js
+++ b/apps/api/src/middleware/security.js
@@ -118,6 +118,15 @@ const limiters = {
     keyGenerator: (req) => req.ip,
     message: { error: 'Webhook rate limit exceeded.' },
   }),
+  publicLeadCapture: createLimiter('publicLeadCapture', {
+    windowMs: parseInt(process.env.RATE_LIMIT_PUBLIC_LEAD_CAPTURE_WINDOW_MS || '60') * 60 * 1000,
+    max: parseInt(process.env.RATE_LIMIT_PUBLIC_LEAD_CAPTURE_MAX || '10'),
+    keyGenerator: (req) => {
+      const email = typeof req.body?.email === 'string' ? req.body.email.trim().toLowerCase() : null;
+      return email || req.ip;
+    },
+    message: { error: 'Lead capture rate limit exceeded. Please try again later.' },
+  }),
 };
 
 // Authentication via JWT

--- a/apps/api/src/routes/sales.ts
+++ b/apps/api/src/routes/sales.ts
@@ -72,7 +72,7 @@ const router = Router();
  */
 router.post(
   "/leads",
-  limiters.general,
+  limiters.publicLeadCapture,
   [
     body("name").isString().notEmpty().withMessage("Name is required"),
     body("email").isEmail().withMessage("Valid email is required"),


### PR DESCRIPTION
Codex generated this pull request, but encountered an unexpected error after generation. This is a placeholder PR message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cf05077708330987d54cc2c9ec3c5)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a dedicated rate limiter for public lead capture to reduce spam without throttling other sales endpoints. It keys by email (normalized) or IP and is configurable via environment variables.

- **New Features**
  - Introduced limiters.publicLeadCapture with window/max from RATE_LIMIT_PUBLIC_LEAD_CAPTURE_WINDOW_MS and RATE_LIMIT_PUBLIC_LEAD_CAPTURE_MAX.
  - Keyed by normalized email; falls back to IP when email is missing.
  - Updated POST /leads to use the new limiter with a clear error message.

<sup>Written for commit 191c99648137993c5a849681d8c32b12539d7ca2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

