### PR TITLE
Fix header array handling for usage report auth key

### DIFF
--- a/apps/api/src/routes/stripe.js
+++ b/apps/api/src/routes/stripe.js
@@ -196,12 +196,17 @@ function hasValidUsageKey(usageKey, providedKey) {
 
 /**
  * Coerce an Express header value into a single string.
+ * For security-sensitive headers, multiple values are treated as invalid/ambiguous.
  * @param {string|string[]|undefined} headerValue - Header value from Express request headers.
- * @returns {string|undefined} First header value when multiple are supplied; otherwise the original string.
+ * @returns {string|undefined} The single header value when exactly one is supplied; otherwise `undefined` for arrays, or the original string/undefined.
  */
 function toSingleHeaderValue(headerValue) {
   if (Array.isArray(headerValue)) {
-    return headerValue[0];
+    // Reject ambiguous multi-valued headers by returning undefined
+    if (headerValue.length === 1) {
+      return headerValue[0];
+    }
+    return undefined;
   }
   return headerValue;
 }


### PR DESCRIPTION
### Motivation
- Repeated request headers in Express can be presented as `string[]`, which when coerced to a string (comma-joined) will not match an expected secret and can cause valid requests to be rejected with 401/403 errors. 
- Normalize header values before secret/timing-safe comparison to avoid false negatives in auth flows such as usage reporting.

### Description
- Added a helper `toSingleHeaderValue(headerValue)` in `apps/api/src/routes/stripe.js` that coerces an Express header value of type `string | string[] | undefined` to a single `string | undefined` by returning the first element when an array is present. 
- Updated the `/api/stripe/report-usage` endpoint to call `toSingleHeaderValue(req.headers["x-usage-report-key"])` before passing the value into `hasValidUsageKey`, preventing array-to-string mismatches during timing-safe comparison.

### Testing
- Ran the API build: `npm --prefix apps/api run build`, which completed successfully. 
- Static/type-check step in the build confirmed no syntax errors in the modified file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cf07f68ec8330a68e2890f9afbf64)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize x-usage-report-key header to a single string before the timing-safe check to prevent valid usage report requests from being rejected with 401/403. Applied in /api/stripe/report-usage.

- **Bug Fixes**
  - Added toSingleHeaderValue to coerce string|string[]|undefined to a single string (first element if array).
  - Use it for x-usage-report-key before hasValidUsageKey to avoid array-to-string mismatches.

<sup>Written for commit 6d16cf99bb3a568f776a0f94337dcabf0a17e860. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

