### PR TITLE
fix(web): restore dashboard page test syntax and assertion closure

### DIFF
--- a/apps/web/tests/dashboard-page.test.tsx
+++ b/apps/web/tests/dashboard-page.test.tsx
@@ -56,8 +56,11 @@ describe("dashboard page", () => {
             component: "dashboard",
             action: "listLoads",
           }),
-    const errorMessage = await screen.findByText("Failed to load dashboard data. Please try again.");
+        }),
+      );
+    });
 
+    const errorMessage = await screen.findByText("Failed to load dashboard data. Please try again.");
     expect(errorMessage).toBeInTheDocument();
     expect(reportSentryErrorMock).toHaveBeenCalledTimes(1);
   });

--- a/apps/web/tests/dashboard-page.test.tsx
+++ b/apps/web/tests/dashboard-page.test.tsx
@@ -50,16 +50,17 @@ describe("dashboard page", () => {
 
     await waitFor(() => {
       expect(reportSentryErrorMock).toHaveBeenCalledTimes(1);
-
-      const [reportedError, reportedContext] = reportSentryErrorMock.mock.calls[0];
-      expect(reportedError).toBeInstanceOf(Error);
-      expect((reportedError as Error).message).toBe("firestore unavailable");
-      expect(reportedContext).toEqual(expect.objectContaining({
-        contexts: expect.objectContaining({
-          component: "dashboard",
-          action: "listLoads",
+      expect(reportSentryErrorMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "firestore unavailable",
         }),
-      }));
+        expect.objectContaining({
+          contexts: expect.objectContaining({
+            component: "dashboard",
+            action: "listLoads",
+          }),
+        }),
+      );
     });
 
     const errorMessage = await screen.findByText("Failed to load dashboard data. Please try again.");

--- a/apps/web/tests/dashboard-page.test.tsx
+++ b/apps/web/tests/dashboard-page.test.tsx
@@ -49,24 +49,21 @@ describe("dashboard page", () => {
     render(<Dashboard />);
 
     await waitFor(() => {
-      expect(reportSentryErrorMock).toHaveBeenCalledWith(
-        expect.any(Error),
-        expect.objectContaining({
-          contexts: expect.objectContaining({
-            component: "dashboard",
-            action: "listLoads",
-          }),
+      expect(reportSentryErrorMock).toHaveBeenCalledTimes(1);
+
+      const [reportedError, reportedContext] = reportSentryErrorMock.mock.calls[0];
+      expect(reportedError).toBeInstanceOf(Error);
+      expect((reportedError as Error).message).toBe("firestore unavailable");
+      expect(reportedContext).toEqual(expect.objectContaining({
+        contexts: expect.objectContaining({
+          component: "dashboard",
+          action: "listLoads",
         }),
-      );
+      }));
     });
 
     const errorMessage = await screen.findByText("Failed to load dashboard data. Please try again.");
     expect(errorMessage).toBeInTheDocument();
-    expect(reportSentryErrorMock).toHaveBeenCalledTimes(1);
-
-    const [reportedError] = reportSentryErrorMock.mock.calls[0] ?? [];
-    expect(reportedError).toBeInstanceOf(Error);
-    expect((reportedError as Error).message).toBe("firestore unavailable");
   });
 
   it("redirects unauthenticated users to login", async () => {

--- a/apps/web/tests/dashboard-page.test.tsx
+++ b/apps/web/tests/dashboard-page.test.tsx
@@ -63,6 +63,10 @@ describe("dashboard page", () => {
     const errorMessage = await screen.findByText("Failed to load dashboard data. Please try again.");
     expect(errorMessage).toBeInTheDocument();
     expect(reportSentryErrorMock).toHaveBeenCalledTimes(1);
+
+    const [reportedError] = reportSentryErrorMock.mock.calls[0] ?? [];
+    expect(reportedError).toBeInstanceOf(Error);
+    expect((reportedError as Error).message).toBe("firestore unavailable");
   });
 
   it("redirects unauthenticated users to login", async () => {


### PR DESCRIPTION
### Motivation
- Fix a syntax/formatting error in the dashboard page test that caused the test transform to fail and blocked the web test suite.

### Description
- Close the previously-unterminated `expect.objectContaining(...)`, `toHaveBeenCalledWith(...)`, and `waitFor(...)` blocks in `apps/web/tests/dashboard-page.test.tsx` so the test compiles and preserves its original assertions for Sentry reporting and the user-facing error message.

### Testing
- Initialized Node 24 / pnpm 10 toolchain and ran `pnpm install` followed by `pnpm test -- --runInBand`, and the workspace tests completed successfully with all suites passing (test files: 8 passed; tests: 18 passed, 22 skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5fe6c588c83308d76521b0f5ae5e2)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores and tightens the dashboard test to unblock the web test suite. Asserts exactly one Sentry report inside `waitFor` using `expect.objectContaining` for the error message ("firestore unavailable") and `contexts`, and verifies the failure message is shown.

<sup>Written for commit 6878a440b70ad3f23f2795d3acf67bc8369c680e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Tightened and clarified test assertions for dashboard error handling and reporting to ensure a single, well-formed error is recorded and the user-facing error message still displays.

---

Note: This release contains internal test improvements only. No changes visible to end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->