### PR TITLE
Fix Netlify `env:set` value/context usage in production bootstrap script

### DIFF
--- a/docs/ENV_SETUP_SECRETS_GUIDE.md
+++ b/docs/ENV_SETUP_SECRETS_GUIDE.md
@@ -43,9 +43,12 @@ DRY_RUN=1 ./scripts/bootstrap-production-secrets.sh
 ### 4) Apply to Netlify environment
 
 ```bash
-printf '%s' "$NEXT_PUBLIC_API_URL" | netlify env:set NEXT_PUBLIC_API_URL production
-printf '%s' "$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY" | netlify env:set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY production
-printf '%s' "$JWT_SECRET" | netlify env:set JWT_SECRET production
+env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" \
+  netlify env:set NEXT_PUBLIC_API_URL "$NEXT_PUBLIC_API_URL" --context production
+env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" \
+  netlify env:set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY "$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY" --context production
+env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" \
+  netlify env:set JWT_SECRET "$JWT_SECRET" --context production
 ```
 
 ### 5) Apply to Fly.io environment

--- a/scripts/bootstrap-production-secrets.sh
+++ b/scripts/bootstrap-production-secrets.sh
@@ -85,14 +85,6 @@ FLY_APP_NAME="${FLY_APP_NAME:-infamous-freight-api}"
 NETLIFY_CONTEXT="${NETLIFY_CONTEXT:-production}"
 DRY_RUN="${DRY_RUN:-0}"
 
-run_cmd() {
-  if [[ "$DRY_RUN" == "1" ]]; then
-    echo "[dry-run] $*"
-  else
-    "$@"
-  fi
-}
-
 echo "[bootstrap-secrets] Applying Netlify env vars to context '${NETLIFY_CONTEXT}' for site '${NETLIFY_SITE_ID}'."
 if [[ "$DRY_RUN" == "1" ]]; then
   echo "[dry-run] env NETLIFY_AUTH_TOKEN=*** NETLIFY_SITE_ID=*** netlify env:set NEXT_PUBLIC_API_URL \"\$NEXT_PUBLIC_API_URL\" --context ${NETLIFY_CONTEXT}"

