### PR TITLE
feat(api): add tenant-aware JWT auth with refresh token rotation

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -25,8 +25,9 @@ model User {
   email        String   @unique
   passwordHash String
   role         String   @default("dispatcher")
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  createdAt    DateTime       @default(now())
+  updatedAt    DateTime       @updatedAt
+  refreshTokens RefreshToken[]
 
   @@index([tenantId])
   @@index([email])
@@ -100,4 +101,18 @@ model Load {
   updatedAt       DateTime  @updatedAt
 
   @@index([tenantId])
+}
+
+model RefreshToken {
+  id        String   @id @default(cuid())
+  userId    String
+  tenantId  String
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  tokenHash String   @unique
+  expiresAt DateTime
+  revokedAt DateTime?
+  createdAt DateTime @default(now())
+
+  @@index([userId, tenantId])
+  @@index([expiresAt])
 }

--- a/apps/api/src/auth/jwt.js
+++ b/apps/api/src/auth/jwt.js
@@ -1,20 +1,48 @@
+const crypto = require("crypto");
 const jwt = require("jsonwebtoken");
 const { env } = require("../config/env");
 
+function getAccessSecret() {
+  return env.jwtSecret;
+}
+
+function getRefreshSecret() {
+  return env.jwtRefreshSecret || env.jwtSecret;
+}
+
+function signAccessToken(payload) {
+  return jwt.sign(payload, getAccessSecret(), { expiresIn: env.jwtExpiry || "15m" });
+}
+
+function signRefreshToken(payload) {
+  return jwt.sign(payload, getRefreshSecret(), { expiresIn: env.jwtRefreshExpiry || "30d" });
+}
+
 function signUserToken(userId) {
-  const claims = { sub: userId, scopes: ["user:avatar"] };
-  return jwt.sign(claims, env.jwtSecret, { expiresIn: env.jwtExpiry || "30d" });
+  return signAccessToken({ sub: userId, scopes: ["user:avatar"], role: "dispatcher", org_id: "dev-tenant" });
 }
 
 function verifyToken(token) {
   try {
-    return jwt.verify(token, env.jwtSecret);
+    return jwt.verify(token, getAccessSecret());
   } catch {
     return null;
   }
 }
 
+function verifyRefreshToken(token) {
+  return jwt.verify(token, getRefreshSecret());
+}
+
+function hashRefreshToken(token) {
+  return crypto.createHash("sha256").update(token).digest("hex");
+}
+
 module.exports = {
+  signAccessToken,
+  signRefreshToken,
   signUserToken,
   verifyToken,
+  verifyRefreshToken,
+  hashRefreshToken,
 };

--- a/apps/api/src/auth/jwt.js
+++ b/apps/api/src/auth/jwt.js
@@ -15,7 +15,15 @@ function signAccessToken(payload) {
 }
 
 function signRefreshToken(payload) {
-  return jwt.sign(payload, getRefreshSecret(), { expiresIn: env.jwtRefreshExpiry || "30d" });
+  const jwtId =
+    typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID()
+      : crypto.randomBytes(16).toString("hex");
+
+  return jwt.sign(payload, getRefreshSecret(), {
+    expiresIn: env.jwtRefreshExpiry || "30d",
+    jwtid: jwtId,
+  });
 }
 
 function signUserToken(userId) {

--- a/apps/api/src/auth/routes.js
+++ b/apps/api/src/auth/routes.js
@@ -190,7 +190,7 @@ router.post("/refresh", express.json(), async (req, res) => {
       refreshExpiresIn: env.jwtRefreshExpiry,
     });
   } catch (err) {
-    const statusCode = err.statusCode || (err.name === "ZodError" ? 400 : 401);
+    const statusCode = err.statusCode || (err.name === "ZodError" ? 400 : 500);
     return res.status(statusCode).json({ ok: false, error: err.message || "Unable to refresh token" });
   }
 });

--- a/apps/api/src/auth/routes.js
+++ b/apps/api/src/auth/routes.js
@@ -1,10 +1,85 @@
 const express = require("express");
+const bcrypt = require("bcryptjs");
 const { z } = require("zod");
-const { signUserToken } = require("./jwt");
+const { signAccessToken, signRefreshToken, verifyRefreshToken, hashRefreshToken } = require("./jwt");
 const { getUserId } = require("./user");
 const { env } = require("../config/env");
+const { getPrisma } = require("../db/prisma");
 
 const router = express.Router();
