### PR TITLE
Stabilize API test suite: add shared scope mocks, Prisma guards, router export, and test path fixes

### DIFF
--- a/apps/api/__tests__/integration/api-workflows.integration.test.js
+++ b/apps/api/__tests__/integration/api-workflows.integration.test.js
@@ -6,7 +6,7 @@
 
 const request = require('supertest');
 const jwt = require('jsonwebtoken');
-const { prisma } = require('../../../src/db/prisma');
+const { prisma } = require('../../src/db/prisma');
 
 const TEST_JWT_SECRET = process.env.JWT_SECRET || 'test-secret-key';
 const VALID_UUID = '550e8400-e29b-41d4-a716-446655440000';
@@ -35,8 +35,8 @@ describe('API Integration Tests - Complete Workflows', () => {
     let userToken;
     let adminToken;
 
-    before(async () => {
-        app = require('../../../src/app');
+    beforeAll(async () => {
+        app = require('../../src/app');
 
         userToken = generateTestToken(TEST_USER_ID, [
             'shipment:read',

--- a/apps/api/__tests__/setup.js
+++ b/apps/api/__tests__/setup.js
@@ -49,7 +49,13 @@ jest.mock("@infamous-freight/shared", () => ({
     DELIVERED: "delivered",
     CANCELED: "canceled",
   },
+  validateScope: jest.fn(() => true),
+  hasScope: jest.fn(() => true),
+  hasAllScopes: jest.fn(() => true),
 }));
+
+global.__PRISMA_MOCK__ = global.__PRISMA_MOCK__ || {};
+global.__PRISMA_MOCK__.$on = global.__PRISMA_MOCK__.$on || jest.fn();
 
 // Mock external services
 jest.mock("../src/services/aiSyntheticClient", () => ({

--- a/apps/api/src/db/prisma.js
+++ b/apps/api/src/db/prisma.js
@@ -30,41 +30,45 @@ function getPrisma() {
     attachSlowQueryLogger(basePrisma);
 
     // Track query performance for admin analytics using Prisma Client Extensions (v7)
-    prisma = basePrisma.$extends({
-      query: {
-        $allModels: {
-          async $allOperations({ model, operation, args, query }) {
-            const start = Date.now();
-            try {
-              const result = await query(args);
-              const duration = Date.now() - start;
+    if (typeof basePrisma.$extends === "function") {
+      prisma = basePrisma.$extends({
+        query: {
+          $allModels: {
+            async $allOperations({ model, operation, args, query }) {
+              const start = Date.now();
+              try {
+                const result = await query(args);
+                const duration = Date.now() - start;
 
-              if (duration >= DEFAULT_THRESHOLD) {
-                console.warn(`Slow query detected: ${model}.${operation} took ${duration}ms`);
+                if (duration >= DEFAULT_THRESHOLD) {
+                  console.warn(`Slow query detected: ${model}.${operation} took ${duration}ms`);
+                }
+
+                recordQuery({
+                  model,
+                  action: operation,
+                  duration,
+                  args,
+                });
+
+                return result;
+              } catch (error) {
+                recordQuery({
+                  model,
+                  action: operation,
+                  duration: Date.now() - start,
+                  args,
+                  error,
+                });
+                throw error;
               }
-
-              recordQuery({
-                model,
-                action: operation,
-                duration,
-                args,
-              });
-
-              return result;
-            } catch (error) {
-              recordQuery({
-                model,
-                action: operation,
-                duration: Date.now() - start,
-                args,
-                error,
-              });
-              throw error;
-            }
+            },
           },
         },
-      },
-    });
+      });
+    } else {
+      prisma = basePrisma;
+    }
   }
   return prisma;
 }

--- a/apps/api/src/lib/slowQueryLogger.js
+++ b/apps/api/src/lib/slowQueryLogger.js
@@ -9,6 +9,8 @@ const Sentry = require("@sentry/node");
 const SLOW_QUERY_THRESHOLD_MS = parseInt(process.env.SLOW_QUERY_THRESHOLD_MS || "1000", 10);
 
 function attachSlowQueryLogger(prisma) {
+  if (!prisma || typeof prisma.$on !== "function") return prisma;
+
   prisma.$on("query", (e) => {
     const durationMs = e.duration;
 

--- a/apps/api/src/routes/users.js
+++ b/apps/api/src/routes/users.js
@@ -46,6 +46,8 @@ router.get(
   }),
 );
 
+module.exports = router;
+
 /**
  * PATCH /api/users/me
  * Update current user profile

--- a/apps/api/src/services/__tests__/redisCache.test.js
+++ b/apps/api/src/services/__tests__/redisCache.test.js
@@ -3,7 +3,6 @@
  * Unit tests for RedisCache class and caching middleware
  */
 
-const { describe, it, expect, beforeEach, afterEach, vi } = require("vitest");
 const { RedisCache, getCache } = require("../redisCache");
 
 describe("RedisCache", () => {
@@ -13,26 +12,26 @@ describe("RedisCache", () => {
     cache = new RedisCache("redis://localhost:6379");
     // Mock client methods
     cache.client = {
-      get: vi.fn(),
-      setEx: vi.fn(),
-      del: vi.fn(),
-      keys: vi.fn(),
-      ping: vi.fn(),
-      connect: vi.fn(),
-      disconnect: vi.fn(),
-      on: vi.fn(),
-      incrBy: vi.fn(),
-      decrBy: vi.fn(),
-      sAdd: vi.fn(),
-      sIsMember: vi.fn(),
-      sMembers: vi.fn(),
-      flushAll: vi.fn(),
+      get: jest.fn(),
+      setEx: jest.fn(),
+      del: jest.fn(),
+      keys: jest.fn(),
+      ping: jest.fn(),
+      connect: jest.fn(),
+      disconnect: jest.fn(),
+      on: jest.fn(),
+      incrBy: jest.fn(),
+      decrBy: jest.fn(),
+      sAdd: jest.fn(),
+      sIsMember: jest.fn(),
+      sMembers: jest.fn(),
+      flushAll: jest.fn(),
     };
     cache.connected = true;
   });
 
   afterEach(() => {
-    vi.clearAllMocks();
+    jest.clearAllMocks();
   });
 
   describe("get()", () => {
@@ -107,7 +106,7 @@ describe("RedisCache", () => {
   describe("getOrCompute()", () => {
     it("should return cached value without computing", async () => {
       const testData = { id: 1 };
-      const computeFn = vi.fn();
+      const computeFn = jest.fn();
 
       cache.client.get.mockResolvedValue(JSON.stringify(testData));
 
@@ -120,7 +119,7 @@ describe("RedisCache", () => {
 
     it("should compute and cache value on miss", async () => {
       const testData = { id: 1, computed: true };
-      const computeFn = vi.fn().mockResolvedValue(testData);
+      const computeFn = jest.fn().mockResolvedValue(testData);
 
       cache.client.get.mockResolvedValue(null);
       cache.client.setEx.mockResolvedValue("OK");
@@ -237,7 +236,7 @@ describe("RedisCache", () => {
 
     it("should execute and cache query on miss", async () => {
       const queryResult = [{ id: 1 }, { id: 2 }];
-      const queryFn = vi.fn().mockResolvedValue(queryResult);
+      const queryFn = jest.fn().mockResolvedValue(queryResult);
 
       cache.client.get.mockResolvedValue(null);
       cache.client.setEx.mockResolvedValue("OK");

--- a/apps/api/src/services/__tests__/shipmentValidator.test.js
+++ b/apps/api/src/services/__tests__/shipmentValidator.test.js
@@ -12,7 +12,7 @@ const {
     getValidNextStatuses,
     isTerminalStatus,
     getShipmentStateInfo,
-} = require("../services/shipmentValidator");
+} = require("../shipmentValidator");
 const { SHIPMENT_STATUSES } = require("@infamous-freight/shared");
 
 describe("Shipment Validator Service", () => {


### PR DESCRIPTION
### Motivation
- Reduce cascading test failures caused by missing auth scope helpers and absent Prisma event hooks during unit/integration runs.
- Prevent runtime crashes in test environments when Prisma is mocked or missing features like `$on`/`$extends`.
- Fix broken test imports and runner mismatches (Vitest → Jest) that cause numerous spurious failures.

### Description
- Add missing shared helpers and a Prisma `$on` fallback mock in the test harness (`apps/api/__tests__/setup.js`) by adding `validateScope`, `hasScope`, `hasAllScopes` mocks and `global.__PRISMA_MOCK__.$on`.
- Export the Express router from `apps/api/src/routes/users.js` by adding `module.exports = router` so route imports resolve correctly.
- Guard slow-query registration in `apps/api/src/lib/slowQueryLogger.js` with `if (!prisma || typeof prisma.$on !== "function") return prisma;` to avoid errors when `$on` is unavailable.
- Guard Prisma client extension usage in `apps/api/src/db/prisma.js` by checking `typeof basePrisma.$extends === "function"` and falling back to the base client when not present.
- Fix test import paths and runner compatibility by updating `apps/api/src/services/__tests__/shipmentValidator.test.js` to use the correct `require('../shipmentValidator')`, updating `apps/api/__tests__/integration/api-workflows.integration.test.js` relative imports and `beforeAll`, and converting Vitest `vi` usages to Jest `jest` in `apps/api/src/services/__tests__/redisCache.test.js`.

### Testing
- Ran `node --check` across modified files (`apps/api/src/routes/users.js`, `apps/api/src/lib/slowQueryLogger.js`, `apps/api/src/db/prisma.js`, `apps/api/src/services/__tests__/shipmentValidator.test.js`, `apps/api/src/services/__tests__/redisCache.test.js`, `apps/api/__tests__/integration/api-workflows.integration.test.js`) and it succeeded.
- Attempted to run the impacted tests with `npm test -- --runInBand ...` but the environment lacks the `jest` binary so the Jest run failed with `jest: not found` and could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9329269e08330b5f1b6184f8f84fe)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the API test suite by adding shared scope mocks, guarding Prisma hooks/extensions, exporting the users router, and fixing Jest paths/usages. This stops cascading test failures and prevents crashes when Prisma event APIs aren’t available.

- **Bug Fixes**
  - Test harness: add validateScope, hasScope, hasAllScopes mocks and a global __PRISMA_MOCK__.$on fallback.
  - Prisma guards: skip attachSlowQueryLogger when $on is missing; fall back to base client when $extends isn’t a function.
  - Routing: export the users router to fix import resolution.
  - Tests: fix import paths in integration and shipmentValidator tests; switch Vitest vi to Jest jest; use beforeAll in integration test.

<sup>Written for commit 20a6918bb74be004e2ee781c3db6debf3d1a7a18. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

