### PR TITLE
fix(ci): align workflow package paths with apps/* monorepo layout

### DIFF
--- a/.github/workflows/contract-testing.yml
+++ b/.github/workflows/contract-testing.yml
@@ -40,7 +40,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Web - Generate consumer contracts
-        run: pnpm --filter @infamous-freight/web test:contract
+        run: pnpm --filter web test:contract
         continue-on-error: true
 
       - name: Upload Pact files

--- a/.github/workflows/deploy-api-bluegreen.yml
+++ b/.github/workflows/deploy-api-bluegreen.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
     paths:
       - "apps/api/**"
-      - "packages/**"
+      - "packages/shared/**"
       - "pnpm-lock.yaml"
   workflow_call: {}
 concurrency:
@@ -39,7 +39,7 @@ jobs:
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
-      - run: pnpm --filter infamous-freight-api build
+      - run: pnpm --filter api build
 
       - name: Decide target color
         id: color
@@ -80,7 +80,7 @@ jobs:
             # Ensure the lock process is cleaned up on exit or error
             trap 'kill "$db_lock_pid" 2>/dev/null || true' EXIT
 
-            pnpm --filter infamous-freight-api prisma migrate deploy
+            pnpm --filter api prisma migrate deploy
 
             # Migration complete; release the lock and remove the trap
             kill "$db_lock_pid" 2>/dev/null || true

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
     paths:
       - "apps/api/**"
-      - "packages/**"
+      - "packages/shared/**"
       - "pnpm-lock.yaml"
   workflow_call: {}
 
@@ -39,7 +39,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build API
-        run: pnpm --filter infamous-freight-api build
+        run: pnpm --filter api build
 
       - name: Prisma migrate deploy (guarded + locked)
         run: |
@@ -58,7 +58,7 @@ jobs:
               echo "Failed to acquire Prisma migration lock within 180 seconds." >&2
               exit 1
             fi
-            pnpm --filter infamous-freight-api prisma migrate deploy
+            pnpm --filter api prisma migrate deploy
           else
             echo "No apps/api/prisma changes detected; skipping Prisma migrate deploy."
           fi

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -6,7 +6,7 @@ on:
       package-name:
         required: true
         type: string
-        description: "Package name to build (e.g., @infamous-freight/shared, infamous-freight-api)"
+        description: "Workspace package name to build (e.g., api, web, @infamous-freight/shared)"
       node-version:
         required: false
         type: string

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -6,7 +6,7 @@ on:
       package-name:
         required: true
         type: string
-        description: "Package name to test (e.g., infamous-freight-api, infamous-freight-web)"
+        description: "Workspace package name to test (e.g., api, web, @infamous-freight/shared)"
       node-version:
         required: false
         type: string


### PR DESCRIPTION
### Motivation
- Ensure CI and deployment workflows target current workspace package names under the `apps/*` monorepo layout rather than legacy package identifiers.
- Limit deploy triggers to the actual shared package location to avoid unnecessary runs on unrelated `packages/**` changes.

### Description
- Updated consumer contract job in `.github/workflows/contract-testing.yml` to run `pnpm --filter web test:contract` instead of the legacy `@infamous-freight/web` filter.
- Updated API deploy workflows (`.github/workflows/deploy-api.yml` and `.github/workflows/deploy-api-bluegreen.yml`) to watch `packages/shared/**` instead of `packages/**` and to run build/migrate commands using the workspace package name `api` (e.g. `pnpm --filter api build` and `pnpm --filter api prisma migrate deploy`).
- Clarified reusable workflow inputs in `.github/workflows/reusable-build.yml` and `.github/workflows/reusable-test.yml` to document workspace package names (`api`, `web`, `@infamous-freight/shared`).
- Committed the changes and opened a PR with the updated workflow files.

### Testing
- Ran repository searches to confirm no remaining legacy package filters with `rg` and validated expected replacements; the searches returned no legacy matches (success).
- Ran `git diff --check` to validate patch formatting and whitespace; no problems found (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4575dbab48330b94b54e7c57d6ca1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configurations to optimize package naming and deployment triggers across build, test, and deployment pipelines.
  * Updated workflow documentation to reflect current workspace package naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->