+
+const roleScopes = {
+  admin: ["admin", "users:read", "users:write", "shipments:read", "shipments:write", "organization:read", "organization:write"],
+  dispatcher: ["shipments:read", "shipments:write", "loads:read", "loads:write", "dispatch:read", "dispatch:write", "users:read"],
+  driver: ["shipments:read", "loads:read", "dispatch:read"],
+  viewer: ["shipments:read", "loads:read", "users:read"],
+};
+
+function normalizeRole(role) {
+  return String(role || "dispatcher").trim().toLowerCase();
+}
+
+function getScopesForRole(role) {
+  return roleScopes[normalizeRole(role)] || roleScopes.dispatcher;
+}
+
+function serializeAuthUser(user) {
+  return {
+    id: user.id,
+    email: user.email,
+    tenantId: user.tenantId,
+    role: normalizeRole(user.role),
+    scopes: getScopesForRole(user.role),
+  };
+}
+
+async function persistRefreshToken(prisma, payload, refreshToken) {
+  if (!prisma?.refreshToken) {
+    return null;
+  }
+
+  const decoded = verifyRefreshToken(refreshToken);
+  await prisma.refreshToken.create({
+    data: {
+      userId: payload.sub,
+      tenantId: payload.org_id,
+      tokenHash: hashRefreshToken(refreshToken),
+      expiresAt: new Date(decoded.exp * 1000),
+    },
+  });
+
+  return decoded;
+}
+
+async function rotateRefreshToken(prisma, refreshToken) {
+  const decoded = verifyRefreshToken(refreshToken);
+
+  if (!prisma?.refreshToken) {
+    return decoded;
+  }
+
+  const tokenHash = hashRefreshToken(refreshToken);
+  const stored = await prisma.refreshToken.findFirst({
+    where: {
+      tokenHash,
+      revokedAt: null,
+      expiresAt: { gt: new Date() },
+    },
+  });
+
+  if (!stored) {
+    const error = new Error("Refresh token revoked or expired");
+    error.statusCode = 401;
+    throw error;
+  }
+
+  await prisma.refreshToken.update({
+    where: { id: stored.id },
+    data: { revokedAt: new Date() },
+  });
+
+  return decoded;
+}
 
 // POST /v1/auth/dev-token -> issue a JWT for a given userId (dev helper)
 router.post("/dev-token", express.json(), (req, res) => {
@@ -16,10 +91,130 @@ router.post("/dev-token", express.json(), (req, res) => {
       return res.status(403).json({ ok: false, error: "dev-token disabled" });
     }
 
-    const token = signUserToken(body.userId);
-    res.json({ ok: true, token });
+    const accessToken = signAccessToken({
+      sub: body.userId,
+      email: undefined,
+      role: "dispatcher",
+      org_id: req.headers["x-org-id"] || "dev-tenant",
+      scopes: roleScopes.dispatcher,
+    });
+    res.json({ ok: true, token: accessToken, accessToken });
   } catch (err) {
     res.status(400).json({ ok: false, error: err?.message || "invalid request" });
+  }
+});
+
+router.post("/login", express.json(), async (req, res) => {
+  try {
+    const schema = z.object({
+      email: z.email(),
+      password: z.string().min(8),
+      tenantId: z.string().min(1).max(191),
+    });
+    const body = schema.parse(req.body);
+
+    const prisma = getPrisma();
+    if (!prisma?.user) {
+      return res.status(503).json({ ok: false, error: "Database unavailable" });
+    }
+
+    const user = await prisma.user.findFirst({
+      where: {
+        email: body.email.toLowerCase(),
+        tenantId: body.tenantId,
+      },
+    });
+
+    if (!user) {
+      return res.status(401).json({ ok: false, error: "Invalid credentials" });
+    }
+
+    const validPassword = await bcrypt.compare(body.password, user.passwordHash);
+    if (!validPassword) {
+      return res.status(401).json({ ok: false, error: "Invalid credentials" });
+    }
+
+    const authUser = serializeAuthUser(user);
+    const tokenPayload = {
+      sub: authUser.id,
+      email: authUser.email,
+      role: authUser.role,
+      org_id: authUser.tenantId,
+      scopes: authUser.scopes,
+    };
+
+    const accessToken = signAccessToken(tokenPayload);
+    const refreshToken = signRefreshToken(tokenPayload);
+    await persistRefreshToken(prisma, tokenPayload, refreshToken);
+
+    return res.json({
+      ok: true,
+      accessToken,
+      refreshToken,
+      tokenType: "Bearer",
+      expiresIn: env.jwtExpiry,
+      refreshExpiresIn: env.jwtRefreshExpiry,
+      user: authUser,
+    });
+  } catch (err) {
+    const statusCode = err.statusCode || (err.name === "ZodError" ? 400 : 500);
+    return res.status(statusCode).json({ ok: false, error: err.message || "Authentication failed" });
+  }
+});
+
+router.post("/refresh", express.json(), async (req, res) => {
+  try {
+    const schema = z.object({ refreshToken: z.string().min(1) });
+    const { refreshToken } = schema.parse(req.body);
+    const prisma = getPrisma();
+    const decoded = await rotateRefreshToken(prisma, refreshToken);
+
+    const payload = {
+      sub: decoded.sub,
+      email: decoded.email,
+      role: normalizeRole(decoded.role),
+      org_id: decoded.org_id,
+      scopes: Array.isArray(decoded.scopes) ? decoded.scopes : getScopesForRole(decoded.role),
+    };
+
+    const accessToken = signAccessToken(payload);
+    const nextRefreshToken = signRefreshToken(payload);
+    await persistRefreshToken(prisma, payload, nextRefreshToken);
+
+    return res.json({
+      ok: true,
+      accessToken,
+      refreshToken: nextRefreshToken,
+      tokenType: "Bearer",
+      expiresIn: env.jwtExpiry,
+      refreshExpiresIn: env.jwtRefreshExpiry,
+    });
+  } catch (err) {
+    const statusCode = err.statusCode || (err.name === "ZodError" ? 400 : 401);
+    return res.status(statusCode).json({ ok: false, error: err.message || "Unable to refresh token" });
+  }
+});
+
+router.post("/logout", express.json(), async (req, res) => {
+  try {
+    const schema = z.object({ refreshToken: z.string().min(1) });
+    const { refreshToken } = schema.parse(req.body);
+    const prisma = getPrisma();
+
+    if (prisma?.refreshToken) {
+      await prisma.refreshToken.updateMany({
+        where: {
+          tokenHash: hashRefreshToken(refreshToken),
+          revokedAt: null,
+        },
+        data: { revokedAt: new Date() },
+      });
+    }
+
+    return res.json({ ok: true });
+  } catch (err) {
+    const statusCode = err.name === "ZodError" ? 400 : 500;
+    return res.status(statusCode).json({ ok: false, error: err.message || "Unable to logout" });
   }
 });
 
