### PR TITLE
fix(web): repair malformed dashboard-page test assertion

### DIFF
--- a/apps/web/tests/dashboard-page.test.tsx
+++ b/apps/web/tests/dashboard-page.test.tsx
@@ -56,6 +56,10 @@ describe("dashboard page", () => {
             component: "dashboard",
             action: "listLoads",
           }),
+        }),
+      );
+    });
+
     const errorMessage = await screen.findByText("Failed to load dashboard data. Please try again.");
 
     expect(errorMessage).toBeInTheDocument();

--- a/apps/web/tests/dashboard-page.test.tsx
+++ b/apps/web/tests/dashboard-page.test.tsx
@@ -63,6 +63,7 @@ describe("dashboard page", () => {
     const errorMessage = await screen.findByText("Failed to load dashboard data. Please try again.");
 
     expect(errorMessage).toBeInTheDocument();
+    expect(listLoadsMock).toHaveBeenCalledTimes(1);
     expect(reportSentryErrorMock).toHaveBeenCalledTimes(1);
   });
 
@@ -98,6 +99,7 @@ describe("dashboard page", () => {
       expect(pushMock).toHaveBeenCalledWith("/login");
     });
 
+    expect(listLoadsMock).toHaveBeenCalledTimes(1);
     expect(screen.queryByText(/DAL-HOU/)).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
### Motivation
- Fix a malformed `waitFor` expectation block in the dashboard page test that caused a lint parsing error and blocked test/lint runs for the `web` package.

### Description
- Restored the missing closing braces/parentheses and closed the `waitFor` callback in `apps/web/tests/dashboard-page.test.tsx` so the test file parses and assertions run correctly.

### Testing
- Ran `pnpm --filter web lint` which completed with only warnings and no errors; the lint step passed for the previously failing file.
- Ran `pnpm --filter web test -- --runInBand` which completed with the web test suite passing (8 passed, 22 skipped).
- Ran `pnpm run health:quick` which completed the repo typecheck and build steps without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d665b6bca4833093ae94190fd7faaa)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repaired the malformed waitFor block in `apps/web/tests/dashboard-page.test.tsx` and added explicit call-count assertions for `listLoads` in error and auth-redirect scenarios. This unblocks lint/test runs for the `web` package and tightens the dashboard tests to verify a single load attempt and proper error reporting.

<sup>Written for commit 11a9c3656708c0e6aa86ab405f86f6c8716bb172. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

