### PR TITLE
test: skip non-assertive rate limiting header check

### DIFF
--- a/apps/web/tests/security.test.ts
+++ b/apps/web/tests/security.test.ts
@@ -137,7 +137,7 @@ describe("API Endpoint Security", () => {
     expect(allowMethods).toContain("GET");
   });
 
-  it("should have rate limiting headers on repeated requests", async () => {
+  it.skip("should have rate limiting headers on repeated requests", async () => {
     // Make 5 quick requests to test rate limiting
     const requests = Array(5)
       .fill(null)
@@ -150,8 +150,7 @@ describe("API Endpoint Security", () => {
       (r) => r.headers.has("x-ratelimit-limit") || r.headers.has("ratelimit-limit"),
     );
 
-    // This might not be implemented yet, so just log for now
-    console.log("Rate limiting headers present:", hasRateLimitHeaders);
+    expect(hasRateLimitHeaders).toBe(true);
   });
 });
 


### PR DESCRIPTION
### Motivation
- Prevent a false-positive test that only logged whether rate limit headers existed so the suite doesn't give a false sense of coverage.

### Description
- Updated `apps/web/tests/security.test.ts` to change the rate-limiting header test from `it(...)` to `it.skip(...)` so it is not counted as passing while unimplemented.
- Replaced the previous `console.log`-only behavior with an explicit assertion `expect(hasRateLimitHeaders).toBe(true)` to document the expected behavior when the test is re-enabled.
- Changes are committed under message `test: skip non-assertive rate limiting header check` and modify the single file `apps/web/tests/security.test.ts`.

### Testing
- Attempted to run the targeted test with `pnpm --filter web test:security`, but the run was blocked by a Node engine mismatch (package expects `>=20.11.1 <21`, environment has `v22.21.1`), so no automated tests were executed.
- No other automated test runs were performed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cf174cd0c8330bf9b831c1ddc3548)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skipped the rate-limiting header test and replaced logging with an explicit assertion to document the expected behavior. This prevents a misleading pass until rate-limit headers are implemented.

<sup>Written for commit 1a2646773cc989b83db958775b01680d5c501417. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

