### PR TITLE
docs: add Codex PR command pack guide

### DIFF
--- a/docs/CODEX_PR_COMMAND_PACK.md
+++ b/docs/CODEX_PR_COMMAND_PACK.md
@@ -109,7 +109,7 @@ Review pass checklist:
 ## 12) If Codex is too vague
 
 ```text
-@codex address all current review comments with concrete code changes. Do not just summarize the issues. Update the PR directly, keep the patch set minimal, and prioritize deterministic fixes over speculative refactors. Validate auth/rbac behavior, Prisma safety, test setup compatibility, and CI reliability. Then post a file-by-file summary of what changed.
+@codex address all current review comments with concrete code changes. Do not just summarize the issues. Update the PR directly, keep the patch set minimal, and prioritize deterministic fixes over speculative refactors. Validate auth/RBAC behavior, Prisma safety, test setup compatibility, and CI reliability. Then post a file-by-file summary of what changed.
 ```
 
 ## 13) If Codex keeps thrashing


### PR DESCRIPTION
### Motivation
- Provide maintainers a single in-repo playbook of ready-to-paste `@codex` PR comments to speed review/fix loops and reduce ambiguity. 
- Make it easier to triage high-impact problems like failing CI/tests, auth/RBAC, Prisma/database issues, and test/mocking problems with scoped command templates.

### Description
- Add a new file `docs/CODEX_PR_COMMAND_PACK.md` containing a comprehensive set of ready-to-paste `@codex` review and fix commands. 
- Include scoped command variants for CI/tests, backend/auth/API, frontend/web, Prisma/database, tests/mocks, and CI/workflows. 
- Provide maintainer-facing reply templates, a re-review checklist, and a recommended execution order to ensure minimal, production-safe patches.

### Testing
- Verified the new file content by printing the file head and verifying line count with `nl -ba docs/CODEX_PR_COMMAND_PACK.md | sed -n '1,220p'`, which showed the expected guide content. 
- Confirmed file length with `wc -l docs/CODEX_PR_COMMAND_PACK.md`, which returned the expected line count and indicated the file was created successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa4292ec48833098cfebfe2ba1dacf)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Codex PR command pack guide with ready-to-paste @codex comments to speed reviews and stabilize CI. Includes a repo-specific best all‑in‑one command, an ultra‑compact quick-start, and prompts for concise post-change summaries.

- **New Features**
  - Added docs/CODEX_PR_COMMAND_PACK.md with templates for fresh review, fix‑all, review‑only, and targeted scopes (CI/tests, auth/RBAC & API, frontend, Prisma/db, tests/mocks, workflows).
  - Added guardrail commands for vague/thrashing cases, plus maintainer reply/checklist, a recommended execution order, and notes on required inputs for real fixes.

<sup>Written for commit bf605cc337ea3ea5d0d478ef9517fd2a2600058f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

