### PR TITLE
Fix ESM/CommonJS interop for prisma and middleware imports

### DIFF
--- a/apps/api/src/db/prisma.ts
+++ b/apps/api/src/db/prisma.ts
@@ -1,6 +1,9 @@
-import { PrismaClient } from "@prisma/client";
-import { PrismaPg } from "@prisma/adapter-pg";
-import { Pool } from "pg";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const { PrismaClient } = require("@prisma/client");
+const { PrismaPg } = require("@prisma/adapter-pg");
+const { Pool } = require("pg");
 
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,

--- a/apps/api/src/db/prisma.ts
+++ b/apps/api/src/db/prisma.ts
@@ -1,7 +1,18 @@
 import { PrismaClient } from "@prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { Pool } from "pg";
 
-export const prisma = new PrismaClient();
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+});
+
+const adapter = new PrismaPg(pool);
+
+// Prisma runtime requires an adapter with engineType=client, while generated
+// typings expose a zero-arg constructor. Cast is used to bridge that mismatch.
+export const prisma = new (PrismaClient as any)({ adapter });
 
 export async function closePrisma(): Promise<void> {
   await prisma.$disconnect();
+  await pool.end();
 }

--- a/apps/api/src/integrations/stripe/stripe.billing.ts
+++ b/apps/api/src/integrations/stripe/stripe.billing.ts
@@ -1,5 +1,8 @@
 import { stripe } from './stripe.client.js';
-import prisma from '../../lib/prisma.js';
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+const prisma = require('../../lib/prisma.js');
 
 export async function createPaymentIntentForInvoice(orgId: string, invoiceId: string) {
   if (!stripe) throw new Error('Stripe not configured');

--- a/apps/api/src/integrations/stripe/stripe.billing.ts
+++ b/apps/api/src/integrations/stripe/stripe.billing.ts
@@ -1,8 +1,7 @@
 import { stripe } from './stripe.client.js';
-import { createRequire } from "module";
+import { PrismaClient } from '@prisma/client';
 
-const require = createRequire(import.meta.url);
-const prisma = require('../../lib/prisma.js');
+const prisma = new PrismaClient();
 
 export async function createPaymentIntentForInvoice(orgId: string, invoiceId: string) {
   if (!stripe) throw new Error('Stripe not configured');

--- a/apps/api/src/lib/prisma.js
+++ b/apps/api/src/lib/prisma.js
@@ -14,3 +14,6 @@ if (prisma) {
     },
   };
 }
+
+// Allow ESM default imports from TypeScript route modules.
+module.exports.default = module.exports;

--- a/apps/api/src/lib/rateLimitMetrics.ts
+++ b/apps/api/src/lib/rateLimitMetrics.ts
@@ -1,0 +1,12 @@
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const rateLimitMetrics = require("./rateLimitMetrics.cjs");
+
+export const recordHit = rateLimitMetrics.recordHit;
+export const recordBlocked = rateLimitMetrics.recordBlocked;
+export const recordSuccess = rateLimitMetrics.recordSuccess;
+export const getMetrics = rateLimitMetrics.getMetrics;
+export const resetMetrics = rateLimitMetrics.resetMetrics;
+
+export default rateLimitMetrics;

--- a/apps/api/src/middleware/advancedSecurity.ts
+++ b/apps/api/src/middleware/advancedSecurity.ts
@@ -1,0 +1,10 @@
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const advancedSecurity = require("./advancedSecurity.cjs");
+
+export const authenticateWithRotation = advancedSecurity.authenticateWithRotation;
+export const generateToken = advancedSecurity.generateToken;
+export const verifyToken = advancedSecurity.verifyToken;
+
+export default advancedSecurity;

--- a/apps/api/src/middleware/security.js
+++ b/apps/api/src/middleware/security.js
@@ -9,7 +9,7 @@ const { ipKeyGenerator } = require("express-rate-limit");
 const jwt = require("jsonwebtoken");
 const { authenticateWithRotation } = require("./advancedSecurity.cjs");
 const { env } = require("../config/env");