@@ -27,7 +222,16 @@ router.post("/dev-token", express.json(), (req, res) => {
 router.get("/me", (req, res) => {
   const userId = getUserId(req);
   if (!userId) return res.status(401).json({ ok: false, error: "unauthorized" });
-  res.json({ ok: true, userId, nodeEnv: env.nodeEnv });
+
+  const auth = req.auth || req.user || {};
+  res.json({
+    ok: true,
+    userId,
+    nodeEnv: env.nodeEnv,
+    tenantId: auth.organizationId || auth.org_id,
+    role: auth.role,
+    scopes: auth.scopes || [],
+  });
 });
 
 module.exports = router;

--- a/apps/api/src/auth/routes.js
+++ b/apps/api/src/auth/routes.js
@@ -167,20 +167,24 @@ router.post("/refresh", express.json(), async (req, res) => {
     const schema = z.object({ refreshToken: z.string().min(1) });
     const { refreshToken } = schema.parse(req.body);
     const prisma = getPrisma();
-    const decoded = await rotateRefreshToken(prisma, refreshToken);
 
-    const payload = {
-      sub: decoded.sub,
-      email: decoded.email,
-      role: normalizeRole(decoded.role),
-      org_id: decoded.org_id,
-      scopes: Array.isArray(decoded.scopes) ? decoded.scopes : getScopesForRole(decoded.role),
-    };
+    const { accessToken, nextRefreshToken } = await prisma.$transaction(async (tx) => {
+      const decoded = await rotateRefreshToken(tx, refreshToken);
 
-    const accessToken = signAccessToken(payload);
-    const nextRefreshToken = signRefreshToken(payload);
-    await persistRefreshToken(prisma, payload, nextRefreshToken);
+      const payload = {
+        sub: decoded.sub,
+        email: decoded.email,
+        role: normalizeRole(decoded.role),
+        org_id: decoded.org_id,
+        scopes: Array.isArray(decoded.scopes) ? decoded.scopes : getScopesForRole(decoded.role),
+      };
 
+      const accessToken = signAccessToken(payload);
+      const nextRefreshToken = signRefreshToken(payload);
+      await persistRefreshToken(tx, payload, nextRefreshToken);
+
+      return { accessToken, nextRefreshToken };
+    });
     return res.json({
       ok: true,
       accessToken,

--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -6,7 +6,9 @@ const env = {
   apiPort: Number(process.env.API_PORT || process.env.PORT || 4000),
   databaseUrl: process.env.DATABASE_URL || "",
   jwtSecret: process.env.JWT_SECRET || "dev_insecure_change_me_please_update",
-  jwtExpiry: process.env.JWT_EXPIRY || "30d",
+  jwtExpiry: process.env.JWT_EXPIRY || "15m",
+  jwtRefreshSecret: process.env.JWT_REFRESH_SECRET || process.env.JWT_SECRET || "dev_insecure_change_me_please_update",
+  jwtRefreshExpiry: process.env.JWT_REFRESH_EXPIRY || "30d",
   avatarStorage: process.env.AVATAR_STORAGE || "local",
   avatarUploadDir:
     process.env.AVATAR_UPLOAD_DIR || path.join(process.cwd(), "apps/api/public/uploads"),


### PR DESCRIPTION
### Motivation
- Introduce a production-ready, tenant-scoped authentication foundation with short-lived access tokens and rotatable refresh tokens to support RBAC and multi-tenant isolation. 

### Description
- Add tenant-aware credential endpoints and token lifecycle handlers in `apps/api/src/auth/routes.js`, including `POST /v1/auth/login`, `POST /v1/auth/refresh`, `POST /v1/auth/logout`, enriched `GET /v1/auth/me`, plus a dev `POST /v1/auth/dev-token` helper. 
- Implement separate access/refresh JWT helpers in `apps/api/src/auth/jwt.js` with support for distinct refresh secret, `verifyRefreshToken`, and `hashRefreshToken` for persisted token revocation. 
- Persist refresh tokens by extending Prisma schema `User` with `refreshTokens` and adding a new `RefreshToken` model in `apps/api/prisma/schema.prisma` for rotation and revocation. 
- Add environment defaults for access/refresh lifetimes and refresh secret in `apps/api/src/config/env.js` and wire auth handlers to the existing Prisma access via `getPrisma` and tenant-aware claims. 

### Testing
- Ran CommonJS smoke test for JWT helpers (`signAccessToken`/`signRefreshToken`/`verify*`/`hashRefreshToken`) which passed. 
- Ran a CommonJS smoke test of the `/login` route handler with mocked Prisma and bcrypt which passed. 
- Attempted the package test run via `vitest` for the new auth test which failed due to ESM/CommonJS module configuration in the repo (`require` in an ES module context). 
- Ran TypeScript `tsc --noEmit` which reported type errors across the codebase (existing issues unrelated to the auth change), and `prisma validate` failed because the repository uses a Prisma schema pattern incompatible with Prisma v7 (`datasource.url` in schema).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be0c564c1c8330ae321911f0a001d9)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds tenant-aware JWT auth with 15‑minute access tokens and refresh token rotation for secure, multi-tenant RBAC. Adds login/refresh/logout, updates `me`, and persists hashed refresh tokens for revocation.

- **New Features**
  - Endpoints: `POST /v1/auth/login`, `POST /v1/auth/refresh`, `POST /v1/auth/logout`, updated `GET /v1/auth/me`, and dev `POST /v1/auth/dev-token`.
  - Tokens carry `org_id` (tenant) and role-based scopes (admin/dispatcher/driver/viewer).
  - Refresh tokens are stored hashed, validated on refresh, rotated, and revoked on use/logout (Prisma-backed).
  - `GET /v1/auth/me` now returns `tenantId`, `role`, and `scopes`.
  - Config: `JWT_EXPIRY` (default `15m`), `JWT_REFRESH_SECRET`, `JWT_REFRESH_EXPIRY` (default `30d`); access/refresh use separate secrets.

- **Migration**
  - Apply Prisma changes to add `RefreshToken` and `User.refreshTokens`.
  - Set env vars: `JWT_REFRESH_SECRET`, `JWT_EXPIRY`, `JWT_REFRESH_EXPIRY`.
  - Update clients: send `tenantId` on login; store `refreshToken`; call `/v1/auth/refresh` to rotate; include Bearer `accessToken` on API calls; call `/v1/auth/logout` with the current `refreshToken`.

<sup>Written for commit d2518a53f8d9251ccf164782a61636a6219d5489. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added login and logout endpoints for user authentication.
  * Introduced automatic refresh token mechanism for secure session management.
  * Improved token handling with distinct access and refresh token lifecycles.

* **Security**
  * Enhanced JWT configuration with separate expiry times for access and refresh tokens.
  * Implemented secure token storage and rotation to prevent unauthorized token reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->