### PR TITLE
docs: fix architecture map package paths to real monorepo locations

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,6 +20,21 @@ server-side for observability, auditability, and resilience.
 Client (Web / Mobile) → API Gateway → AI Orchestration → Business Logic Engine →
 Data + Memory Layer → Automation + Jobs
 
+## Implementation Path Map (Authoritative)
+
+Use the following repository paths as the execution reference for current
+implementation ownership:
+
+- **UI implementation:** `apps/web/`
+- **AI implementation:** `apps/ai/`
+- **Financial/billing implementation:** `apps/api/src/routes/billing.js`,
+  `apps/api/src/services/`, and `payments/`
+- **Shared contracts/types/utilities:** `packages/shared/`
+
+> Note: legacy references to `packages/ui`, `packages/ai-engine`, and
+> `packages/financial` are obsolete in this repository and should not be used
+> for implementation work.
+
 ## Architecture Freeze Policy
 
 To stop structural churn, the architecture is frozen and changes to core


### PR DESCRIPTION
### Motivation

- The architecture document contained legacy package paths that do not exist in this repository and could misdirect implementers and owners.
- Provide an authoritative, execution-ready map that points to the actual locations of UI, AI, financial, and shared code so contributors can find the correct modules.

### Description

- Added an "Implementation Path Map (Authoritative)" section to `docs/architecture.md` with concrete repository paths used for implementation ownership. 
- Mapped UI to `apps/web/`, AI to `apps/ai/`, financial/billing to `apps/api/src/routes/billing.js`, `apps/api/src/services/`, and `payments/`, and shared contracts to `packages/shared/`.
- Added a clear deprecation note stating that `packages/ui`, `packages/ai-engine`, and `packages/financial` are obsolete for this repository.
- Kept the change localized to `docs/architecture.md` to avoid impacting runtime code.

### Testing

- Verified the referenced directories exist using `test -d apps/web && test -d apps/ai && test -d packages/shared && test -d payments` which returned `path checks passed`.
- Confirmed the updated `docs/architecture.md` was written to disk and the diff contains the new authoritative mapping (local verification successful).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4714c6cd08330afd0278a7416b8ec)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation with a new "Implementation Path Map (Authoritative)" section clarifying current repository paths for UI, AI, Financial/billing, and Shared components.
  * Added notices marking legacy repository references as obsolete to guide developers toward current best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->