-const rateLimitMetrics = require("../lib/rateLimitMetrics.cjs");
+const rateLimitMetrics = require("../lib/rateLimitMetrics");
 const { logger } = require("./logger");
 const { validateScope, hasScope, hasAllScopes } = require("@infamous-freight/shared");
 

--- a/apps/api/src/middleware/security.js
+++ b/apps/api/src/middleware/security.js
@@ -7,9 +7,9 @@
 const rateLimit = require("express-rate-limit");
 const { ipKeyGenerator } = require("express-rate-limit");
 const jwt = require("jsonwebtoken");
-const { authenticateWithRotation } = require("./advancedSecurity");
+const { authenticateWithRotation } = require("./advancedSecurity.cjs");
 const { env } = require("../config/env");
-const rateLimitMetrics = require("../lib/rateLimitMetrics");
+const rateLimitMetrics = require("../lib/rateLimitMetrics.cjs");
 const { logger } = require("./logger");
 const { validateScope, hasScope, hasAllScopes } = require("@infamous-freight/shared");
 

--- a/apps/api/src/routes/billing.ts
+++ b/apps/api/src/routes/billing.ts
@@ -16,7 +16,7 @@ import {
   requireScope,
   limiters,
 } from "../middleware/security.js";
-import validation from "../middleware/validation.js";
+import * as validation from "../middleware/validation.js";
 import { logAuditEvent, AUDIT_ACTIONS } from "../audit/orgAuditLog.js";
 import { tenantPrisma } from "../db/tenant.js";
 import { body, query } from "express-validator";

--- a/apps/api/src/routes/documents.routes.ts
+++ b/apps/api/src/routes/documents.routes.ts
@@ -8,7 +8,7 @@ import { requireTenant } from '../middleware/tenant.js';
 
 const require = createRequire(import.meta.url);
 const { requireRole } = require('../middleware/rbac.js');
-const prisma = require('../lib/prisma.js');
+const prisma = require('../lib/prisma.cjs');
 
 const uploadDir = process.env.UPLOAD_DIR || './uploads';
 fs.mkdirSync(uploadDir, { recursive: true });

--- a/apps/api/src/routes/documents.routes.ts
+++ b/apps/api/src/routes/documents.routes.ts
@@ -2,10 +2,13 @@ import { Router } from 'express';
 import multer from 'multer';
 import path from 'path';
 import fs from 'fs';
-import { requireAuth } from '../middleware/auth.js';
-import { requireTenant } from '../middleware/tenant.js';
-import { requireRole } from '../middleware/rbac.js';
-import prisma from '../lib/prisma.js';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const { requireAuth } = require('../middleware/auth.js');
+const { requireTenant } = require('../middleware/tenant.js');
+const { requireRole } = require('../middleware/rbac.js');
+const prisma = require('../lib/prisma.js');
 
 const uploadDir = process.env.UPLOAD_DIR || './uploads';
 fs.mkdirSync(uploadDir, { recursive: true });

--- a/apps/api/src/routes/documents.routes.ts
+++ b/apps/api/src/routes/documents.routes.ts
@@ -3,10 +3,10 @@ import multer from 'multer';
 import path from 'path';
 import fs from 'fs';
 import { createRequire } from 'module';
+import { requireAuth } from '../middleware/auth.js';
+import { requireTenant } from '../middleware/tenant.js';
 
 const require = createRequire(import.meta.url);
-const { requireAuth } = require('../middleware/auth.js');
-const { requireTenant } = require('../middleware/tenant.js');
 const { requireRole } = require('../middleware/rbac.js');
 const prisma = require('../lib/prisma.js');
 

--- a/apps/api/src/routes/sales.ts
+++ b/apps/api/src/routes/sales.ts
@@ -12,7 +12,7 @@
 import { Router, type Request, type Response, type NextFunction } from "express";
 import { body, query } from "express-validator";
 import { authenticate, requireScope, limiters } from "../middleware/security.js";
