### PR TITLE
Remove eslint-disable-next-line no-console from dashboard page

### DIFF
--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 
 import { observeAuthState } from "@/lib/auth";
 import { listLoads } from "@/lib/firestoreCrud";
-import { logError } from "@/lib/sentry";
+import { reportSentryError } from "@/lib/sentry";
 import type { Load } from "@/types";
 
 export default function Dashboard() {
@@ -27,9 +27,11 @@ export default function Dashboard() {
         setLoads(loadDocs);
         setError(null);
       } catch (err) {
-        logError(err, {
-          component: "dashboard",
-          action: "listLoads",
+        reportSentryError(err instanceof Error ? err : new Error("Failed to load dashboard data"), {
+          contexts: {
+            component: "dashboard",
+            action: "listLoads",
+          },
         });
         setError("Failed to load dashboard data. Please try again.");
       } finally {

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -30,10 +30,21 @@ export default function Dashboard() {
         setLoads(loadDocs);
         setError(null);
       } catch (err) {
-        reportSentryError(err instanceof Error ? err : new Error("Failed to load dashboard data"), {
+        const reportedError =
+          err instanceof Error
+            ? err
+            : new Error("Failed to load dashboard data", { cause: err });
+
+        reportSentryError(reportedError, {
           contexts: {
             component: "dashboard",
             action: "listLoads",
+            originalError:
+              err instanceof Error
+                ? undefined
+                : {
+                    value: String(err),
+                  },
           },
         });
         setError("Failed to load dashboard data. Please try again.");

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -15,7 +15,10 @@ export default function Dashboard() {
   const router = useRouter();
 
   useEffect(() => {
+    let isMounted = true;
+
     const unsubscribe = observeAuthState(async (user) => {
+      if (!isMounted) return;
       if (!user) {
         router.push("/login");
         setLoading(false);
@@ -39,7 +42,10 @@ export default function Dashboard() {
       }
     });
 
-    return () => unsubscribe();
+    return () => {
+      isMounted = false;
+      unsubscribe();
+    };
   }, [router]);
 
   if (loading) return <div className="p-6">Loading dashboard...</div>;

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 
 import { observeAuthState } from "@/lib/auth";
 import { listLoads } from "@/lib/firestoreCrud";
+import { logError } from "@/lib/sentry";
 import type { Load } from "@/types";
 
 export default function Dashboard() {
@@ -26,7 +27,10 @@ export default function Dashboard() {
         setLoads(loadDocs);
         setError(null);
       } catch (err) {
-        console.error("Failed to load dashboard data", err);
+        logError(err, {
+          component: "dashboard",
+          action: "listLoads",
+        });
         setError("Failed to load dashboard data. Please try again.");
       } finally {
         setLoading(false);

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -26,7 +26,6 @@ export default function Dashboard() {
         setLoads(loadDocs);
         setError(null);
       } catch (err) {
-        // eslint-disable-next-line no-console
         console.error("Failed to load dashboard data", err);
         setError("Failed to load dashboard data. Please try again.");
       } finally {


### PR DESCRIPTION
### Motivation
- Allow the linter to surface uses of `console` in the dashboard page instead of suppressing the rule so console logging can be addressed or removed intentionally.

### Description
- Removed the `// eslint-disable-next-line no-console` comment in `apps/web/app/dashboard/page.tsx`, leaving the existing `console.error` call intact.

### Testing
- Ran `npm run lint` and `next build` to validate linting and type/build checks, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5da856140833081e067010822d80d)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `// eslint-disable-next-line no-console` in `apps/web/app/dashboard/page.tsx`, replaced `console.error` with `reportSentryError` from `@/lib/sentry`, and added an unmount guard for the auth observer. Errors are now wrapped when not instances of `Error` and reported to Sentry with `component: "dashboard"`, `action: "listLoads"`, and an `originalError` context.

<sup>Written for commit c45765a6bf7fafb9b9790ab7fb255e2c3ac29eaf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

