### PR TITLE
Add API Sentry instrumentation bootstrap and verification endpoint

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -94,6 +94,11 @@ export function createApp(): Express {
       return;
     }
 
+    if (!env.sentryDsn) {
+      res.status(503).json({ success: false, error: { code: "SENTRY_DISABLED", message: "SENTRY_DSN not configured" } });
+      return;
+    }
+
     verifySentryCapture();
     res.status(202).json({ success: true, data: { captured: true } });
   });

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -88,19 +88,29 @@ export function createApp(): Express {
     });
   });
 
-  app.post("/api/health/sentry-check", (req, res) => {
+  app.post("/api/health/sentry-check", (_req, res) => {
     if (env.nodeEnv === "production") {
       res.status(404).json({ success: false, error: { code: "NOT_FOUND", message: "Route not found" } });
       return;
     }
 
     if (!env.sentryDsn) {
-      res.status(503).json({ success: false, error: { code: "SENTRY_DISABLED", message: "SENTRY_DSN not configured" } });
+      res.status(503).json({
+        success: false,
+        error: { code: "SENTRY_DISABLED", message: "SENTRY_DSN not configured" },
+        data: { sentryEnabled: false, captureAttempted: false },
+      });
       return;
     }
 
     verifySentryCapture();
-    res.status(202).json({ success: true, data: { captured: true } });
+    res.status(202).json({
+      success: true,
+      data: {
+        sentryEnabled: true,
+        captureAttempted: true,
+      },
+    });
   });
 
   app.get("/readyz", (_req, res) => {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -3,6 +3,7 @@ import cors from "cors";
 import express, { type Express } from "express";
 import helmet from "helmet";
 import { env } from "./config/env.js";
+import { sentryErrorHandler, verifySentryCapture } from "./instrument.js";
 import { requestIdMiddleware, httpLoggerMiddleware } from "./lib/logger.js";
 import { errorHandler, notFound } from "./middleware/error-handler.js";
 import { generalLimiter } from "./middleware/rateLimit.js";
@@ -87,6 +88,16 @@ export function createApp(): Express {
     });
   });
 
+  app.post("/api/health/sentry-check", (req, res) => {
+    if (env.nodeEnv === "production") {
+      res.status(404).json({ success: false, error: { code: "NOT_FOUND", message: "Route not found" } });
+      return;
+    }
+
+    verifySentryCapture();
+    res.status(202).json({ success: true, data: { captured: true } });
+  });
+
   app.get("/readyz", (_req, res) => {
     res.json({ success: true, data: { ok: true } });
   });
@@ -116,6 +127,7 @@ export function createApp(): Express {
   app.use("/api/tenants", tenants);
 
   app.use(notFound);
+  app.use(sentryErrorHandler);
   app.use(errorHandler);
 
   return app;

--- a/apps/api/src/instrument.ts
+++ b/apps/api/src/instrument.ts
@@ -1,18 +1,33 @@
+import "dotenv/config";
 import * as Sentry from "@sentry/node";
 import type { ErrorRequestHandler } from "express";
 
-const sentryDsn = process.env.SENTRY_DSN;
+let sentryInitialized = false;
 
-if (sentryDsn) {
+function initializeSentry(): boolean {
+  if (sentryInitialized) {
+    return true;
+  }
+
+  const sentryDsn = process.env.SENTRY_DSN;
+  if (!sentryDsn) {
+    return false;
+  }
+
   Sentry.init({
     dsn: sentryDsn,
     environment: process.env.NODE_ENV ?? "development",
     tracesSampleRate: Number(process.env.SENTRY_TRACES_SAMPLE_RATE ?? 0),
   });
+
+  sentryInitialized = true;
+  return true;
 }
 
+initializeSentry();
+
 export function captureException(error: unknown, extras?: Record<string, unknown>): void {
-  if (!sentryDsn) {
+  if (!initializeSentry()) {
     return;
   }
 

--- a/apps/api/src/instrument.ts
+++ b/apps/api/src/instrument.ts
@@ -1,0 +1,36 @@
+import * as Sentry from "@sentry/node";
+import type { ErrorRequestHandler } from "express";
+
+const sentryDsn = process.env.SENTRY_DSN;
+
+if (sentryDsn) {
+  Sentry.init({
+    dsn: sentryDsn,
+    environment: process.env.NODE_ENV ?? "development",
+    tracesSampleRate: Number(process.env.SENTRY_TRACES_SAMPLE_RATE ?? 0),
+  });
+}
+
+export function captureException(error: unknown, extras?: Record<string, unknown>): void {
+  if (!sentryDsn) {
+    return;
+  }
+
+  const normalizedError = error instanceof Error ? error : new Error(String(error));
+  Sentry.captureException(normalizedError, extras ? { extra: extras } : undefined);
+}
+
+export const sentryErrorHandler: ErrorRequestHandler = (err, req, _res, next) => {
+  captureException(err, {
+    method: req.method,
+    path: req.path,
+    requestId: req.headers["x-request-id"],
+  });
+  next(err);
+};
+
+export function verifySentryCapture(): void {
+  captureException(new Error("Sentry integration verification event"), {
+    source: "manual-verification",
+  });
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1,3 +1,4 @@
+import "./instrument.js";
 import { createApp } from "./app.js";
 import { env } from "./config/env.js";
 import { logger } from "./lib/logger.js";


### PR DESCRIPTION
### Motivation
- Provide an early, centralized Sentry bootstrap for the API so error/trace instrumentation is initialized as soon as possible. 
- Offer a small, safe verification path to validate Sentry wiring in non-production environments without crashing the process. 
- Keep Sentry configuration driven solely by `SENTRY_DSN` and follow existing repo conventions (pnpm + TypeScript + ESM). 

### Description
- Added `apps/api/src/instrument.ts` which initializes Sentry from `SENTRY_DSN`, exposes `captureException`, an Express `sentryErrorHandler`, and `verifySentryCapture()` for manual verification. 
- Imported the instrumentation first in the API entrypoint via `import "./instrument.js"` so initialization runs before other startup logic. 
- Wired `sentryErrorHandler` into the Express middleware chain (added before the existing `errorHandler`) and added a non-production `POST /api/health/sentry-check` endpoint that calls `verifySentryCapture()`. 
- No fallback DSN or hardcoded secrets were added; instrumentation only activates when `SENTRY_DSN` is present. 

### Testing
- Initialized toolchain per repo instructions with `nvm use`, `corepack prepare pnpm@10.15.0`, and verified Node and pnpm versions succeeded. 
- Installed workspace dependencies with `pnpm install`, which completed successfully. 
- Verified the new instrumentation module loads at runtime with `pnpm -C apps/api exec tsx -e "import './src/instrument.ts'; console.log('instrument-ok')"`, which printed `instrument-ok`. 
- Attempted a full API build with `pnpm -C apps/api build`, which failed due to pre-existing workspace/TypeScript resolution issues (unrelated unresolved `@infamous-freight/shared` types and other existing TS errors); build failure is not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d136283afc833084c981774c9acca3)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bootstraps Sentry at API startup and adds a non-prod verification endpoint. Instrumentation runs only when `SENTRY_DSN` is set; the check returns 404 in prod and 503 if DSN is missing.

- **New Features**
  - Early Sentry init via `apps/api/src/instrument.ts`, imported first in `server.ts`; exports `captureException`.
  - Added Express `sentryErrorHandler` before `errorHandler` to capture errors with request metadata.
  - Added non-prod `POST /api/health/sentry-check` to trigger a test event and return 202.
  - Configurable trace sampling via `SENTRY_TRACES_SAMPLE_RATE`; no fallback DSN.

- **Migration**
  - Set `SENTRY_DSN` (and optional `SENTRY_TRACES_SAMPLE_RATE`) to enable Sentry.
  - In dev/staging, POST to `/api/health/sentry-check` to verify integration.

<sup>Written for commit f682ac3c7387e081650a3c2e5749818c693daf86. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

