### PR TITLE
Refactor dashboard-page test to assert Sentry error call details and ordering

### DIFF
--- a/apps/web/tests/dashboard-page.test.tsx
+++ b/apps/web/tests/dashboard-page.test.tsx
@@ -49,17 +49,23 @@ describe("dashboard page", () => {
     render(<Dashboard />);
 
     await waitFor(() => {
-      expect(reportSentryErrorMock).toHaveBeenCalledWith(
-        expect.any(Error),
-        expect.objectContaining({
-          contexts: expect.objectContaining({
-            component: "dashboard",
-            action: "listLoads",
-          }),
-    const errorMessage = await screen.findByText("Failed to load dashboard data. Please try again.");
+      expect(reportSentryErrorMock).toHaveBeenCalledTimes(1);
+    });
 
+    const [reportedError, reportedContext] = reportSentryErrorMock.mock.calls[0];
+    expect(reportedError).toBeInstanceOf(Error);
+    expect(reportedError).toEqual(expect.objectContaining({
+      message: "firestore unavailable",
+    }));
+    expect(reportedContext).toEqual(expect.objectContaining({
+      contexts: expect.objectContaining({
+        component: "dashboard",
+        action: "listLoads",
+      }),
+    }));
+
+    const errorMessage = await screen.findByText("Failed to load dashboard data. Please try again.");
     expect(errorMessage).toBeInTheDocument();
-    expect(reportSentryErrorMock).toHaveBeenCalledTimes(1);
   });
 
   it("redirects unauthenticated users to login", async () => {


### PR DESCRIPTION
### Motivation

- Stabilize and make the dashboard error-handling test more explicit about the Sentry reporting behavior and timing.

### Description

- Updated `apps/web/tests/dashboard-page.test.tsx` to first assert `reportSentryErrorMock` call count with `toHaveBeenCalledTimes(1)` before inspecting arguments.
- Replaced the previous `toHaveBeenCalledWith` style assertion with explicit unpacking of `reportSentryErrorMock.mock.calls[0]` and checks that the reported error is an `Error` with message `"firestore unavailable"` and that the reported context contains `component: "dashboard"` and `action: "listLoads"`.
- Kept the assertion that the user-facing error message `"Failed to load dashboard data. Please try again."` is rendered in the DOM.

### Testing

- Ran unit tests with `vitest`, including `apps/web/tests/dashboard-page.test.tsx`, and the updated test passed.
- All related test suites completed successfully. }

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5fe6c588c83308d76521b0f5ae5e2)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the dashboard-page test to first confirm a single Sentry report, then explicitly verify the reported error and context for clearer, more stable assertions. Kept the user-facing error message check.

- **Refactors**
  - Wait for `reportSentryErrorMock` to be called once before reading args.
  - Unpack the first call and assert an `Error` with message "firestore unavailable" and context with `component: "dashboard"` and `action: "listLoads"`.
  - Keep the DOM assertion for "Failed to load dashboard data. Please try again."

<sup>Written for commit b670564a5e3bdd0cd028e850b85bf39681713a6c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

