### PR TITLE
Allow server-to-server lead capture when origin allowlist is configured

### DIFF
--- a/apps/api/src/routes/sales.ts
+++ b/apps/api/src/routes/sales.ts
@@ -62,6 +62,53 @@ import {
 
 const router = Router();
 
+function parseAllowedOrigins(rawOrigins?: string): Set<string> {
+  if (!rawOrigins) {
+    return new Set();
+  }
+
+  return new Set(
+    rawOrigins
+      .split(",")
+      .map((origin) => origin.trim())
+      .filter(Boolean),
+  );
+}
+
+/**
+ * Restrict browser origins for public lead capture when configured.
+ *
+ * Notes:
+ * - Missing Origin is allowed to support server-to-server submissions.
+ * - When Origin is present, it must be on the explicit allowlist.
+ */
+function validateLeadCaptureOrigin(req, res, next) {
+  const allowedOrigins = parseAllowedOrigins(
+    process.env.SALES_LEAD_CAPTURE_ALLOWED_ORIGINS,
+  );
+
+  // No allowlist configured => do not apply route-level Origin restrictions.
+  if (allowedOrigins.size === 0) {
+    return next();
+  }
+
+  const origin = req.get("origin");
+
+  // Keep parity with API-wide CORS behavior: allow server-to-server requests.
+  if (!origin) {
+    return next();
+  }
+
+  if (!allowedOrigins.has(origin)) {
+    return res.status(403).json({
+      error: "Forbidden origin",
+      message: "Origin is not allowed for lead capture",
+    });
+  }
+
+  return next();
+}
+
 // ============================================
 // Lead Capture (21.2)
 // ============================================
@@ -73,6 +120,7 @@ const router = Router();
 router.post(
   "/leads",
   limiters.general,
+  validateLeadCaptureOrigin,
   [
     body("name").isString().notEmpty().withMessage("Name is required"),
     body("email").isEmail().withMessage("Valid email is required"),


### PR DESCRIPTION
### Motivation
- Prevent legitimate non-browser (server-to-server) lead capture requests from being rejected when `SALES_LEAD_CAPTURE_ALLOWED_ORIGINS` is set, and align route-level behavior with the API-wide CORS policy that permits missing `Origin` headers.

### Description
- Added a `parseAllowedOrigins` helper to normalize `SALES_LEAD_CAPTURE_ALLOWED_ORIGINS` into a `Set` in `apps/api/src/routes/sales.ts`.
- Implemented `validateLeadCaptureOrigin` middleware that allows requests with no `Origin` header but enforces the allowlist when an `Origin` is present.
- Applied `validateLeadCaptureOrigin` to the `POST /api/sales/leads` route so lead capture enforces configured browser origin restrictions without breaking server-to-server submissions.

### Testing
- Ran lint against the changed file with `npm run lint -- src/routes/sales.ts`, which failed due to a missing ESLint package (`@eslint/js`) in the environment and not due to the code change.
- No other automated tests were executed as part of this change in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cf0959a248330ad6edfe03ff4d4f3)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow server-to-server lead capture even when an origin allowlist is configured. Browser requests must use an allowed Origin; requests without Origin are accepted to match API-wide CORS policy.

- **Bug Fixes**
  - Added parseAllowedOrigins to normalize SALES_LEAD_CAPTURE_ALLOWED_ORIGINS into a Set.
  - Implemented validateLeadCaptureOrigin middleware and applied it to POST /api/sales/leads.

<sup>Written for commit fb222a8f3795b1dfb050c5cd05122aeda2af24a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added origin validation to the lead capture API endpoint for enhanced security.
  * Requests from origins not included on the allowlist will be rejected with a 403 error.
  * Server-to-server requests (without an Origin header) will continue to be processed normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->