### PR TITLE
Enforce tenant/org scoping for shipments and add Sentry observability

### DIFF
--- a/apps/api/src/routes/shipments.js
+++ b/apps/api/src/routes/shipments.js
@@ -467,6 +467,7 @@ router.get(
       Object.assign(where, tenantScope);
       if (status) where.status = status;
       if (driverId) where.driverId = driverId;
+      if (req.user?.role !== "admin" && req.user?.sub) where.userId = req.user.sub;
 
       // Fetch shipments
       const shipments = await prisma.shipment.findMany({

--- a/apps/api/src/routes/shipments.js
+++ b/apps/api/src/routes/shipments.js
@@ -1,5 +1,6 @@
 const express = require("express");
 const { randomUUID } = require("crypto");
+const Sentry = require("@sentry/node");
 const { prisma } = require("../db/prisma");
 const { asyncHandler, ConflictError, NotFoundError } = require("../lib/errors");
 const {
@@ -30,6 +31,18 @@ const {
 } = require("../services/shipmentValidator");
 
 const router = express.Router();
+const resolveTenantContext = (req) => {
+  const tenantId = req.auth?.organizationId || req.user?.tenantId || req.user?.organizationId;
+  return {
+    tenantId: tenantId || null,
+    orgId: req.user?.organizationId || req.user?.orgId || tenantId || null,
+  };
+};
+const shipmentTenantScope = ({ tenantId, orgId }) => {
+  if (tenantId) return { tenantId };
+  if (orgId) return { orgId };
+  return null;
+};
 
 // Get all shipments with optional filtering
 router.get(
@@ -48,10 +61,16 @@ router.get(
   asyncHandler(async (req, res) => {
       const { status, driverId } = req.query;
       const where = {};
+      const { tenantId, orgId } = resolveTenantContext(req);
+      const tenantScope = shipmentTenantScope({ tenantId, orgId });
+      if (!tenantScope) {
+        return res.status(403).json({ ok: false, error: "Tenant context is required" });
+      }
 
       if (req.user?.role !== "admin") {
         where.userId = req.user?.sub;
       }
+      Object.assign(where, tenantScope);
 
       if (status) where.status = status;
       if (driverId) where.driverId = driverId;
@@ -89,8 +108,16 @@ router.get(
   validateUUID("id"),
   handleValidationErrors,
   asyncHandler(async (req, res) => {
-      const shipment = await prisma.shipment.findUnique({
-        where: { id: req.params.id },
+      const { tenantId, orgId } = resolveTenantContext(req);
+      const tenantScope = shipmentTenantScope({ tenantId, orgId });
+      if (!tenantScope) {
+        return res.status(403).json({ ok: false, error: "Tenant context is required" });
+      }
+      const shipment = await prisma.shipment.findFirst({
+        where: {
+          id: req.params.id,
+          ...tenantScope,
+        },
         include: {
           driver: {
             select: {
@@ -142,11 +169,14 @@ router.post(
       }
 
       const userId = req.user?.sub;
+      const { tenantId, orgId } = resolveTenantContext(req);
+      if (!tenantId && !orgId) {
+        return res.status(403).json({ ok: false, error: "Tenant context is required" });
+      }
       const newTrackingId =
         trackingId || reference || `TRK-${randomUUID().replace(/-/g, "").slice(0, 12)}`;
 
       // Use transaction to ensure atomic operation
-      const Sentry = require("@sentry/node");
       Sentry.addBreadcrumb({
         category: "database",
         message: "Creating shipment with transaction",
@@ -161,6 +191,8 @@ router.post(
               trackingId: newTrackingId,
               reference: reference || newTrackingId,
               userId,
+              tenantId,
+              orgId,
               origin,
               destination,
               driverId: driverId || null,
@@ -209,6 +241,7 @@ router.post(
       });
   } catch (err) {
       if (err.code === "P2002") throw new ConflictError("Reference already exists");
+      Sentry.captureException(err);
       throw err;
     }
   }),
@@ -232,10 +265,18 @@ router.patch(
     try {
       const { status, driverId } = req.body;
       const updates = {};
+      const { tenantId, orgId } = resolveTenantContext(req);
+      const tenantScope = shipmentTenantScope({ tenantId, orgId });
+      if (!tenantScope) {
+        return res.status(403).json({ ok: false, error: "Tenant context is required" });
+      }
 
       // Fetch full shipment for validation
-      const existing = await prisma.shipment.findUnique({
-        where: { id: req.params.id },
+      const existing = await prisma.shipment.findFirst({
+        where: {
+          id: req.params.id,
+          ...tenantScope,
+        },
         select: {
           id: true,
           userId: true,
@@ -260,7 +301,6 @@ router.patch(
       // Validate shipment state machine and business rules
       const validation = validateShipmentUpdate(existing, updates);
       if (!validation.valid) {
-        const Sentry = require("@sentry/node");
         Sentry.addBreadcrumb({
           category: "validation",
           message: "Invalid shipment update",
@@ -281,7 +321,6 @@ router.patch(
         });
       }
 
-      const Sentry = require("@sentry/node");
       Sentry.addBreadcrumb({
         category: "database",
         message: "Updating shipment with transaction",
@@ -350,6 +389,7 @@ router.patch(
       });
   } catch (err) {
       if (err.code === "P2025") throw new NotFoundError("Shipment not found");
+      Sentry.captureException(err);
       throw err;
     }
   }),
@@ -366,8 +406,16 @@ router.delete(
   [validateUUID("id"), handleValidationErrors],
   asyncHandler(async (req, res) => {
     try {
-      const existing = await prisma.shipment.findUnique({
-        where: { id: req.params.id },
+      const { tenantId, orgId } = resolveTenantContext(req);
+      const tenantScope = shipmentTenantScope({ tenantId, orgId });
+      if (!tenantScope) {
+        return res.status(403).json({ ok: false, error: "Tenant context is required" });
+      }
+      const existing = await prisma.shipment.findFirst({
+        where: {
+          id: req.params.id,
+          ...tenantScope,
+        },
         select: { id: true, userId: true },
       });
 
@@ -388,6 +436,7 @@ router.delete(
       await invalidateCache("*shipments*");
   } catch (err) {
       if (err.code === "P2025") throw new NotFoundError("Shipment not found");
+      Sentry.captureException(err);
       throw err;
     }
   }),
@@ -405,9 +454,15 @@ router.get(
   asyncHandler(async (req, res) => {
       const { format } = req.params;
       const { status, driverId } = req.query;
+      const { tenantId, orgId } = resolveTenantContext(req);
+      const tenantScope = shipmentTenantScope({ tenantId, orgId });
+      if (!tenantScope) {
+        return res.status(403).json({ ok: false, error: "Tenant context is required" });
+      }
 
       // Build query
       const where = {};
+      Object.assign(where, tenantScope);
       if (status) where.status = status;
       if (driverId) where.driverId = driverId;
 

--- a/apps/api/src/routes/shipments.js
+++ b/apps/api/src/routes/shipments.js
@@ -35,12 +35,11 @@ const resolveTenantContext = (req) => {
   const tenantId = req.auth?.organizationId || req.user?.tenantId || req.user?.organizationId;
   return {
     tenantId: tenantId || null,
-    orgId: req.user?.organizationId || req.user?.orgId || tenantId || null,
+    orgId: req.user?.organizationId || req.user?.orgId || null,
   };
 };
-const shipmentTenantScope = ({ tenantId, orgId }) => {
+const shipmentTenantScope = ({ tenantId }) => {
   if (tenantId) return { tenantId };
-  if (orgId) return { orgId };
   return null;
 };
 
@@ -61,8 +60,8 @@ router.get(
   asyncHandler(async (req, res) => {
       const { status, driverId } = req.query;
       const where = {};
-      const { tenantId, orgId } = resolveTenantContext(req);
-      const tenantScope = shipmentTenantScope({ tenantId, orgId });
+      const { tenantId } = resolveTenantContext(req);
+      const tenantScope = shipmentTenantScope({ tenantId });
       if (!tenantScope) {
         return res.status(403).json({ ok: false, error: "Tenant context is required" });
       }
@@ -108,8 +107,8 @@ router.get(
   validateUUID("id"),
   handleValidationErrors,
   asyncHandler(async (req, res) => {
-      const { tenantId, orgId } = resolveTenantContext(req);
-      const tenantScope = shipmentTenantScope({ tenantId, orgId });
+      const { tenantId } = resolveTenantContext(req);
+      const tenantScope = shipmentTenantScope({ tenantId });
       if (!tenantScope) {
         return res.status(403).json({ ok: false, error: "Tenant context is required" });
       }
@@ -170,7 +169,7 @@ router.post(
 
       const userId = req.user?.sub;
       const { tenantId, orgId } = resolveTenantContext(req);
-      if (!tenantId && !orgId) {
+      if (!tenantId) {
         return res.status(403).json({ ok: false, error: "Tenant context is required" });
       }
       const newTrackingId =
@@ -265,8 +264,8 @@ router.patch(
     try {
       const { status, driverId } = req.body;
       const updates = {};
-      const { tenantId, orgId } = resolveTenantContext(req);
-      const tenantScope = shipmentTenantScope({ tenantId, orgId });
+      const { tenantId } = resolveTenantContext(req);
+      const tenantScope = shipmentTenantScope({ tenantId });
       if (!tenantScope) {
         return res.status(403).json({ ok: false, error: "Tenant context is required" });
       }
@@ -406,8 +405,8 @@ router.delete(
   [validateUUID("id"), handleValidationErrors],
   asyncHandler(async (req, res) => {
     try {
-      const { tenantId, orgId } = resolveTenantContext(req);
-      const tenantScope = shipmentTenantScope({ tenantId, orgId });
+      const { tenantId } = resolveTenantContext(req);
+      const tenantScope = shipmentTenantScope({ tenantId });
       if (!tenantScope) {
         return res.status(403).json({ ok: false, error: "Tenant context is required" });
       }
@@ -454,8 +453,8 @@ router.get(
   asyncHandler(async (req, res) => {
       const { format } = req.params;
       const { status, driverId } = req.query;
-      const { tenantId, orgId } = resolveTenantContext(req);
-      const tenantScope = shipmentTenantScope({ tenantId, orgId });
+      const { tenantId } = resolveTenantContext(req);
+      const tenantScope = shipmentTenantScope({ tenantId });
       if (!tenantScope) {
         return res.status(403).json({ ok: false, error: "Tenant context is required" });
       }

--- a/apps/api/src/routes/shipments.js
+++ b/apps/api/src/routes/shipments.js
@@ -70,6 +70,9 @@ router.get(
         where.userId = req.user?.sub;
       }
       Object.assign(where, tenantScope);
+      if (req.user?.role !== "admin") {
+        where.userId = req.user?.sub;
+      }
 
       if (status) where.status = status;
       if (driverId) where.driverId = driverId;

--- a/apps/api/src/routes/shipments.js
+++ b/apps/api/src/routes/shipments.js
@@ -35,7 +35,7 @@ const resolveTenantContext = (req) => {
   const tenantId = req.auth?.organizationId || req.user?.tenantId || req.user?.organizationId;
   return {
     tenantId: tenantId || null,
-    orgId: req.user?.organizationId || req.user?.orgId || null,
+    orgId: req.user?.organizationId || req.user?.orgId || tenantId || null,
   };
 };
 const shipmentTenantScope = ({ tenantId }) => {


### PR DESCRIPTION
### Motivation
- Prevent cross-tenant access by ensuring all shipments queries and mutations are scoped to a tenant or organization context.
- Persist tenant metadata on created shipments to support multi-tenant data separation.
- Improve observability and error reporting around shipment operations using Sentry breadcrumbs and exception capture.

### Description
- Add `resolveTenantContext` and `shipmentTenantScope` helpers and import `@sentry/node` at the top of `routes/shipments.js`.
- Enforce tenant/org scope on all endpoints by returning `403` when no tenant context is present and by merging tenant scope into query `where` clauses for `GET /shipments`, `GET /shipments/:id` (now using `findFirst` with tenant filters), `PATCH /shipments/:id`, `DELETE /shipments/:id` (uses `findFirst` to validate), and `GET /shipments/export/:format`.
- Include `tenantId` and `orgId` when creating shipments inside the transaction in `POST /shipments` and add Sentry breadcrumbs for create/update/validation steps.
- Replace per-handler `require("@sentry/node")` calls with the top-level import and call `Sentry.captureException(err)` in catch blocks for improved centralized error reporting.

### Testing
- Ran the automated test suite with `npm test` and all tests passed.
- Ran the project linting with `npm run lint` and no new lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5f73c6e8c8330a9224c0766561c70)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces tenant-scoped access across all shipment APIs and adds Sentry breadcrumbs and exception capture for clearer observability and safer multi-tenant behavior.

- **New Features - New features added**
  - Require tenant context on all shipment routes; return 403 when missing. Use `resolveTenantContext` and `shipmentTenantScope` to apply `{ tenantId }` on `GET`, `GET/:id` (switch to `findFirst`), `POST` (persist `tenantId` and `orgId`), `PATCH` (switch to `findFirst`), `DELETE` (switch to `findFirst`), and `GET /shipments/export/:format` (also respects non-admin user scoping).
  - Centralize `@sentry/node` import; add breadcrumbs for validation and database operations, and call `Sentry.captureException` in `POST`, `PATCH`, and `DELETE` catch blocks.

- **Migration - Steps needed for adoption (if applicable)**
  - All shipment requests must include a tenant context (from `req.auth.organizationId`, `req.user.tenantId`, or `req.user.organizationId`) or they will receive 403.

<sup>Written for commit a766609332b391db56c22e0d1aa234fe43263875. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

