### PR TITLE
Add production secrets bootstrap script, docs, tests, and CI integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ on:
       - 'Dockerfile'
       - 'Dockerfile.*'
       - 'docker/**'
+      - 'scripts/**'
+      - 'tests/**'
+      - 'docs/**'
   pull_request:
     branches:
       - main
@@ -33,6 +36,9 @@ on:
       - 'Dockerfile'
       - 'Dockerfile.*'
       - 'docker/**'
+      - 'scripts/**'
+      - 'tests/**'
+      - 'docs/**'
   workflow_dispatch:
 
 permissions:
@@ -98,6 +104,9 @@ jobs:
 
       - name: Run fly config test
         run: bash tests/ci/fly-config.test.sh
+
+      - name: Run bootstrap secrets test
+        run: bash tests/ci/bootstrap-production-secrets.test.sh
 
   lint:
     name: lint

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/server.js",
     "typecheck": "pnpm --filter @infamous-freight/shared build && tsc --noEmit -p tsconfig.json",
     "lint": "eslint src --ext .ts",
-    "test": "node scripts/run-vitest.mjs",
+    "test": "pnpm --filter @infamous-freight/shared build && node scripts/run-vitest.mjs",
     "smoke": "node -e \"const base = (process.env.API_URL || 'http://localhost:4000').replace(/\\/$/, ''); fetch(base + '/health').then((res) => { if (!res.ok) process.exit(1); }).catch(() => process.exit(1));\"",
     "prisma:generate": "node scripts/prisma-generate-safe.mjs",
     "db:migrate": "PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 prisma migrate deploy --schema=prisma/schema.prisma",

--- a/apps/api/scripts/run-vitest.mjs
+++ b/apps/api/scripts/run-vitest.mjs
@@ -19,9 +19,9 @@ for (const arg of forwardedArgs) {
 }
 
 const defaultPatterns = [
-  'src/**/*.test.ts',
+  'src/**/*.test.{ts,js,mjs}',
   'src/**/*.spec.ts',
-  'src/**/__tests__/**/*.test.ts',
+  'src/**/__tests__/**/*.test.{ts,js,mjs}',
 ];
 
 const hasExplicitFileFilter = sanitizedArgs.some((arg) => !arg.startsWith('-'));

