### PR TITLE
ci: fix auto-health-monitoring git hooks check and harden workflow logging

### DIFF
--- a/.github/workflows/auto-health-monitoring.yml
+++ b/.github/workflows/auto-health-monitoring.yml
@@ -21,6 +21,7 @@ jobs:
 
       - name: 📊 Collect Health Metrics
         run: |
+          set -euxo pipefail
           echo "📡 Repository Health Monitor"
           echo "════════════════════════════════════════════════════════"
           echo ""
@@ -70,6 +71,7 @@ jobs:
 
       - name: 🔍 Forbidden Patterns Check
         run: |
+          set -euxo pipefail
           echo "🔍 Checking forbidden patterns..."
           echo ""
           
@@ -91,22 +93,31 @@ jobs:
 
       - name: 🔐 Git Hooks Health
         run: |
+          set -euxo pipefail
           echo "🔐 Git Hooks Configuration:"
           echo ""
-          
-          HOOKS_PATH=$(git config core.hooksPath)
-          echo "  - core.hooksPath: $HOOKS_PATH"
-          
-          if [ -d "$HOOKS_PATH" ]; then
-            echo "  ✅ Hooks directory exists"
-            HOOKS=$(ls -1 "$HOOKS_PATH" 2>/dev/null | wc -l)
-            echo "  - Hooks configured: $HOOKS"
+
+          # Safe retrieval when core.hooksPath is not configured.
+          HOOKS_PATH="$(git config --get core.hooksPath || true)"
+
+          if [ -n "$HOOKS_PATH" ]; then
+            echo "  - core.hooksPath: $HOOKS_PATH"
+
+            if [ -d "$HOOKS_PATH" ]; then
+              echo "  ✅ Hooks directory exists"
+              HOOKS=$(find "$HOOKS_PATH" -maxdepth 1 -type f 2>/dev/null | wc -l)
+              echo "  - Hooks configured: $HOOKS"
+            else
+              echo "  ⚠️  Hooks path is set but directory was not found"
+            fi
           else
-            echo "  ⚠️  Hooks directory not found"
+            echo "  - core.hooksPath: not configured"
+            echo "  ℹ️  Using default .git/hooks behavior"
           fi
 
       - name: 📚 Documentation Health
         run: |
+          set -euxo pipefail
           echo "📚 Documentation Status:"
           echo ""
           
@@ -134,6 +145,7 @@ jobs:
 
       - name: 🔗 Link Verification
         run: |
+          set -euxo pipefail
           echo "🔗 Link Health Check:"
           echo ""
           
@@ -152,6 +164,7 @@ jobs:
 
       - name: 📊 Generate Health Score
         run: |
+          set -euxo pipefail
           echo "📊 Repository Health Score:"
           echo ""
           
@@ -165,7 +178,8 @@ jobs:
           fi
           
           # Check git config
-          if [ -z "$(git config core.hooksPath)" ]; then
+          HOOKS_PATH="$(git config --get core.hooksPath || true)"
+          if [ -z "$HOOKS_PATH" ]; then
             HEALTH=$((HEALTH - 5))
           fi
           
@@ -197,6 +211,7 @@ jobs:
     steps:
       - name: 📊 Upload Metrics
         run: |
+          set -euxo pipefail
           echo "════════════════════════════════════════════════════════"
           echo "📡 AUTO HEALTH MONITORING REPORT"
           echo "════════════════════════════════════════════════════════"


### PR DESCRIPTION
### Motivation
- The `Git Hooks Health` step could fail when `core.hooksPath` is unset because `git config` returned a non-zero exit status and the workflow was running in fail-fast mode.
- Workflow logging and shell steps lacked strict safety flags which made diagnosing failures harder and allowed subtle errors to terminate the job unexpectedly.

### Description
- Add `set -euxo pipefail` to each run step to enable strict shell behavior and improve debugging traceability.
- Safely read the hooks configuration using `git config --get core.hooksPath || true` and only act when a value is present to avoid non-zero exit failures.
- Replace brittle `ls` counting with `find ... -type f` to robustly count configured hook files and handle missing directories gracefully.
- Update the health score calculation to use the safe `HOOKS_PATH` retrieval before applying score deductions and emit clear fallback messages when hooks are not configured.

### Testing
- Ran `git diff -- .github/workflows/auto-health-monitoring.yml` to verify the intended changes are present and the diff looks correct, and this check passed.
- Ran `git diff --check` to ensure there are no whitespace or index errors, and this check passed.
- Attempted to run `yamllint` for YAML validation but `yamllint` was not installed in the environment, so linting was skipped.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aff229ff448330b3fff1d9aa0b10a5)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the Git Hooks Health step in `auto-health-monitoring.yml` so it doesn’t fail when `core.hooksPath` is unset, and harden shell steps with strict flags for clearer logs. This prevents false CI failures and makes debugging easier.

- **Bug Fixes**
  - Add `set -euxo pipefail` to all run steps for safer execution and clearer tracing.
  - Read hooks path with `git config --get core.hooksPath || true` and only check when present.
  - Replace `ls` with `find ... -type f` for robust hook file counting; update health score to use the safe `HOOKS_PATH` and emit clear fallback messages when hooks aren’t configured.

<sup>Written for commit 9fbdb31cc875f5cb09135cae877aa37ae06788a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

