### PR TITLE
Add one-command live SaaS monorepo generator script

### DIFF
--- a/scripts/generate-live-saas-monorepo.sh
+++ b/scripts/generate-live-saas-monorepo.sh
@@ -199,20 +199,30 @@ import { env } from '../env.js';
 
 export const authRoutes = Router();
 
-authRoutes.post('/register', async (req, res) => {
-  const { orgName, email, password } = req.body ?? {};
-  const org = await prisma.organization.create({ data: { name: orgName } });
-  const user = await prisma.user.create({ data: { orgId: org.id, email, role: 'OWNER', passwordHash: await bcrypt.hash(password, 12) } });
-  const token = jwt.sign({ sub: user.id, orgId: org.id, role: user.role, email: user.email }, env.JWT_SECRET, { expiresIn: '7d' });
-  res.json({ org, user: { id: user.id, email: user.email, role: user.role }, token });
+authRoutes.post('/register', async (req, res, next) => {
+  try {
+    const { orgName, email, password } = req.body ?? {};
+    const org = await prisma.organization.create({ data: { name: orgName } });
+    const user = await prisma.user.create({ data: { orgId: org.id, email, role: 'OWNER', passwordHash: await bcrypt.hash(password, 12) } });
+    const token = jwt.sign({ sub: user.id, orgId: org.id, role: user.role, email: user.email }, env.JWT_SECRET, { expiresIn: '7d' });
+    res.json({ org, user: { id: user.id, email: user.email, role: user.role }, token });
+  } catch (err) {
+    next(err);
+  }
 });
 
-authRoutes.post('/login', async (req, res) => {
-  const { orgId, email, password } = req.body ?? {};
-  const user = await prisma.user.findFirst({ where: { orgId, email } });
-  if (!user || !(await bcrypt.compare(password, user.passwordHash))) return res.status(401).json({ error: 'Invalid credentials' });
-  const token = jwt.sign({ sub: user.id, orgId: user.orgId, role: user.role, email: user.email }, env.JWT_SECRET, { expiresIn: '7d' });
-  res.json({ token, user: { id: user.id, email: user.email, role: user.role } });
+authRoutes.post('/login', async (req, res, next) => {
+  try {
+    const { orgId, email, password } = req.body ?? {};
+    const user = await prisma.user.findFirst({ where: { orgId, email } });
+    if (!user || !(await bcrypt.compare(password, user.passwordHash))) {
+      return res.status(401).json({ error: 'Invalid credentials' });
+    }
+    const token = jwt.sign({ sub: user.id, orgId: user.orgId, role: user.role, email: user.email }, env.JWT_SECRET, { expiresIn: '7d' });
+    res.json({ token, user: { id: user.id, email: user.email, role: user.role } });
+  } catch (err) {
+    next(err);
+  }
 });
 TS
 


### PR DESCRIPTION
### Motivation
- Provide a single, reproducible command to scaffold a full Live SaaS monorepo (API, worker, web, mobile, infra) so contributors can bootstrap the project quickly.
- Ensure the generated output is runnable out-of-the-box with sensible defaults for local development (Postgres + Redis via `docker-compose`, Prisma schema, seed data, basic auth and routes).
- Reduce manual setup errors by scripting workspace, package, and app creation into one executable script.

### Description
- Add an executable script `scripts/generate-live-saas-monorepo.sh` that creates a pnpm workspace with `package.json`, `pnpm-workspace.yaml`, `turbo.json`, and `docker-compose.yml` for Postgres and Redis.
- The script generates a `packages/shared` package with environment schemas and scaffolded `apps/api` including a Prisma `schema.prisma`, `env` parsing, `prisma` client, basic auth middleware, auth and loads routes, and a `seed.ts` script.
- It also scaffolds `apps/web` (Next.js shell, API helper) and `apps/mobile` (Expo shell) plus a top-level `README.md` with quick-start commands.
- The generator accepts an optional output directory argument (default `infamous-freight`) and is designed to be run directly to produce a working monorepo skeleton.

### Testing
- Performed a syntax check with `bash -n scripts/generate-live-saas-monorepo.sh` which succeeded.
- Executed the generator into a temporary folder with `scripts/generate-live-saas-monorepo.sh ./.tmp-gen-$$` and verified generated files exist by checking `./.tmp-gen-*/apps/api/src/index.ts` and `./.tmp-gen-*/apps/mobile/App.tsx` which succeeded.
- No automated unit tests were added in this change; validation focused on generation correctness and file presence checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7d05ee850833090f6cfcf511e3b33)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a one-command generator to scaffold a complete Live SaaS pnpm monorepo (API, worker, web, mobile, infra) with Postgres/Redis. Produces a runnable setup with JWT auth, loads endpoints, a health check, and quick-start scripts.

- **New Features**
  - Added scripts/generate-live-saas-monorepo.sh (optional output dir, default: infamous-freight).
  - Creates workspace config (package.json with dev/build/db:up/db:down, pnpm-workspace.yaml, turbo.json) and docker-compose for Postgres + Redis.
  - Scaffolds shared env schemas; API (Express + Prisma + /auth + /loads + seed + /health); Worker (BullMQ scaffold); Web (Next.js app router + API helper); Mobile (Expo app).
  - Adds .env.example for API/web/mobile and a top-level README with quick-start commands.

- **Migration**
  - Run: scripts/generate-live-saas-monorepo.sh <dir>.
  - In the new dir: pnpm i → pnpm db:up → copy .env examples → prisma migrate + seed for API → start API and web dev servers.

<sup>Written for commit 0de6d3e0fdc725d42937184fd7f0bb070f930f9a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