--- a/scripts/bootstrap-production-secrets.sh
+++ b/scripts/bootstrap-production-secrets.sh
@@ -95,13 +95,16 @@ run_cmd() {
 
 echo "[bootstrap-secrets] Applying Netlify env vars to context '${NETLIFY_CONTEXT}' for site '${NETLIFY_SITE_ID}'."
 if [[ "$DRY_RUN" == "1" ]]; then
-  echo "[dry-run] printf '%s' \"\$NEXT_PUBLIC_API_URL\" | netlify env:set NEXT_PUBLIC_API_URL ${NETLIFY_CONTEXT}"
-  echo "[dry-run] printf '%s' \"\$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY\" | netlify env:set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ${NETLIFY_CONTEXT}"
-  echo "[dry-run] printf '%s' \"\$JWT_SECRET\" | netlify env:set JWT_SECRET ${NETLIFY_CONTEXT}"
+  echo "[dry-run] env NETLIFY_AUTH_TOKEN=*** NETLIFY_SITE_ID=*** netlify env:set NEXT_PUBLIC_API_URL \"\$NEXT_PUBLIC_API_URL\" --context ${NETLIFY_CONTEXT}"
+  echo "[dry-run] env NETLIFY_AUTH_TOKEN=*** NETLIFY_SITE_ID=*** netlify env:set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY \"\$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY\" --context ${NETLIFY_CONTEXT}"
+  echo "[dry-run] env NETLIFY_AUTH_TOKEN=*** NETLIFY_SITE_ID=*** netlify env:set JWT_SECRET \"\$JWT_SECRET\" --context ${NETLIFY_CONTEXT}"
 else
-  printf '%s' "$NEXT_PUBLIC_API_URL" | env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" netlify env:set NEXT_PUBLIC_API_URL "$NETLIFY_CONTEXT"
-  printf '%s' "$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY" | env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" netlify env:set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY "$NETLIFY_CONTEXT"
-  printf '%s' "$JWT_SECRET" | env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" netlify env:set JWT_SECRET "$NETLIFY_CONTEXT"
+  env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" \
+    netlify env:set NEXT_PUBLIC_API_URL "$NEXT_PUBLIC_API_URL" --context "$NETLIFY_CONTEXT"
+  env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" \
+    netlify env:set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY "$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY" --context "$NETLIFY_CONTEXT"
+  env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" \
+    netlify env:set JWT_SECRET "$JWT_SECRET" --context "$NETLIFY_CONTEXT"
 fi
 
 echo "[bootstrap-secrets] Applying Fly.io secrets to app '${FLY_APP_NAME}'."

--- a/tests/ci/bootstrap-production-secrets.test.sh
+++ b/tests/ci/bootstrap-production-secrets.test.sh
@@ -97,6 +97,7 @@ assert_eq "dry run exits zero" "0" "$dry_run_code"
 assert_contains "dry run prints netlify key/value/context command" "$dry_run_output" 'netlify env:set NEXT_PUBLIC_API_URL "$NEXT_PUBLIC_API_URL" --context production'
 assert_contains "dry run prints fly command" "$dry_run_output" "flyctl secrets set DATABASE_URL="
 assert_not_contains "dry run redacts database url value" "$dry_run_output" "postgresql://postgres:pw@localhost:5432/postgres?schema=public"
+assert_not_contains "dry run redacts database password segment" "$dry_run_output" "postgres:pw@"
 assert_not_contains "dry run redacts jwt secret value" "$dry_run_output" "abcdefghijklmnopqrstuvwxyz123456"
 assert_not_contains "dry run redacts fly token value" "$dry_run_output" "test-fly-token"
 

--- a/tests/ci/bootstrap-production-secrets.test.sh
+++ b/tests/ci/bootstrap-production-secrets.test.sh
@@ -100,6 +100,7 @@ assert_not_contains "dry run redacts database url value" "$dry_run_output" "post
 assert_not_contains "dry run redacts database password segment" "$dry_run_output" "postgres:pw@"
 assert_not_contains "dry run redacts jwt secret value" "$dry_run_output" "abcdefghijklmnopqrstuvwxyz123456"
 assert_not_contains "dry run redacts fly token value" "$dry_run_output" "test-fly-token"
+assert_not_contains "dry run redacts netlify token value" "$dry_run_output" "test-netlify-token"
 
 if [ "$FAIL" -gt 0 ]; then
   echo ""

--- a/tests/ci/bootstrap-production-secrets.test.sh
+++ b/tests/ci/bootstrap-production-secrets.test.sh
@@ -18,6 +18,17 @@ assert_contains() {
   fi
 }
 
+assert_not_contains() {
+  local description="$1"
+  local haystack="$2"
+  local needle="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    fail "$description (did not expect '$needle')"
+  else
+    pass "$description"
+  fi
+}
+
 assert_eq() {
   local description="$1"
   local expected="$2"
@@ -85,6 +96,9 @@ set -e
 assert_eq "dry run exits zero" "0" "$dry_run_code"
 assert_contains "dry run prints netlify key/value/context command" "$dry_run_output" 'netlify env:set NEXT_PUBLIC_API_URL "$NEXT_PUBLIC_API_URL" --context production'
 assert_contains "dry run prints fly command" "$dry_run_output" "flyctl secrets set DATABASE_URL="
+assert_not_contains "dry run redacts database url value" "$dry_run_output" "postgresql://postgres:pw@localhost:5432/postgres?schema=public"
+assert_not_contains "dry run redacts jwt secret value" "$dry_run_output" "abcdefghijklmnopqrstuvwxyz123456"
+assert_not_contains "dry run redacts fly token value" "$dry_run_output" "test-fly-token"
 
 if [ "$FAIL" -gt 0 ]; then
   echo ""

--- a/tests/ci/bootstrap-production-secrets.test.sh
+++ b/tests/ci/bootstrap-production-secrets.test.sh
@@ -83,7 +83,7 @@ dry_run_output="$(env "${BASE_ENV[@]}" DRY_RUN=1 "$SCRIPT" 2>&1)"
 dry_run_code=$?
 set -e
 assert_eq "dry run exits zero" "0" "$dry_run_code"
-assert_contains "dry run prints netlify command" "$dry_run_output" "netlify env:set NEXT_PUBLIC_API_URL production"
+assert_contains "dry run prints netlify key/value/context command" "$dry_run_output" 'netlify env:set NEXT_PUBLIC_API_URL "$NEXT_PUBLIC_API_URL" --context production'
 assert_contains "dry run prints fly command" "$dry_run_output" "flyctl secrets set DATABASE_URL="
 
 if [ "$FAIL" -gt 0 ]; then


### PR DESCRIPTION
### Motivation

- Correct a high-priority bug where `netlify env:set` was invoked by piping secret values to stdin while passing the Netlify context positionally, which could cause the context (e.g. `production`) to be interpreted as the secret value. 
- Make dry-run output faithful to the actual commands so operators can safely review what will be applied before running the script.

### Description

- Update `scripts/bootstrap-production-secrets.sh` to call Netlify with the supported form `netlify env:set <KEY> <VALUE> --context <context>` and provide auth/site values via `env NETLIFY_AUTH_TOKEN=... NETLIFY_SITE_ID=...` instead of piping secrets to stdin. 
- Change dry-run messages in `scripts/bootstrap-production-secrets.sh` to show the exact `env ... netlify env:set KEY "$VALUE" --context <context>` command that will be executed. 
- Update `tests/ci/bootstrap-production-secrets.test.sh` to assert the corrected dry-run Netlify command format. 
- Retain Fly.io secret application behavior and existing validation logic.

### Testing

- Ran `bash tests/ci/bootstrap-production-secrets.test.sh`, which completed successfully with all checks passing (result: PASS). 
- The change is covered by the existing CI test harness that runs the bootstrap test as part of the `sanity` job for changes to `scripts/**` and `tests/**`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6a67d39548330b176f73da6705fbc)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where `netlify env:set` in the production bootstrap could treat the context as the value. The script now calls `netlify env:set <KEY> <VALUE> --context <context>` with `NETLIFY_AUTH_TOKEN`/`NETLIFY_SITE_ID` via env vars; dry-run shows the exact command with secrets redacted (DB URL/password segment, JWT secret, Fly and Netlify tokens), tests assert the format, and the docs show the correct syntax.

<sup>Written for commit 10b2d0e66841fba45f8c561a1557f9a1688a6275. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

