### PR TITLE
Update MIT license copyright holder to Santorio Miles

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 [Your Name]
+Copyright (c) 2026 Santorio Miles
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
### Motivation
- Replace the placeholder `[Your Name]` in `LICENSE` so the MIT license is correctly assigned to the project owner.

### Description
- Updated the `LICENSE` file to read `Copyright (c) 2026 Santorio Miles` at the top of the file.

### Testing
- Verified the update with `git diff -- LICENSE && git status --short` and inspected the file start with `nl -ba LICENSE | sed -n '1,20p'`, both showing the new copyright line.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa6342dc18833088a41150af016448)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the MIT LICENSE to attribute copyright to Santorio Miles (2026), replacing the placeholder so the project license is correctly assigned.

<sup>Written for commit 21c10bac8fbc0bed41154c08d5145b056cfed236. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the copyright holder name in the LICENSE file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->