### PR TITLE
docs: add strategic monitoring cadence to ONGOING_MONITORING.md

### DIFF
--- a/docs/ONGOING_MONITORING.md
+++ b/docs/ONGOING_MONITORING.md
@@ -10,6 +10,18 @@ Effective ongoing monitoring ensures early detection of issues, prevents
 technical debt accumulation, and maintains system reliability. This guide
 provides actionable procedures for daily, weekly, and monthly tasks.
 
+## Strategic Monitoring Cadence
+
+Use the following fixed cadence for market and business monitoring:
+
+| Task | Frequency | Time |
+| --- | --- | --- |
+| Monitor freight industry news | Daily | 8:00 AM |
+| Check platform reliability and incidents | Daily | 9:00 AM |
+| Watch competitor funding and launches | Daily | 12:00 PM |
+| Monitor trucking and brokerage regulations | Weekly (Monday) | 7:30 AM |
+| Review Infamous Freight revenue engine | Weekly (Friday) | 4:00 PM |
+
 ## Minimum Ops Stack (Locked)
 
 - **Central Logs**: API request + error logs


### PR DESCRIPTION
### Motivation
- Add a fixed, actionable cadence for market and platform monitoring tasks so operations have a clear daily/weekly schedule (daily 8:00 AM freight news, daily 9:00 AM reliability/incidents, daily 12:00 PM competitor funding/launches, weekly Mondays 7:30 AM regulations, weekly Fridays 4:00 PM revenue engine). 

### Description
- Inserted a new `Strategic Monitoring Cadence` section with a 3-column table into `docs/ONGOING_MONITORING.md` that documents the five recurring tasks and their scheduled times, and committed the change. 

### Testing
- Documentation-only change; no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a92182730083308d6ada7a53a445a7)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a Strategic Monitoring Cadence to ONGOING_MONITORING.md with fixed daily and weekly times for key monitoring tasks. This gives operations a clear schedule for industry news, reliability checks, competitor activity, regulations, and revenue reviews.

<sup>Written for commit 8eb67bcbe0f4c4814d1120c06df1c19248958ce4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