--- a/apps/api/scripts/run-vitest.mjs
+++ b/apps/api/scripts/run-vitest.mjs
@@ -6,6 +6,10 @@ const sanitizedArgs = [];
 let forceSingleWorker = false;
 
 for (const arg of forwardedArgs) {
+  if (arg === '--') {
+    continue;
+  }
+
   if (arg === '--runInBand') {
     forceSingleWorker = true;
     continue;
@@ -14,7 +18,18 @@ for (const arg of forwardedArgs) {
   sanitizedArgs.push(arg);
 }
 
-const vitestArgs = ['run', '--passWithNoTests', 'src/**/*.test.{ts,js,mjs}'];
+const defaultPatterns = [
+  'src/**/*.test.ts',
+  'src/**/*.spec.ts',
+  'src/**/__tests__/**/*.test.ts',
+];
+
+const hasExplicitFileFilter = sanitizedArgs.some((arg) => !arg.startsWith('-'));
+const vitestArgs = ['run', '--passWithNoTests'];
+
+if (!hasExplicitFileFilter) {
+  vitestArgs.push(...defaultPatterns);
+}
 
 if (forceSingleWorker && !sanitizedArgs.some((arg) => arg.startsWith('--maxWorkers'))) {
   vitestArgs.push('--maxWorkers=1');

--- a/docs/ENV_SETUP_SECRETS_GUIDE.md
+++ b/docs/ENV_SETUP_SECRETS_GUIDE.md
@@ -1,5 +1,73 @@
 # Environment Setup & Secrets Guide
 
+## Production Secret Bootstrap (Netlify + Fly.io)
+
+Use this checklist when wiring production credentials for the current deployment targets.
+
+### 1) Required variables before first deploy
+
+| Variable | Used by | Status | Notes |
+|---|---|---|---|
+| `NETLIFY_AUTH_TOKEN` | Netlify CLI/API | required | Personal access token for `netlify env:*` and deploy automation. |
+| `NETLIFY_SITE_ID` | Netlify site targeting | required | UUID for the production web site. |
+| `FLY_API_TOKEN` | Fly.io CLI/API | required | Generate with `flyctl auth token`. |
+| `DATABASE_URL` | API + Prisma | required | Use the managed Postgres connection string with a real password. |
+| `NEXT_PUBLIC_API_URL` | Web frontend | required | Public API origin (for example `https://infamous.fly.dev`). |
+| `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | Stripe checkout UI | required if billing enabled | Must be the publishable key (`pk_...`), never a secret key. |
+| `JWT_SECRET` | API auth signing (HS256 mode + web stripe route) | required | Generate with `openssl rand -base64 32`. |
+
+### 2) Export locally (do not commit secrets)
+
+```bash
+export NETLIFY_AUTH_TOKEN="<set-in-shell-or-password-manager>"
+export NETLIFY_SITE_ID="<your-netlify-site-id>"
+export FLY_API_TOKEN="$(flyctl auth token)"
+export DATABASE_URL="postgresql://postgres:<password>@<host>:5432/postgres?schema=public"
+export NEXT_PUBLIC_API_URL="https://infamous.fly.dev"
+export NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY="pk_live_..."
+export JWT_SECRET="$(openssl rand -base64 32)"
+```
+
+### 3) Apply automatically with one script (recommended)
+
+```bash
+./scripts/bootstrap-production-secrets.sh
+```
+
+Use `DRY_RUN=1` first to preview changes:
+
+```bash
+DRY_RUN=1 ./scripts/bootstrap-production-secrets.sh
+```
+
+### 4) Apply to Netlify environment
+
+```bash
+printf '%s' "$NEXT_PUBLIC_API_URL" | netlify env:set NEXT_PUBLIC_API_URL production
+printf '%s' "$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY" | netlify env:set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY production
+printf '%s' "$JWT_SECRET" | netlify env:set JWT_SECRET production
+```
+
+### 5) Apply to Fly.io environment
+
+```bash
+flyctl secrets set \
+  DATABASE_URL="$DATABASE_URL" \
+  JWT_SECRET="$JWT_SECRET" \
+  --app infamous-freight-api
+```
+
+### 6) Post-setup verification
+
+```bash
+netlify env:list --context production
+flyctl secrets list --app infamous-freight-api
+```
+
+> Security note: keep real token/key values in your secret manager and CI provider; commit only placeholders in tracked files.
+
+---
+
 ## Quick Reference
 
 ```bash

--- a/docs/ENV_SETUP_SECRETS_GUIDE.md
+++ b/docs/ENV_SETUP_SECRETS_GUIDE.md
@@ -13,7 +13,7 @@ Use this checklist when wiring production credentials for the current deployment
 | `FLY_API_TOKEN` | Fly.io CLI/API | required | Generate with `flyctl auth token`. |
 | `DATABASE_URL` | API + Prisma | required | Use the managed Postgres connection string with a real password. |
 | `NEXT_PUBLIC_API_URL` | Web frontend | required | Public API origin (for example `https://infamous.fly.dev`). |
-| `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | Stripe checkout UI | required if billing enabled | Must be the publishable key (`pk_...`), never a secret key. |
+| `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | Stripe checkout UI | required | Must be the publishable key (`pk_...`), never a secret key. |
 | `JWT_SECRET` | API auth signing (HS256 mode + web stripe route) | required | Generate with `openssl rand -base64 32`. |
 
 ### 2) Export locally (do not commit secrets)

--- a/scripts/bootstrap-production-secrets.sh
+++ b/scripts/bootstrap-production-secrets.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Bootstrap production secrets for Netlify + Fly.io.
+
+Required environment variables:
+  NETLIFY_AUTH_TOKEN
+  NETLIFY_SITE_ID
+  FLY_API_TOKEN
+  DATABASE_URL
+  NEXT_PUBLIC_API_URL
+  NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
+  JWT_SECRET
+
+Optional environment variables:
+  FLY_APP_NAME         (default: infamous-freight-api)
+  NETLIFY_CONTEXT      (default: production)
+  DRY_RUN              (set to 1 to print actions without applying)
+
+Example:
+  NETLIFY_AUTH_TOKEN=... NETLIFY_SITE_ID=... FLY_API_TOKEN=... \
+  DATABASE_URL=... NEXT_PUBLIC_API_URL=https://infamous.fly.dev \
+  NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_live_... JWT_SECRET=$(openssl rand -base64 32) \
+  ./scripts/bootstrap-production-secrets.sh
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+require_var() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    echo "[bootstrap-secrets] Missing required env var: ${name}" >&2
+    exit 1
+  fi
+}
+
+for cmd in netlify flyctl; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "[bootstrap-secrets] Required command not found: $cmd" >&2
+    exit 1
+  fi
+done
+
+required_vars=(
+  NETLIFY_AUTH_TOKEN
+  NETLIFY_SITE_ID
+  FLY_API_TOKEN
+  DATABASE_URL
+  NEXT_PUBLIC_API_URL
+  NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
+  JWT_SECRET
+)
+
+for var_name in "${required_vars[@]}"; do
+  require_var "$var_name"
+done
+
+if [[ ! "${DATABASE_URL}" =~ ^postgres(ql)?:// ]]; then
+  echo "[bootstrap-secrets] DATABASE_URL must start with postgres:// or postgresql://" >&2
+  exit 1
+fi
+
+if [[ ! "${NEXT_PUBLIC_API_URL}" =~ ^https:// ]]; then
+  echo "[bootstrap-secrets] NEXT_PUBLIC_API_URL must be https:// in production" >&2
+  exit 1
+fi
+
+if [[ ! "${NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY}" =~ ^pk_(live|test)_ ]]; then
+  echo "[bootstrap-secrets] NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY must be a Stripe publishable key" >&2
+  exit 1
+fi
+
+if [[ ${#JWT_SECRET} -lt 32 ]]; then
+  echo "[bootstrap-secrets] JWT_SECRET must be at least 32 characters" >&2
+  exit 1
+fi
+
+FLY_APP_NAME="${FLY_APP_NAME:-infamous-freight-api}"
+NETLIFY_CONTEXT="${NETLIFY_CONTEXT:-production}"
+DRY_RUN="${DRY_RUN:-0}"
+
+run_cmd() {
+  if [[ "$DRY_RUN" == "1" ]]; then
+    echo "[dry-run] $*"
+  else
+    "$@"
+  fi
+}
+
+echo "[bootstrap-secrets] Applying Netlify env vars to context '${NETLIFY_CONTEXT}' for site '${NETLIFY_SITE_ID}'."
+if [[ "$DRY_RUN" == "1" ]]; then
+  echo "[dry-run] printf '%s' \"\$NEXT_PUBLIC_API_URL\" | netlify env:set NEXT_PUBLIC_API_URL ${NETLIFY_CONTEXT}"
+  echo "[dry-run] printf '%s' \"\$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY\" | netlify env:set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ${NETLIFY_CONTEXT}"
+  echo "[dry-run] printf '%s' \"\$JWT_SECRET\" | netlify env:set JWT_SECRET ${NETLIFY_CONTEXT}"
+else
+  printf '%s' "$NEXT_PUBLIC_API_URL" | env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" netlify env:set NEXT_PUBLIC_API_URL "$NETLIFY_CONTEXT"
+  printf '%s' "$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY" | env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" netlify env:set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY "$NETLIFY_CONTEXT"
+  printf '%s' "$JWT_SECRET" | env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" netlify env:set JWT_SECRET "$NETLIFY_CONTEXT"
+fi
+
+echo "[bootstrap-secrets] Applying Fly.io secrets to app '${FLY_APP_NAME}'."
+run_cmd env FLY_API_TOKEN="$FLY_API_TOKEN" flyctl secrets set \
+  DATABASE_URL="$DATABASE_URL" \
+  JWT_SECRET="$JWT_SECRET" \
+  --app "$FLY_APP_NAME"
+
+echo "[bootstrap-secrets] Done. Verify with:"
+echo "  NETLIFY_AUTH_TOKEN=*** NETLIFY_SITE_ID=*** netlify env:list --context ${NETLIFY_CONTEXT}"
+echo "  FLY_API_TOKEN=*** flyctl secrets list --app ${FLY_APP_NAME}"

--- a/scripts/bootstrap-production-secrets.sh
+++ b/scripts/bootstrap-production-secrets.sh
@@ -105,10 +105,14 @@ else
 fi
 
 echo "[bootstrap-secrets] Applying Fly.io secrets to app '${FLY_APP_NAME}'."
-run_cmd env FLY_API_TOKEN="$FLY_API_TOKEN" flyctl secrets set \
-  DATABASE_URL="$DATABASE_URL" \
-  JWT_SECRET="$JWT_SECRET" \
-  --app "$FLY_APP_NAME"
+if [[ "$DRY_RUN" == "1" ]]; then
+  echo "[dry-run] env FLY_API_TOKEN=*** flyctl secrets set DATABASE_URL=\"\$DATABASE_URL\" JWT_SECRET=\"\$JWT_SECRET\" --app ${FLY_APP_NAME}"
+else
+  env FLY_API_TOKEN="$FLY_API_TOKEN" flyctl secrets set \
+    DATABASE_URL="$DATABASE_URL" \
+    JWT_SECRET="$JWT_SECRET" \
+    --app "$FLY_APP_NAME"
+fi
 
 echo "[bootstrap-secrets] Done. Verify with:"
 echo "  NETLIFY_AUTH_TOKEN=*** NETLIFY_SITE_ID=*** netlify env:list --context ${NETLIFY_CONTEXT}"

--- a/tests/ci/bootstrap-production-secrets.test.sh
+++ b/tests/ci/bootstrap-production-secrets.test.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+assert_contains() {
+  local description="$1"
+  local haystack="$2"
+  local needle="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    pass "$description"
+  else
+    fail "$description (expected '$needle')"
+  fi
+}
+
+assert_eq() {
+  local description="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    pass "$description"
+  else
+    fail "$description (expected='$expected' got='$actual')"
+  fi
+}
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/bootstrap-production-secrets.sh"
+
+TMP_DIR="$(mktemp -d)"
+cleanup() { rm -rf "$TMP_DIR"; }
+trap cleanup EXIT
+
+cat > "$TMP_DIR/netlify" <<'NETLIFY'
+#!/usr/bin/env bash
+echo "netlify $*"
+NETLIFY
+
+cat > "$TMP_DIR/flyctl" <<'FLY'
+#!/usr/bin/env bash
+echo "flyctl $*"
+FLY
+
+chmod +x "$TMP_DIR/netlify" "$TMP_DIR/flyctl"
+
+BASE_ENV=(
+  "PATH=$TMP_DIR:$PATH"
+  "NETLIFY_AUTH_TOKEN=test-netlify-token"
+  "NETLIFY_SITE_ID=test-site-id"
+  "FLY_API_TOKEN=test-fly-token"
+  "DATABASE_URL=postgresql://postgres:pw@localhost:5432/postgres?schema=public"
+  "NEXT_PUBLIC_API_URL=https://infamous.fly.dev"
+  "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_live_test"
+  "JWT_SECRET=abcdefghijklmnopqrstuvwxyz123456"
+)
+
+echo "=== bootstrap-production-secrets script checks ==="
+
+help_output="$(env "${BASE_ENV[@]}" "$SCRIPT" --help)"
+assert_contains "help output includes title" "$help_output" "Bootstrap production secrets for Netlify + Fly.io"
+
+set +e
+missing_output="$(env PATH="$TMP_DIR:$PATH" "$SCRIPT" 2>&1)"
+missing_code=$?
+set -e
+assert_eq "missing vars exits non-zero" "1" "$missing_code"
+assert_contains "missing vars prints specific var" "$missing_output" "Missing required env var"
+
+set +e
+invalid_url_output="$(env "${BASE_ENV[@]}" NEXT_PUBLIC_API_URL=http://insecure.example "$SCRIPT" 2>&1)"
+invalid_url_code=$?
+set -e
+assert_eq "http api url exits non-zero" "1" "$invalid_url_code"
+assert_contains "http api url has explicit message" "$invalid_url_output" "NEXT_PUBLIC_API_URL must be https:// in production"
+
+set +e
+dry_run_output="$(env "${BASE_ENV[@]}" DRY_RUN=1 "$SCRIPT" 2>&1)"
+dry_run_code=$?
+set -e
+assert_eq "dry run exits zero" "0" "$dry_run_code"
+assert_contains "dry run prints netlify command" "$dry_run_output" "netlify env:set NEXT_PUBLIC_API_URL production"
+assert_contains "dry run prints fly command" "$dry_run_output" "flyctl secrets set DATABASE_URL="
+
+if [ "$FAIL" -gt 0 ]; then
+  echo ""
+  echo "RESULT: FAIL ($FAIL failed, $PASS passed)"
+  exit 1
+fi
+
+echo ""
+echo "RESULT: PASS ($PASS checks passed)"


### PR DESCRIPTION
### Motivation

- Provide a single, idempotent script to bootstrap production secrets for Netlify and Fly.io and enforce basic validation before applying them. 
- Ensure the process is documented and automatically covered by CI so bootstrap mistakes are caught early.

### Description

- Add `scripts/bootstrap-production-secrets.sh`, a bash script that validates required env vars, enforces HTTPS and Stripe key formats, supports `DRY_RUN=1`, and applies secrets to Netlify and Fly.io. 
- Add `docs/ENV_SETUP_SECRETS_GUIDE.md` with a Production Secret Bootstrap checklist, usage examples, and verification commands. 
- Add `tests/ci/bootstrap-production-secrets.test.sh`, a test harness that mocks `netlify`/`flyctl` to verify help output, missing-var failures, URL validation, and dry-run behavior. 
- Update `.github/workflows/ci.yml` to include `scripts/**`, `tests/**`, and `docs/**` in path filters and to run the new bootstrap test as part of the `sanity` job.

### Testing

- Ran `bash tests/ci/bootstrap-production-secrets.test.sh` locally which executed the checks for help text, required-var failure, HTTP URL rejection, and dry-run output and it passed. 
- CI workflow updated to run `bash tests/ci/bootstrap-production-secrets.test.sh` in the `sanity` job so the test will run automatically on push and PRs affecting scripts, tests, or docs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5f299bf00833090354a84f541563b)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an idempotent script to bootstrap production secrets for Netlify and Fly.io with validation, dry-run, context/app overrides, and hardened Netlify applies. Includes docs, tests, and CI coverage; also stabilizes `apps/api` `vitest` execution and test discovery.

- **New Features**
  - `scripts/bootstrap-production-secrets.sh`: validates required env vars and formats (`https://` API URL, `pk_...`, `postgres(ql)://`, min `JWT_SECRET` length), checks `netlify`/`flyctl` are installed, supports `DRY_RUN=1`, `NETLIFY_CONTEXT`, and `FLY_APP_NAME`, and applies secrets to Netlify (explicit `NETLIFY_AUTH_TOKEN`/`NETLIFY_SITE_ID`) and Fly.io.
  - `docs/ENV_SETUP_SECRETS_GUIDE.md` expanded with a step-by-step production checklist, export examples, `DRY_RUN` usage, per-provider apply commands, verification, and a security note; `tests/ci/bootstrap-production-secrets.test.sh` added and wired in `.github/workflows/ci.yml` (includes `scripts/**`, `tests/**`, `docs/**` path filters).

- **Bug Fixes**
  - `apps/api/package.json`: `test` now builds `@infamous-freight/shared` before running `run-vitest.mjs`.
  - `apps/api/scripts/run-vitest.mjs`: ignores `--`, adds default patterns when no explicit file filter is provided (`*.test.*`, `*.spec.ts`, and `__tests__/**`), preserves `--runInBand`, and uses `--passWithNoTests` for consistent runs.

<sup>Written for commit de29c00d74004cd1b11a6602d8e26ab233484ba3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

