### PR TITLE
Improve Fly deploy script reliability for local auth/token workflows

### DIFF
--- a/scripts/fly-deploy-api.sh
+++ b/scripts/fly-deploy-api.sh
@@ -5,14 +5,27 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 CONFIG_PATH="${1:-$ROOT_DIR/fly.api.toml}"
 
-if command -v flyctl >/dev/null 2>&1; then
-  FLYCTL_BIN="flyctl"
-elif [ -x "/home/vscode/.fly/bin/flyctl" ]; then
-  FLYCTL_BIN="/home/vscode/.fly/bin/flyctl"
-else
+resolve_flyctl() {
+  if command -v flyctl >/dev/null 2>&1; then
+    command -v flyctl
+    return 0
+  fi
+
+  if [ -x "$HOME/.fly/bin/flyctl" ]; then
+    echo "$HOME/.fly/bin/flyctl"
+    return 0
+  fi
+
+  if [ -x "/home/vscode/.fly/bin/flyctl" ]; then
+    echo "/home/vscode/.fly/bin/flyctl"
+    return 0
+  fi
+
   echo "ERROR: flyctl not found."
-  exit 1
-fi
+  return 1
+}
+
+FLYCTL_BIN="$(resolve_flyctl)"
 
 TARGET_APP="${FLY_APP:-$(awk -F'=' '/^[[:space:]]*app[[:space:]]*=/{gsub(/[[:space:]\047\042]/, "", $2); print $2; exit}' "$CONFIG_PATH")}"
 

