### PR TITLE
Enforce AI v2 billing subscription and monthly usage limits

### DIFF
--- a/apps/api/src/routes/ai.routes.ts
+++ b/apps/api/src/routes/ai.routes.ts
@@ -68,44 +68,48 @@ const enforceUsageLimit = async (req: Request, res: Response, next: NextFunction
     }
 
     const month = new Date().toISOString().slice(0, 7);
-    const usage = await prisma.orgUsage.findUnique({
-      where: { organizationId_month: { organizationId: billing.organizationId, month } },
-      select: { jobs: true },
-    });
-
     const plan = String(billing.plan ?? "STARTER").toUpperCase();
     const planLimit = PLAN_LIMITS[plan] ?? PLAN_LIMITS.STARTER;
     const configuredLimit =
       Number.isFinite(billing.monthlyQuota) && billing.monthlyQuota > 0
         ? billing.monthlyQuota
         : planLimit;
-    const currentUsage = usage?.jobs ?? 0;
 
-    if (currentUsage >= configuredLimit) {
+    if (!Number.isFinite(configuredLimit)) {
+      await prisma.orgUsage.upsert({
+        where: { organizationId_month: { organizationId: billing.organizationId, month } },
+        update: { jobs: { increment: 1 } },
+        create: { organizationId: billing.organizationId, month, jobs: 1 },
+      });
+      return next();
+    }
+
+    const didReserveQuota = await prisma.$transaction(async (tx) => {
+      await tx.orgUsage.upsert({
+        where: { organizationId_month: { organizationId: billing.organizationId, month } },
+        update: {},
+        create: { organizationId: billing.organizationId, month, jobs: 0 },
+      });
+
+      const result = await tx.orgUsage.updateMany({
+        where: {
+          organizationId: billing.organizationId,
+          month,
+          jobs: { lt: configuredLimit },
+        },
+        data: { jobs: { increment: 1 } },
+      });
+
+      return result.count === 1;
+    });
+
+    if (!didReserveQuota) {
       return res.status(403).json({ error: "Usage limit exceeded" });
     }
 
     return next();
   } catch {
     return res.status(500).json({ error: "Failed to verify usage limits" });
-  }
-};
-
-const trackAiUsage = async (req: Request) => {
-  const organizationId = req.billing?.organizationId;
-  if (!organizationId) {
-    return;
-  }
-
-  try {
-    const month = new Date().toISOString().slice(0, 7);
-    await prisma.orgUsage.upsert({
-      where: { organizationId_month: { organizationId, month } },
-      update: { jobs: { increment: 1 } },
-      create: { organizationId, month, jobs: 1 },
-    });
-  } catch {
-    // Non-blocking usage tracking to avoid failing successful AI responses.
   }
 };
 