-import validation from "../middleware/validation.js";
+import * as validation from "../middleware/validation.js";
 
 import {
   createLead,

--- a/apps/api/src/routes/stripe.routes.ts
+++ b/apps/api/src/routes/stripe.routes.ts
@@ -1,9 +1,12 @@
 import { Router } from 'express';
+import { createRequire } from 'module';
 import { authenticate as requireAuth } from '../middleware/security.js';
-import { requireRole } from '../middleware/rbac.js';
 import { createPaymentIntentForInvoice, handleStripeWebhookEvent } from '../integrations/stripe/stripe.billing.js';
 import { env } from '@infamous-freight/shared';
 import { stripe } from '../integrations/stripe/stripe.client.js';
+
+const require = createRequire(import.meta.url);
+const { requireRole } = require('../middleware/rbac.js');
 
 export const stripeRoutes: Router = Router();
 

--- a/apps/api/src/sales/demoScheduling.ts
+++ b/apps/api/src/sales/demoScheduling.ts
@@ -8,8 +8,11 @@
  */
 
 import { PrismaClient } from "@prisma/client";
+import { createRequire } from "module";
 import { createLead, convertLead } from "./leadCapture.js";
-import { sendEmail } from "../services/emailService.js";
+
+const require = createRequire(import.meta.url);
+const { sendEmail } = require("../services/emailService.js");
 
 const prisma = new PrismaClient();
 


### PR DESCRIPTION
### Motivation

- Address runtime import issues when ESM modules import CommonJS helpers like `prisma` and middleware, which caused missing/default export problems. 
- Ensure server route and integration modules can correctly require legacy CommonJS modules from ESM code. 

### Description

- Export a `default` on the `prisma` CommonJS wrapper by adding `module.exports.default = module.exports` to `apps/api/src/lib/prisma.js`. 
- Replace failing ESM default imports with Node's `createRequire` and CommonJS `require` in `stripe.billing.ts`, `documents.routes.ts`, and `demoScheduling.ts` to import `prisma`, auth/tenant/rbac middleware, and `sendEmail`. 
- Change `validation` imports in `routes/billing.ts` and `routes/sales.ts` from a default import to a namespace import using `import * as validation` to match the actual exports. 

### Testing

- Ran TypeScript build with `npm run build` to verify compilation and the ESM/CommonJS interop changes, which succeeded. 
- Executed the test suite with `npm test`, and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5e727ef148330b47a59e134a33491)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix ESM/CommonJS interop across API routes and middleware, and harden Prisma client init with `@prisma/adapter-pg` + `pg` Pool to stop default-export and runtime import errors. Adds ESM-safe wrappers and uses `createRequire` where needed.

- **Bug Fixes**
  - Prisma: make `apps/api/src/lib/prisma.js` default-exportable; in `apps/api/src/db/prisma.ts` load `PrismaClient` via `createRequire`, use `@prisma/adapter-pg` with a `pg` Pool, and have `closePrisma` end the Pool.
  - Security/metrics: add ESM wrappers `apps/api/src/lib/rateLimitMetrics.ts` and `apps/api/src/middleware/advancedSecurity.ts`; update `apps/api/src/middleware/security.js` to import `./advancedSecurity.cjs`.
  - Routes: in `apps/api/src/routes/documents.routes.ts` and `apps/api/src/routes/stripe.routes.ts`, use `createRequire` to load `requireRole` and require `../lib/prisma.cjs` where needed.
  - Stripe/demo: in `apps/api/src/integrations/stripe/stripe.billing.ts` instantiate a local `PrismaClient` instead of importing `prisma`; in `apps/api/src/sales/demoScheduling.ts` load `sendEmail` via `createRequire`.
  - Validation: switch to `import * as validation` in `apps/api/src/routes/billing.ts` and `apps/api/src/routes/sales.ts`.

<sup>Written for commit fa6038ac20ae3489dc280926ebecc3f9040b0c38. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