--- a/scripts/fly-deploy-api.sh
+++ b/scripts/fly-deploy-api.sh
@@ -11,8 +11,13 @@ resolve_flyctl() {
     return 0
   fi
 
-  if [ -x "$HOME/.fly/bin/flyctl" ]; then
-    echo "$HOME/.fly/bin/flyctl"
+  local home_flyctl=""
+  if [ -n "${HOME:-}" ]; then
+    home_flyctl="${HOME}/.fly/bin/flyctl"
+  fi
+
+  if [ -n "$home_flyctl" ] && [ -x "$home_flyctl" ]; then
+    echo "$home_flyctl"
     return 0
   fi
 

--- a/scripts/fly-deploy-api.sh
+++ b/scripts/fly-deploy-api.sh
@@ -30,7 +30,10 @@ resolve_flyctl() {
   return 1
 }
 
-FLYCTL_BIN="$(resolve_flyctl)"
+if ! FLYCTL_BIN="$(resolve_flyctl)"; then
+  echo "ERROR: flyctl not found." >&2
+  exit 1
+fi
 
 TARGET_APP="${FLY_APP:-$(awk -F'=' '/^[[:space:]]*app[[:space:]]*=/{gsub(/[[:space:]\047\042]/, "", $2); print $2; exit}' "$CONFIG_PATH")}"
 

--- a/scripts/fly-preflight.sh
+++ b/scripts/fly-preflight.sh
@@ -30,7 +30,9 @@ resolve_flyctl() {
   return 1
 }
 
-FLYCTL_BIN="$(resolve_flyctl)"
+if ! FLYCTL_BIN="$(resolve_flyctl)"; then
+  exit 1
+fi
 
 config_app="$(awk -F'=' '/^[[:space:]]*app[[:space:]]*=/{gsub(/[[:space:]\047\042]/, "", $2); print $2; exit}' "$CONFIG_PATH")"
 config_dockerfile="$(awk -F'=' '/^[[:space:]]*dockerfile[[:space:]]*=/{gsub(/[[:space:]\047\042]/, "", $2); print $2; exit}' "$CONFIG_PATH")"

--- a/scripts/fly-preflight.sh
+++ b/scripts/fly-preflight.sh
@@ -10,14 +10,27 @@ if [ ! -f "$CONFIG_PATH" ]; then
   exit 1
 fi
 
-if command -v flyctl >/dev/null 2>&1; then
-  FLYCTL_BIN="flyctl"
-elif [ -x "/home/vscode/.fly/bin/flyctl" ]; then
-  FLYCTL_BIN="/home/vscode/.fly/bin/flyctl"
-else
+resolve_flyctl() {
+  if command -v flyctl >/dev/null 2>&1; then
+    command -v flyctl
+    return 0
+  fi
+
+  if [ -x "$HOME/.fly/bin/flyctl" ]; then
+    echo "$HOME/.fly/bin/flyctl"
+    return 0
+  fi
+
+  if [ -x "/home/vscode/.fly/bin/flyctl" ]; then
+    echo "/home/vscode/.fly/bin/flyctl"
+    return 0
+  fi
+
   echo "ERROR: flyctl not found. Install it first: https://fly.io/docs/hands-on/install-flyctl/"
-  exit 1
-fi
+  return 1
+}
+
+FLYCTL_BIN="$(resolve_flyctl)"
 
 config_app="$(awk -F'=' '/^[[:space:]]*app[[:space:]]*=/{gsub(/[[:space:]\047\042]/, "", $2); print $2; exit}' "$CONFIG_PATH")"
 config_dockerfile="$(awk -F'=' '/^[[:space:]]*dockerfile[[:space:]]*=/{gsub(/[[:space:]\047\042]/, "", $2); print $2; exit}' "$CONFIG_PATH")"
@@ -39,7 +52,10 @@ if [ -z "${FLY_API_TOKEN:-}" ] && [ -z "${FLY_ACCESS_TOKEN:-}" ]; then
 fi
 
 if ! "$FLYCTL_BIN" auth whoami >/dev/null 2>&1; then
-  echo "ERROR: flyctl is not authenticated. Run: flyctl auth login"
+  echo "ERROR: flyctl is not authenticated."
+  echo "Run one of the following before deploying:"
+  echo "  1) flyctl auth login"
+  echo "  2) export FLY_API_TOKEN=<token>"
   exit 1
 fi
 

--- a/scripts/fly-preflight.sh
+++ b/scripts/fly-preflight.sh
@@ -16,7 +16,7 @@ resolve_flyctl() {
     return 0
   fi
 
-  if [ -x "$HOME/.fly/bin/flyctl" ]; then
+  if [ -n "${HOME:-}" ] && [ -x "$HOME/.fly/bin/flyctl" ]; then
     echo "$HOME/.fly/bin/flyctl"
     return 0
   fi

--- a/scripts/fly-preflight.sh
+++ b/scripts/fly-preflight.sh
@@ -26,7 +26,7 @@ resolve_flyctl() {
     return 0
   fi
 
-  echo "ERROR: flyctl not found. Install it first: https://fly.io/docs/hands-on/install-flyctl/"
+  echo "ERROR: flyctl not found. Install it first: https://fly.io/docs/hands-on/install-flyctl/" >&2
   return 1
 }
 

--- a/scripts/fly-preflight.sh
+++ b/scripts/fly-preflight.sh
@@ -55,7 +55,7 @@ if ! "$FLYCTL_BIN" auth whoami >/dev/null 2>&1; then
   echo "ERROR: flyctl is not authenticated."
   echo "Run one of the following before deploying:"
   echo "  1) flyctl auth login"
-  echo "  2) export FLY_API_TOKEN=<token>"
+  echo "  2) export FLY_API_TOKEN=<token> (or export FLY_ACCESS_TOKEN=<token>)"
   exit 1
 fi
 


### PR DESCRIPTION
### Motivation

- Deployment tooling can fail in environments where `flyctl` is installed in `$HOME/.fly/bin` or `/home/vscode/.fly/bin` instead of being on `PATH`, causing brittle CI/dev deploy flows.
- Preflight failures were unclear when no interactive `flyctl` auth session exists, which led to confusing errors like "no access token available".
- The `fly-deploy-api.sh` script used different resolution logic than preflight, causing inconsistent behavior across deploy flows.

### Description

- Added a reusable `resolve_flyctl()` function to `scripts/fly-preflight.sh` and `scripts/fly-deploy-api.sh` that prefers `command -v flyctl` then `$HOME/.fly/bin/flyctl` then `/home/vscode/.fly/bin/flyctl` and returns the resolved path.
- Set `FLYCTL_BIN` from the `resolve_flyctl()` result so callers consistently invoke the discovered binary.
- Changed the preflight auth failure message to explicitly suggest remediation by either running `flyctl auth login` or exporting `FLY_API_TOKEN` for non-interactive runs.
- Modified the helper to return non-zero on failure (instead of exiting inside the helper) so the caller can control termination and produce clearer messages.

### Testing

- Ran a shell syntax check with `bash -n scripts/fly-preflight.sh scripts/fly-deploy-api.sh`, which passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4d418b7988330ae6b46aa72ccd048)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves Fly deploy reliability by consistently resolving `flyctl` in both scripts and giving clear local/CI auth guidance. Fixes “no access token available” errors and keeps preflight and deploy flows aligned.

- **Bug Fixes**
  - Added shared `resolve_flyctl()` in `scripts/fly-preflight.sh` and `scripts/fly-deploy-api.sh`; checks PATH, `$HOME/.fly/bin/flyctl`, then `/home/vscode/.fly/bin/flyctl`, echoes the path, sets `FLYCTL_BIN`, and returns non-zero so callers control exits and messages.
  - Preflight now prints an install URL hint to stderr when `flyctl` is missing and clearer auth steps when unauthenticated: run `flyctl auth login` or export `FLY_API_TOKEN`/`FLY_ACCESS_TOKEN`.

<sup>Written for commit 09e57e9b513fdafe12edcd8d06f7a1cfcb6ed472. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

