### PR TITLE
Add one-command SaaS scaffold generator script

### DIFF
--- a/scripts/generate-saas-scaffold.sh
+++ b/scripts/generate-saas-scaffold.sh
@@ -1,7 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO_NAME="${1:-infamous-freight}"
+FORCE=0
+
+if [[ "${1-}" == "--force" ]]; then
+  FORCE=1
+  REPO_NAME="${2:-infamous-freight}"
+else
+  REPO_NAME="${1:-infamous-freight}"
+fi
+
+if [[ -d "$REPO_NAME" && $FORCE -ne 1 ]]; then
+  if [[ -n "$(ls -A "$REPO_NAME" 2>/dev/null || true)" ]]; then
+    echo "Error: Directory '$REPO_NAME' already exists and is not empty. Re-run with --force to overwrite." >&2
+    exit 1
+  fi
+fi
 mkdir -p "$REPO_NAME"
 cd "$REPO_NAME"
 


### PR DESCRIPTION
### Motivation
- Provide a simple, copy/paste-ready bootstrap that creates a GitHub-ready monorepo scaffold for the Infamous Freight SaaS so users can generate a starter codebase with one command.

### Description
- Add an executable script `scripts/generate-saas-scaffold.sh` that creates a new repo folder and writes core workspace files including `package.json`, `pnpm-workspace.yaml`, and `turbo.json`.
- The script also emits `docker-compose.yml` for `postgres` and `redis`, creates starter directories for `apps/api`, `apps/web`, `apps/mobile`, and `packages/shared`, and writes `packages/shared/src/types.ts` with `EnvSchema` and `RoleSchema`.
- It creates a minimal API environment template at `apps/api/.env.example` and a top-level `README.md` with quick-start instructions.
- The script is made executable and prints the created target path when complete.

### Testing
- Performed a syntax check with `bash -n scripts/generate-saas-scaffold.sh` which succeeded.
- Executed the script in a temporary directory (`./generate-saas-scaffold.sh test-scaffold`) and verified the presence of `test-scaffold/package.json` and `test-scaffold/packages/shared/src/types.ts`, which returned `OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7cda552a48330b6581305bb8577ef)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a one-command scaffold generator to bootstrap a GitHub-ready PNPM + Turbo monorepo for the Infamous Freight SaaS. Adds a --force overwrite option and a richer API folder structure.

- **New Features**
  - Adds scripts/generate-saas-scaffold.sh with repo setup scripts (dev/build/lint/db:up/db:down), pnpm-workspace.yaml, and turbo.json.
  - Generates docker-compose.yml (Postgres, Redis) and workspace layout: apps/api, apps/web, apps/mobile, packages/shared.
  - Expands apps/api with starter folders (middleware, routes, services, worker, jobs, queue, integrations/stripe, lib, prisma).
  - Includes packages/shared with zod, EnvSchema (JWT/Stripe keys, platform fee), RoleSchema, and index re-export.
  - Supports --force to overwrite a non-empty target directory.

- **Migration**
  - bash scripts/generate-saas-scaffold.sh [repo-name] [--force]
  - cd [repo-name] && pnpm i && pnpm db:up
  - cp apps/api/.env.example apps/api/.env

<sup>Written for commit 8902446c783efc3048862d1cd8fcdcfa4fcad3af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a SaaS scaffold generator that creates a complete monorepo project structure with workspace orchestration, development, build, and lint tasks
  * Includes pre-configured Docker setup with database and cache services
  * Provides a shared TypeScript package with environment configuration and role-based type definitions
  * Scaffolds application and package directories with initial configuration files and sample environment templates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->