@@ -127,8 +131,6 @@ router.post("/dispatch/recommend", enforceUsageLimit, async (req: Request, res: 
     }
 
     const recommendation = await aiDispatchService.recommendDispatch(tenantId, loadId, userId);
-    await trackAiUsage(req);
-
     res.json(recommendation);
   } catch (error: any) {
     if (error.message.includes("not found")) {
@@ -153,8 +155,6 @@ router.post("/dispatch/execute", enforceUsageLimit, async (req: Request, res: Re
     }
 
     const result = await aiDispatchService.executeDispatch(tenantId, loadId, driverId, userId);
-    await trackAiUsage(req);
-
     res.json(result);
   } catch (error: any) {
     if (error.message.includes("not found")) {
@@ -179,7 +179,6 @@ router.get("/carriers/:driverId/score", enforceUsageLimit, async (req: Request, 
       return res.status(404).json({ error: "Carrier score not found" });
     }
 
-    await trackAiUsage(req);
     res.json(score);
   } catch (error: any) {
     res.status(500).json({ error: "Failed to get carrier score" });
@@ -196,8 +195,6 @@ router.post("/carriers/:driverId/recompute", enforceUsageLimit, async (req: Requ
     const tenantId = req.user!.tenantId!;
 
     const score = await carrierIntelligenceService.computeCarrierScore(tenantId, driverId);
-    await trackAiUsage(req);
-
     res.json(score);
   } catch (error: any) {
     if (error.message.includes("not found")) {
@@ -221,8 +218,6 @@ router.post("/pricing/recommend", enforceUsageLimit, async (req: Request, res: R
     }
 
     const pricing = await smartPricingService.recommendPricing(tenantId, loadId);
-    await trackAiUsage(req);
-
     res.json(pricing);
   } catch (error: any) {
     if (error.message.includes("not found")) {
@@ -243,7 +238,6 @@ router.get("/pricing/load/:loadId", enforceUsageLimit, async (req: Request, res:
 
     const history = await smartPricingService.getPricingHistory(tenantId, loadId);
 
-    await trackAiUsage(req);
     res.json(history);
   } catch (error: any) {
     res.status(500).json({ error: "Failed to get pricing history" });
@@ -260,8 +254,6 @@ router.get("/predict/load/:loadId", enforceUsageLimit, async (req: Request, res:
     const tenantId = req.user!.tenantId!;
 
     const prediction = await predictiveOperationsService.predictLoadIssues(tenantId, loadId);
-    await trackAiUsage(req);
-
     res.json(prediction);
   } catch (error: any) {
     if (error.message.includes("not found")) {
@@ -284,8 +276,6 @@ router.get("/predict/shipment/:shipmentId", enforceUsageLimit, async (req: Reque
       tenantId,
       shipmentId,
     );
-    await trackAiUsage(req);
-
     res.json(prediction);
   } catch (error: any) {
     if (error.message.includes("not found")) {

--- a/apps/api/src/routes/ai.routes.ts
+++ b/apps/api/src/routes/ai.routes.ts
@@ -9,6 +9,13 @@ import { prisma } from "../db/prisma.js";
 
 
 const router: Router = Router();
+const PLAN_LIMITS: Record<string, number> = {
+  STARTER: 100,
+  GROWTH: 1000,
+  PRO: 1000,
+  ENTERPRISE: Number.POSITIVE_INFINITY,
+  CUSTOM: Number.POSITIVE_INFINITY,
+};
 
 /**
  * Middleware: Require authentication and tenant context
@@ -20,11 +27,93 @@ const requireAuth = (req: Request, res: Response, next: NextFunction) => {
   next();
 };
 
+const resolveOrganizationId = (req: Request): string | undefined => {
+  return req.organizationId ?? req.orgId ?? req.auth?.organizationId ?? req.user?.tenantId;
+};
+
+const requireActiveSubscription = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const organizationId = resolveOrganizationId(req);
+    if (!organizationId) {
+      return res.status(401).json({ error: "Organization context missing" });
+    }
+
+    const subscription = await prisma.orgBilling.findUnique({
+      where: { organizationId },
+      select: { stripeStatus: true, plan: true, monthlyQuota: true },
+    });
+
+    const stripeStatus = subscription?.stripeStatus?.toLowerCase() ?? "inactive";
+    const isActive = stripeStatus === "active" || stripeStatus === "trialing";
+    if (!isActive) {
+      return res.status(402).json({ error: "Subscription required" });
+    }
+
+    req.billing = {
+      plan: subscription?.plan ?? "STARTER",
+      stripeStatus,
+      monthlyQuota: subscription?.monthlyQuota ?? PLAN_LIMITS.STARTER,
+      organizationId,
+    };
+    return next();
+  } catch {
+    return res.status(500).json({ error: "Failed to verify subscription" });
+  }
+};
+
+const enforceUsageLimit = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const billing = req.billing;
+    if (!billing?.organizationId) {
+      return res.status(401).json({ error: "Organization context missing" });
+    }
+
+    const month = new Date().toISOString().slice(0, 7);
+    const usage = await prisma.orgUsage.findUnique({
+      where: { organizationId_month: { organizationId: billing.organizationId, month } },
+      select: { jobs: true },
+    });
+
+    const plan = String(billing.plan ?? "STARTER").toUpperCase();
+    const planLimit = PLAN_LIMITS[plan] ?? PLAN_LIMITS.STARTER;
+    const configuredLimit =
+      Number.isFinite(billing.monthlyQuota) && billing.monthlyQuota > 0
+        ? billing.monthlyQuota
+        : planLimit;
+    const currentUsage = usage?.jobs ?? 0;
+
+    if (currentUsage >= configuredLimit) {
+      return res.status(403).json({ error: "Usage limit exceeded" });
+    }
+
+    return next();
+  } catch {
+    return res.status(500).json({ error: "Failed to verify usage limits" });
+  }
+};
+
+const trackAiUsage = async (req: Request) => {
+  const organizationId = req.billing?.organizationId;
+  if (!organizationId) {
+    return;
+  }
+
+  const month = new Date().toISOString().slice(0, 7);
+  await prisma.orgUsage.upsert({
+    where: { organizationId_month: { organizationId, month } },
+    update: { jobs: { increment: 1 } },
+    create: { organizationId, month, jobs: 1 },
+  });
+};
+
+router.use(requireAuth);
+router.use(requireActiveSubscription);
+
 /**
  * POST /api/ai/dispatch/recommend
  * Get dispatch recommendation for a load
  */
-router.post("/dispatch/recommend", requireAuth, async (req: Request, res: Response) => {
+router.post("/dispatch/recommend", enforceUsageLimit, async (req: Request, res: Response) => {
   try {
     const { loadId } = req.body;
     const tenantId = req.user!.tenantId!;
@@ -35,6 +124,7 @@ router.post("/dispatch/recommend", requireAuth, async (req: Request, res: Respon
     }
 
     const recommendation = await aiDispatchService.recommendDispatch(tenantId, loadId, userId);
+    await trackAiUsage(req);
 
     res.json(recommendation);
   } catch (error: any) {
@@ -49,7 +139,7 @@ router.post("/dispatch/recommend", requireAuth, async (req: Request, res: Respon
  * POST /api/ai/dispatch/execute
  * Execute dispatch for a load and driver
  */
-router.post("/dispatch/execute", requireAuth, async (req: Request, res: Response) => {
+router.post("/dispatch/execute", enforceUsageLimit, async (req: Request, res: Response) => {
   try {
     const { loadId, driverId } = req.body;
     const tenantId = req.user!.tenantId!;
@@ -60,6 +150,7 @@ router.post("/dispatch/execute", requireAuth, async (req: Request, res: Response
     }
 
     const result = await aiDispatchService.executeDispatch(tenantId, loadId, driverId, userId);
+    await trackAiUsage(req);
 
     res.json(result);
   } catch (error: any) {
@@ -95,12 +186,13 @@ router.get("/carriers/:driverId/score", requireAuth, async (req: Request, res: R
  * POST /api/ai/carriers/:driverId/recompute
  * Recompute carrier score
  */
-router.post("/carriers/:driverId/recompute", requireAuth, async (req: Request, res: Response) => {
+router.post("/carriers/:driverId/recompute", enforceUsageLimit, async (req: Request, res: Response) => {
   try {
     const driverId = req.params.driverId as string;
     const tenantId = req.user!.tenantId!;
 
     const score = await carrierIntelligenceService.computeCarrierScore(tenantId, driverId);
+    await trackAiUsage(req);
 
     res.json(score);
   } catch (error: any) {
@@ -115,7 +207,7 @@ router.post("/carriers/:driverId/recompute", requireAuth, async (req: Request, r
  * POST /api/ai/pricing/recommend
  * Get pricing recommendation for a load
  */
-router.post("/pricing/recommend", requireAuth, async (req: Request, res: Response) => {
+router.post("/pricing/recommend", enforceUsageLimit, async (req: Request, res: Response) => {
   try {
     const { loadId } = req.body;
     const tenantId = req.user!.tenantId!;
@@ -125,6 +217,7 @@ router.post("/pricing/recommend", requireAuth, async (req: Request, res: Respons
     }
 
     const pricing = await smartPricingService.recommendPricing(tenantId, loadId);
+    await trackAiUsage(req);
 
     res.json(pricing);
   } catch (error: any) {
@@ -156,12 +249,13 @@ router.get("/pricing/load/:loadId", requireAuth, async (req: Request, res: Respo
  * GET /api/ai/predict/load/:loadId
  * Get delay prediction for a load
  */
-router.get("/predict/load/:loadId", requireAuth, async (req: Request, res: Response) => {
+router.get("/predict/load/:loadId", enforceUsageLimit, async (req: Request, res: Response) => {
   try {
     const loadId = req.params.loadId as string;
     const tenantId = req.user!.tenantId!;
 
     const prediction = await predictiveOperationsService.predictLoadIssues(tenantId, loadId);
+    await trackAiUsage(req);
 
     res.json(prediction);
   } catch (error: any) {
@@ -176,7 +270,7 @@ router.get("/predict/load/:loadId", requireAuth, async (req: Request, res: Respo
  * GET /api/ai/predict/shipment/:shipmentId
  * Get delay prediction for a shipment
  */
-router.get("/predict/shipment/:shipmentId", requireAuth, async (req: Request, res: Response) => {
+router.get("/predict/shipment/:shipmentId", enforceUsageLimit, async (req: Request, res: Response) => {
   try {
     const shipmentId = req.params.shipmentId as string;
     const tenantId = req.user!.tenantId!;
@@ -185,6 +279,7 @@ router.get("/predict/shipment/:shipmentId", requireAuth, async (req: Request, re
       tenantId,
       shipmentId,
     );
+    await trackAiUsage(req);
 
     res.json(prediction);
   } catch (error: any) {

--- a/apps/api/src/routes/ai.routes.ts
+++ b/apps/api/src/routes/ai.routes.ts
@@ -12,7 +12,6 @@ const router: Router = Router();
 const PLAN_LIMITS: Record<string, number> = {
   STARTER: 100,
   GROWTH: 1000,
-  PRO: 1000,
   ENTERPRISE: Number.POSITIVE_INFINITY,
   CUSTOM: Number.POSITIVE_INFINITY,
 };
@@ -98,12 +97,16 @@ const trackAiUsage = async (req: Request) => {
     return;
   }
 
-  const month = new Date().toISOString().slice(0, 7);
-  await prisma.orgUsage.upsert({
-    where: { organizationId_month: { organizationId, month } },
-    update: { jobs: { increment: 1 } },
-    create: { organizationId, month, jobs: 1 },
-  });
+  try {
+    const month = new Date().toISOString().slice(0, 7);
+    await prisma.orgUsage.upsert({
+      where: { organizationId_month: { organizationId, month } },
+      update: { jobs: { increment: 1 } },
+      create: { organizationId, month, jobs: 1 },
+    });
+  } catch {
+    // Non-blocking usage tracking to avoid failing successful AI responses.
+  }
 };
 
 router.use(requireAuth);
@@ -165,7 +168,7 @@ router.post("/dispatch/execute", enforceUsageLimit, async (req: Request, res: Re
  * GET /api/ai/carriers/:driverId/score
  * Get current carrier score
  */
-router.get("/carriers/:driverId/score", requireAuth, async (req: Request, res: Response) => {
+router.get("/carriers/:driverId/score", enforceUsageLimit, async (req: Request, res: Response) => {
   try {
     const driverId = req.params.driverId as string;
     const tenantId = req.user!.tenantId!;
@@ -176,6 +179,7 @@ router.get("/carriers/:driverId/score", requireAuth, async (req: Request, res: R
       return res.status(404).json({ error: "Carrier score not found" });
     }
 
+    await trackAiUsage(req);
     res.json(score);
   } catch (error: any) {
     res.status(500).json({ error: "Failed to get carrier score" });
@@ -232,13 +236,14 @@ router.post("/pricing/recommend", enforceUsageLimit, async (req: Request, res: R
  * GET /api/ai/pricing/load/:loadId
  * Get pricing history for a load
  */
-router.get("/pricing/load/:loadId", requireAuth, async (req: Request, res: Response) => {
+router.get("/pricing/load/:loadId", enforceUsageLimit, async (req: Request, res: Response) => {
   try {
     const loadId = req.params.loadId as string;
     const tenantId = req.user!.tenantId!;
 
     const history = await smartPricingService.getPricingHistory(tenantId, loadId);
 
+    await trackAiUsage(req);
     res.json(history);
   } catch (error: any) {
     res.status(500).json({ error: "Failed to get pricing history" });

--- a/apps/api/src/types/express.d.ts
+++ b/apps/api/src/types/express.d.ts
@@ -34,6 +34,12 @@ declare global {
       tenantId?: string;
       orgId?: string;
       organizationId?: string;
+      billing?: {
+        plan: string;
+        stripeStatus: string;
+        monthlyQuota: number;
+        organizationId: string;
+      };
     }
   }
 }


### PR DESCRIPTION
### Motivation

- Prevent unpaid or over-quota AI usage by gating `/api/ai/v2` endpoints behind an active organization subscription and monthly quotas, aligning with the Phase 2 monetize runbook.

### Description

- Added plan limits and organization resolution logic in `apps/api/src/routes/ai.routes.ts` with `PLAN_LIMITS` and `resolveOrganizationId` for tenant/org context.
- Implemented `requireActiveSubscription` middleware that enforces `active`/`trialing` org subscriptions and attaches a typed billing context to `req.billing`.
- Implemented `enforceUsageLimit` middleware that checks monthly `orgUsage.jobs` against plan/quota and returns `403` when quota is exhausted, and added `trackAiUsage` to increment usage via `orgUsage.upsert` after successful AI calls.
- Wired `router.use(requireAuth)` and `router.use(requireActiveSubscription)` at the router level and applied `enforceUsageLimit` to metered endpoints (`dispatch/recommend`, `dispatch/execute`, `carriers/:driverId/recompute`, `pricing/recommend`, `predict/load/:loadId`, `predict/shipment/:shipmentId`).
- Extended Express request typing in `apps/api/src/types/express.d.ts` to include a `billing` object with `plan`, `stripeStatus`, `monthlyQuota`, and `organizationId`.

### Testing

- Ran a TypeScript type check with `pnpm -C apps/api typecheck` which failed in this environment due to missing `node_modules` and a `tsconfig` `ignoreDeprecations` incompatibility, so the typecheck did not complete.
- No other automated tests were run in this environment; runtime/CI tests should be executed after installing dependencies to validate types and behaviour.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbc7c6914c833097811b503c5db73a)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces active org subscriptions and monthly usage limits on `/api/ai/v2` endpoints. Blocks unpaid or over‑quota access and atomically tracks monthly usage per org across POST and GET routes.

- **New Features**
  - Added `requireActiveSubscription`. Allows `active`/`trialing`; resolves org via `organizationId|orgId|auth.organizationId|user.tenantId`; returns 401 if org missing, 402 if inactive; attaches `req.billing`.
  - Added `enforceUsageLimit`. Checks monthly `orgUsage.jobs` against plan caps or finite `monthlyQuota` override; reserves quota before handlers; unlimited plans only track usage.
  - Router-level `requireAuth` and subscription checks; limits applied to: `dispatch/recommend`, `dispatch/execute`, `carriers/:driverId/score`, `carriers/:driverId/recompute`, `pricing/recommend`, `pricing/load/:loadId`, `predict/load/:loadId`, `predict/shipment/:shipmentId`.
  - Introduced `PLAN_LIMITS` (`STARTER` 100, `GROWTH` 1000, unlimited for `ENTERPRISE`/`CUSTOM`); falls back to plan caps when no valid `monthlyQuota`.
  - Extended Express `Request` typing with `billing` (plan, stripeStatus, monthlyQuota, organizationId).

- **Bug Fixes**
  - Fixed quota race by atomically reserving usage in a single transaction (`upsert` + guarded `updateMany`), preventing double‑spend under concurrency.

<sup>Written for commit c3d681bc816bf79d0c646a719673cb5fdf3431ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

