### PR TITLE
chore(firebase): set default project to infamous-freight-85082765

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,5 +1,5 @@
 {
   "projects": {
-    "default": "demo-infamous-freight"
+    "default": "infamous-freight-85082765"
   }
 }


### PR DESCRIPTION
### Motivation
- Align the local Firebase CLI default project with the Firebase Studio project so local Firebase commands target `infamous-freight-85082765`.

### Description
- Update the `projects.default` value in `.firebaserc` from `demo-infamous-freight` to `infamous-freight-85082765`.

### Testing
- Validated the updated JSON with `python -m json.tool .firebaserc > /dev/null`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994f7b3289c8330a3778fafa96476d3)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the Firebase CLI default project to infamous-freight-85082765. This ensures local Firebase commands target the correct Firebase Studio project.

<sup>Written for commit b70bdc38e9a280c2c646700d56e3fe501974a1e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

