### PR TITLE
Add server-side Stripe keys and webhook secret to bootstrap script and docs

### DIFF
--- a/docs/ENV_SETUP_SECRETS_GUIDE.md
+++ b/docs/ENV_SETUP_SECRETS_GUIDE.md
@@ -14,6 +14,8 @@ Use this checklist when wiring production credentials for the current deployment
 | `DATABASE_URL` | API + Prisma | required | Use the managed Postgres connection string with a real password. |
 | `NEXT_PUBLIC_API_URL` | Web frontend | required | Public API origin (for example `https://infamous.fly.dev`). |
 | `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | Stripe checkout UI | required | Must be the publishable key (`pk_...`), never a secret key. |
+| `STRIPE_SECRET_KEY` | Stripe server API | required | Secret key used by server-side checkout/webhook handlers (`sk_live_...`). |
+| `STRIPE_WEBHOOK_SECRET` | Stripe webhook verification | required | Signing secret for Stripe webhook validation (`whsec_...`). |
 | `JWT_SECRET` | API auth signing (HS256 mode + web stripe route) | required | Generate with `openssl rand -base64 32`. |
 
 ### 2) Export locally (do not commit secrets)
@@ -25,6 +27,8 @@ export FLY_API_TOKEN="$(flyctl auth token)"
 export DATABASE_URL="postgresql://postgres:<password>@<host>:5432/postgres?schema=public"
 export NEXT_PUBLIC_API_URL="https://infamous.fly.dev"
 export NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY="pk_live_..."
+export STRIPE_SECRET_KEY="sk_live_..."
+export STRIPE_WEBHOOK_SECRET="whsec_..."
 export JWT_SECRET="$(openssl rand -base64 32)"
 ```
 
@@ -43,9 +47,16 @@ DRY_RUN=1 ./scripts/bootstrap-production-secrets.sh
 ### 4) Apply to Netlify environment
 
 ```bash
-printf '%s' "$NEXT_PUBLIC_API_URL" | netlify env:set NEXT_PUBLIC_API_URL production
-printf '%s' "$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY" | netlify env:set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY production
-printf '%s' "$JWT_SECRET" | netlify env:set JWT_SECRET production
+env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" \
+  netlify env:set NEXT_PUBLIC_API_URL "$NEXT_PUBLIC_API_URL" --context production
+env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" \
+  netlify env:set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY "$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY" --context production
+env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" \
+  netlify env:set STRIPE_SECRET_KEY "$STRIPE_SECRET_KEY" --context production
+env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" \
+  netlify env:set STRIPE_WEBHOOK_SECRET "$STRIPE_WEBHOOK_SECRET" --context production
+env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" \
+  netlify env:set JWT_SECRET "$JWT_SECRET" --context production
 ```
 
 ### 5) Apply to Fly.io environment
@@ -54,6 +65,8 @@ printf '%s' "$JWT_SECRET" | netlify env:set JWT_SECRET production
 flyctl secrets set \
   DATABASE_URL="$DATABASE_URL" \
   JWT_SECRET="$JWT_SECRET" \
+  STRIPE_SECRET_KEY="$STRIPE_SECRET_KEY" \
+  STRIPE_WEBHOOK_SECRET="$STRIPE_WEBHOOK_SECRET" \
   --app infamous-freight-api
 ```
 

--- a/docs/ENV_SETUP_SECRETS_GUIDE.md
+++ b/docs/ENV_SETUP_SECRETS_GUIDE.md
@@ -47,16 +47,16 @@ DRY_RUN=1 ./scripts/bootstrap-production-secrets.sh
 ### 4) Apply to Netlify environment
 
 ```bash
-env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" \
-  netlify env:set NEXT_PUBLIC_API_URL "$NEXT_PUBLIC_API_URL" --context production
-env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" \
-  netlify env:set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY "$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY" --context production
-env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" \
-  netlify env:set STRIPE_SECRET_KEY "$STRIPE_SECRET_KEY" --context production
-env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" \
-  netlify env:set STRIPE_WEBHOOK_SECRET "$STRIPE_WEBHOOK_SECRET" --context production
-env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" \
-  netlify env:set JWT_SECRET "$JWT_SECRET" --context production
+env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
+  netlify env:set NEXT_PUBLIC_API_URL "$NEXT_PUBLIC_API_URL" --context production --site "$NETLIFY_SITE_ID"
+env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
+  netlify env:set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY "$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY" --context production --site "$NETLIFY_SITE_ID"
+env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
+  netlify env:set STRIPE_SECRET_KEY "$STRIPE_SECRET_KEY" --context production --site "$NETLIFY_SITE_ID"
+env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
+  netlify env:set STRIPE_WEBHOOK_SECRET "$STRIPE_WEBHOOK_SECRET" --context production --site "$NETLIFY_SITE_ID"
+env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
+  netlify env:set JWT_SECRET "$JWT_SECRET" --context production --site "$NETLIFY_SITE_ID"
 ```
 
 ### 5) Apply to Fly.io environment
@@ -73,7 +73,7 @@ flyctl secrets set \
 ### 6) Post-setup verification
 
 ```bash
-netlify env:list --context production
+netlify env:list --context production --site "$NETLIFY_SITE_ID"
 flyctl secrets list --app infamous-freight-api
 ```
 

--- a/scripts/bootstrap-production-secrets.sh
+++ b/scripts/bootstrap-production-secrets.sh
@@ -91,7 +91,7 @@ if [[ ! "${STRIPE_SECRET_KEY}" =~ ^sk_(live|test)_[[:alnum:]]+$ ]]; then
   exit 1
 fi
 
-if [[ ! "${STRIPE_WEBHOOK_SECRET}" =~ ^whsec_ ]]; then
+if [[ ! "${STRIPE_WEBHOOK_SECRET}" =~ ^whsec_[^[:space:]]+$ ]]; then
   echo "[bootstrap-secrets] STRIPE_WEBHOOK_SECRET must be a Stripe webhook signing secret" >&2
   exit 1
 fi

--- a/scripts/bootstrap-production-secrets.sh
+++ b/scripts/bootstrap-production-secrets.sh
@@ -66,6 +66,11 @@ for var_name in "${required_vars[@]}"; do
   require_var "$var_name"
 done
 
+if [[ ! "${NETLIFY_SITE_ID}" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ ]]; then
+  echo "[bootstrap-secrets] NETLIFY_SITE_ID must be a UUID" >&2
+  exit 1
+fi
+
 if [[ ! "${DATABASE_URL}" =~ ^postgres(ql)?:// ]]; then
   echo "[bootstrap-secrets] DATABASE_URL must start with postgres:// or postgresql://" >&2
   exit 1

--- a/scripts/bootstrap-production-secrets.sh
+++ b/scripts/bootstrap-production-secrets.sh
@@ -86,7 +86,7 @@ if [[ ! "${NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY}" =~ ^pk_(live|test)_ ]]; then
   exit 1
 fi
 
-if [[ ! "${STRIPE_SECRET_KEY}" =~ ^sk_(live|test)_ ]]; then
+if [[ ! "${STRIPE_SECRET_KEY}" =~ ^sk_(live|test)_[[:alnum:]]+$ ]]; then
   echo "[bootstrap-secrets] STRIPE_SECRET_KEY must be a Stripe secret key" >&2
   exit 1
 fi

--- a/scripts/bootstrap-production-secrets.sh
+++ b/scripts/bootstrap-production-secrets.sh
@@ -12,6 +12,8 @@ Required environment variables:
   DATABASE_URL
   NEXT_PUBLIC_API_URL
   NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
+  STRIPE_SECRET_KEY
+  STRIPE_WEBHOOK_SECRET
   JWT_SECRET
 
 Optional environment variables:
@@ -22,7 +24,8 @@ Optional environment variables:
 Example:
   NETLIFY_AUTH_TOKEN=... NETLIFY_SITE_ID=... FLY_API_TOKEN=... \
   DATABASE_URL=... NEXT_PUBLIC_API_URL=https://infamous.fly.dev \
-  NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_live_... JWT_SECRET=$(openssl rand -base64 32) \
+  NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_live_... STRIPE_SECRET_KEY=sk_live_... \
+  STRIPE_WEBHOOK_SECRET=whsec_... JWT_SECRET=$(openssl rand -base64 32) \
   ./scripts/bootstrap-production-secrets.sh
 USAGE
 }
@@ -54,6 +57,8 @@ required_vars=(
   DATABASE_URL
   NEXT_PUBLIC_API_URL
   NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
+  STRIPE_SECRET_KEY
+  STRIPE_WEBHOOK_SECRET
   JWT_SECRET
 )
 
@@ -76,6 +81,16 @@ if [[ ! "${NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY}" =~ ^pk_(live|test)_ ]]; then
   exit 1
 fi
 
+if [[ ! "${STRIPE_SECRET_KEY}" =~ ^sk_(live|test)_ ]]; then
+  echo "[bootstrap-secrets] STRIPE_SECRET_KEY must be a Stripe secret key" >&2
+  exit 1
+fi
+
+if [[ ! "${STRIPE_WEBHOOK_SECRET}" =~ ^whsec_ ]]; then
+  echo "[bootstrap-secrets] STRIPE_WEBHOOK_SECRET must be a Stripe webhook signing secret" >&2
+  exit 1
+fi
+
 if [[ ${#JWT_SECRET} -lt 32 ]]; then
   echo "[bootstrap-secrets] JWT_SECRET must be at least 32 characters" >&2
   exit 1
@@ -85,32 +100,35 @@ FLY_APP_NAME="${FLY_APP_NAME:-infamous-freight-api}"
 NETLIFY_CONTEXT="${NETLIFY_CONTEXT:-production}"
 DRY_RUN="${DRY_RUN:-0}"
 
-run_cmd() {
-  if [[ "$DRY_RUN" == "1" ]]; then
-    echo "[dry-run] $*"
-  else
-    "$@"
-  fi
-}
-
 echo "[bootstrap-secrets] Applying Netlify env vars to context '${NETLIFY_CONTEXT}' for site '${NETLIFY_SITE_ID}'."
 if [[ "$DRY_RUN" == "1" ]]; then
-  echo "[dry-run] printf '%s' \"\$NEXT_PUBLIC_API_URL\" | netlify env:set NEXT_PUBLIC_API_URL ${NETLIFY_CONTEXT}"
-  echo "[dry-run] printf '%s' \"\$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY\" | netlify env:set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ${NETLIFY_CONTEXT}"
-  echo "[dry-run] printf '%s' \"\$JWT_SECRET\" | netlify env:set JWT_SECRET ${NETLIFY_CONTEXT}"
+  echo "[dry-run] env NETLIFY_AUTH_TOKEN=*** NETLIFY_SITE_ID=*** netlify env:set NEXT_PUBLIC_API_URL \"\$NEXT_PUBLIC_API_URL\" --context ${NETLIFY_CONTEXT}"
+  echo "[dry-run] env NETLIFY_AUTH_TOKEN=*** NETLIFY_SITE_ID=*** netlify env:set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY \"\$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY\" --context ${NETLIFY_CONTEXT}"
+  echo "[dry-run] env NETLIFY_AUTH_TOKEN=*** NETLIFY_SITE_ID=*** netlify env:set STRIPE_SECRET_KEY \"\$STRIPE_SECRET_KEY\" --context ${NETLIFY_CONTEXT}"
+  echo "[dry-run] env NETLIFY_AUTH_TOKEN=*** NETLIFY_SITE_ID=*** netlify env:set STRIPE_WEBHOOK_SECRET \"\$STRIPE_WEBHOOK_SECRET\" --context ${NETLIFY_CONTEXT}"
+  echo "[dry-run] env NETLIFY_AUTH_TOKEN=*** NETLIFY_SITE_ID=*** netlify env:set JWT_SECRET \"\$JWT_SECRET\" --context ${NETLIFY_CONTEXT}"
 else
-  printf '%s' "$NEXT_PUBLIC_API_URL" | env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" netlify env:set NEXT_PUBLIC_API_URL "$NETLIFY_CONTEXT"
-  printf '%s' "$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY" | env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" netlify env:set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY "$NETLIFY_CONTEXT"
-  printf '%s' "$JWT_SECRET" | env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" netlify env:set JWT_SECRET "$NETLIFY_CONTEXT"
+  env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" \
+    netlify env:set NEXT_PUBLIC_API_URL "$NEXT_PUBLIC_API_URL" --context "$NETLIFY_CONTEXT"
+  env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" \
+    netlify env:set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY "$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY" --context "$NETLIFY_CONTEXT"
+  env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" \
+    netlify env:set STRIPE_SECRET_KEY "$STRIPE_SECRET_KEY" --context "$NETLIFY_CONTEXT"
+  env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" \
+    netlify env:set STRIPE_WEBHOOK_SECRET "$STRIPE_WEBHOOK_SECRET" --context "$NETLIFY_CONTEXT"
+  env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" \
+    netlify env:set JWT_SECRET "$JWT_SECRET" --context "$NETLIFY_CONTEXT"
 fi
 
 echo "[bootstrap-secrets] Applying Fly.io secrets to app '${FLY_APP_NAME}'."
 if [[ "$DRY_RUN" == "1" ]]; then
-  echo "[dry-run] env FLY_API_TOKEN=*** flyctl secrets set DATABASE_URL=\"\$DATABASE_URL\" JWT_SECRET=\"\$JWT_SECRET\" --app ${FLY_APP_NAME}"
+  echo "[dry-run] env FLY_API_TOKEN=*** flyctl secrets set DATABASE_URL=\"\$DATABASE_URL\" JWT_SECRET=\"\$JWT_SECRET\" STRIPE_SECRET_KEY=\"\$STRIPE_SECRET_KEY\" STRIPE_WEBHOOK_SECRET=\"\$STRIPE_WEBHOOK_SECRET\" --app ${FLY_APP_NAME}"
 else
   env FLY_API_TOKEN="$FLY_API_TOKEN" flyctl secrets set \
     DATABASE_URL="$DATABASE_URL" \
     JWT_SECRET="$JWT_SECRET" \
+    STRIPE_SECRET_KEY="$STRIPE_SECRET_KEY" \
+    STRIPE_WEBHOOK_SECRET="$STRIPE_WEBHOOK_SECRET" \
     --app "$FLY_APP_NAME"
 fi
 

--- a/scripts/bootstrap-production-secrets.sh
+++ b/scripts/bootstrap-production-secrets.sh
@@ -100,24 +100,24 @@ FLY_APP_NAME="${FLY_APP_NAME:-infamous-freight-api}"
 NETLIFY_CONTEXT="${NETLIFY_CONTEXT:-production}"
 DRY_RUN="${DRY_RUN:-0}"
 
-echo "[bootstrap-secrets] Applying Netlify env vars to context '${NETLIFY_CONTEXT}' for site '${NETLIFY_SITE_ID}'."
+echo "[bootstrap-secrets] Applying Netlify env vars to context '${NETLIFY_CONTEXT}' for site '***'."
 if [[ "$DRY_RUN" == "1" ]]; then
-  echo "[dry-run] env NETLIFY_AUTH_TOKEN=*** NETLIFY_SITE_ID=*** netlify env:set NEXT_PUBLIC_API_URL \"\$NEXT_PUBLIC_API_URL\" --context ${NETLIFY_CONTEXT}"
-  echo "[dry-run] env NETLIFY_AUTH_TOKEN=*** NETLIFY_SITE_ID=*** netlify env:set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY \"\$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY\" --context ${NETLIFY_CONTEXT}"
-  echo "[dry-run] env NETLIFY_AUTH_TOKEN=*** NETLIFY_SITE_ID=*** netlify env:set STRIPE_SECRET_KEY \"\$STRIPE_SECRET_KEY\" --context ${NETLIFY_CONTEXT}"
-  echo "[dry-run] env NETLIFY_AUTH_TOKEN=*** NETLIFY_SITE_ID=*** netlify env:set STRIPE_WEBHOOK_SECRET \"\$STRIPE_WEBHOOK_SECRET\" --context ${NETLIFY_CONTEXT}"
-  echo "[dry-run] env NETLIFY_AUTH_TOKEN=*** NETLIFY_SITE_ID=*** netlify env:set JWT_SECRET \"\$JWT_SECRET\" --context ${NETLIFY_CONTEXT}"
+  echo "[dry-run] env NETLIFY_AUTH_TOKEN=*** netlify env:set NEXT_PUBLIC_API_URL \"\$NEXT_PUBLIC_API_URL\" --context ${NETLIFY_CONTEXT} --site ***"
+  echo "[dry-run] env NETLIFY_AUTH_TOKEN=*** netlify env:set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY \"\$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY\" --context ${NETLIFY_CONTEXT} --site ***"
+  echo "[dry-run] env NETLIFY_AUTH_TOKEN=*** netlify env:set STRIPE_SECRET_KEY \"\$STRIPE_SECRET_KEY\" --context ${NETLIFY_CONTEXT} --site ***"
+  echo "[dry-run] env NETLIFY_AUTH_TOKEN=*** netlify env:set STRIPE_WEBHOOK_SECRET \"\$STRIPE_WEBHOOK_SECRET\" --context ${NETLIFY_CONTEXT} --site ***"
+  echo "[dry-run] env NETLIFY_AUTH_TOKEN=*** netlify env:set JWT_SECRET \"\$JWT_SECRET\" --context ${NETLIFY_CONTEXT} --site ***"
 else
-  env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" \
-    netlify env:set NEXT_PUBLIC_API_URL "$NEXT_PUBLIC_API_URL" --context "$NETLIFY_CONTEXT"
-  env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" \
-    netlify env:set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY "$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY" --context "$NETLIFY_CONTEXT"
-  env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" \
-    netlify env:set STRIPE_SECRET_KEY "$STRIPE_SECRET_KEY" --context "$NETLIFY_CONTEXT"
-  env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" \
-    netlify env:set STRIPE_WEBHOOK_SECRET "$STRIPE_WEBHOOK_SECRET" --context "$NETLIFY_CONTEXT"
-  env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" \
-    netlify env:set JWT_SECRET "$JWT_SECRET" --context "$NETLIFY_CONTEXT"
+  env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
+    netlify env:set NEXT_PUBLIC_API_URL "$NEXT_PUBLIC_API_URL" --context "$NETLIFY_CONTEXT" --site "$NETLIFY_SITE_ID"
+  env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
+    netlify env:set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY "$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY" --context "$NETLIFY_CONTEXT" --site "$NETLIFY_SITE_ID"
+  env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
+    netlify env:set STRIPE_SECRET_KEY "$STRIPE_SECRET_KEY" --context "$NETLIFY_CONTEXT" --site "$NETLIFY_SITE_ID"
+  env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
+    netlify env:set STRIPE_WEBHOOK_SECRET "$STRIPE_WEBHOOK_SECRET" --context "$NETLIFY_CONTEXT" --site "$NETLIFY_SITE_ID"
+  env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
+    netlify env:set JWT_SECRET "$JWT_SECRET" --context "$NETLIFY_CONTEXT" --site "$NETLIFY_SITE_ID"
 fi
 
 echo "[bootstrap-secrets] Applying Fly.io secrets to app '${FLY_APP_NAME}'."
@@ -133,5 +133,5 @@ else
 fi
 
 echo "[bootstrap-secrets] Done. Verify with:"
-echo "  NETLIFY_AUTH_TOKEN=*** NETLIFY_SITE_ID=*** netlify env:list --context ${NETLIFY_CONTEXT}"
+echo "  NETLIFY_AUTH_TOKEN=*** netlify env:list --context ${NETLIFY_CONTEXT} --site ***"
 echo "  FLY_API_TOKEN=*** flyctl secrets list --app ${FLY_APP_NAME}"

--- a/tests/ci/bootstrap-production-secrets.test.sh
+++ b/tests/ci/bootstrap-production-secrets.test.sh
@@ -62,7 +62,7 @@ chmod +x "$TMP_DIR/netlify" "$TMP_DIR/flyctl"
 BASE_ENV=(
   "PATH=$TMP_DIR:$PATH"
   "NETLIFY_AUTH_TOKEN=test-netlify-token"
-  "NETLIFY_SITE_ID=test-site-id"
+  "NETLIFY_SITE_ID=11111111-2222-3333-4444-555555555555"
   "FLY_API_TOKEN=test-fly-token"
   "DATABASE_URL=postgresql://postgres:pw@localhost:5432/postgres?schema=public"
   "NEXT_PUBLIC_API_URL=https://infamous.fly.dev"
@@ -92,6 +92,13 @@ assert_eq "http api url exits non-zero" "1" "$invalid_url_code"
 assert_contains "http api url has explicit message" "$invalid_url_output" "NEXT_PUBLIC_API_URL must be https:// in production"
 
 set +e
+invalid_site_id_output="$(env "${BASE_ENV[@]}" NETLIFY_SITE_ID=not-a-uuid "$SCRIPT" 2>&1)"
+invalid_site_id_code=$?
+set -e
+assert_eq "invalid netlify site id exits non-zero" "1" "$invalid_site_id_code"
+assert_contains "invalid netlify site id has explicit message" "$invalid_site_id_output" "NETLIFY_SITE_ID must be a UUID"
+
+set +e
 invalid_stripe_secret_output="$(env "${BASE_ENV[@]}" STRIPE_SECRET_KEY=pk_live_wrong "$SCRIPT" 2>&1)"
 invalid_stripe_secret_code=$?
 set -e
@@ -119,7 +126,7 @@ assert_not_contains "dry run redacts database password segment" "$dry_run_output
 assert_not_contains "dry run redacts jwt secret value" "$dry_run_output" "abcdefghijklmnopqrstuvwxyz123456"
 assert_not_contains "dry run redacts fly token value" "$dry_run_output" "test-fly-token"
 assert_not_contains "dry run redacts netlify token value" "$dry_run_output" "test-netlify-token"
-assert_not_contains "dry run redacts netlify site id value" "$dry_run_output" "test-site-id"
+assert_not_contains "dry run redacts netlify site id value" "$dry_run_output" "11111111-2222-3333-4444-555555555555"
 assert_not_contains "dry run redacts stripe secret key value" "$dry_run_output" "sk_live_test"
 assert_not_contains "dry run redacts stripe webhook secret value" "$dry_run_output" "whsec_test"
 
@@ -128,7 +135,7 @@ apply_output="$(env "${BASE_ENV[@]}" "$SCRIPT" 2>&1)"
 apply_code=$?
 set -e
 assert_eq "apply mode exits zero" "0" "$apply_code"
-assert_contains "apply mode netlify command includes explicit site flag" "$apply_output" "netlify env:set NEXT_PUBLIC_API_URL https://infamous.fly.dev --context production --site test-site-id"
+assert_contains "apply mode netlify command includes explicit site flag" "$apply_output" "netlify env:set NEXT_PUBLIC_API_URL https://infamous.fly.dev --context production --site 11111111-2222-3333-4444-555555555555"
 assert_contains "apply mode netlify includes stripe webhook secret key name" "$apply_output" "netlify env:set STRIPE_WEBHOOK_SECRET"
 assert_contains "apply mode fly command includes stripe server secret key name" "$apply_output" "flyctl secrets set DATABASE_URL=postgresql://postgres:pw@localhost:5432/postgres?schema=public JWT_SECRET=abcdefghijklmnopqrstuvwxyz123456 STRIPE_SECRET_KEY=sk_live_test STRIPE_WEBHOOK_SECRET=whsec_test --app infamous-freight-api"
 

--- a/tests/ci/bootstrap-production-secrets.test.sh
+++ b/tests/ci/bootstrap-production-secrets.test.sh
@@ -123,6 +123,15 @@ assert_not_contains "dry run redacts netlify site id value" "$dry_run_output" "t
 assert_not_contains "dry run redacts stripe secret key value" "$dry_run_output" "sk_live_test"
 assert_not_contains "dry run redacts stripe webhook secret value" "$dry_run_output" "whsec_test"
 
+set +e
+apply_output="$(env "${BASE_ENV[@]}" "$SCRIPT" 2>&1)"
+apply_code=$?
+set -e
+assert_eq "apply mode exits zero" "0" "$apply_code"
+assert_contains "apply mode netlify command includes explicit site flag" "$apply_output" "netlify env:set NEXT_PUBLIC_API_URL https://infamous.fly.dev --context production --site test-site-id"
+assert_contains "apply mode netlify includes stripe webhook secret key name" "$apply_output" "netlify env:set STRIPE_WEBHOOK_SECRET"
+assert_contains "apply mode fly command includes stripe server secret key name" "$apply_output" "flyctl secrets set DATABASE_URL=postgresql://postgres:pw@localhost:5432/postgres?schema=public JWT_SECRET=abcdefghijklmnopqrstuvwxyz123456 STRIPE_SECRET_KEY=sk_live_test STRIPE_WEBHOOK_SECRET=whsec_test --app infamous-freight-api"
+
 if [ "$FAIL" -gt 0 ]; then
   echo ""
   echo "RESULT: FAIL ($FAIL failed, $PASS passed)"

--- a/tests/ci/bootstrap-production-secrets.test.sh
+++ b/tests/ci/bootstrap-production-secrets.test.sh
@@ -110,7 +110,7 @@ dry_run_output="$(env "${BASE_ENV[@]}" DRY_RUN=1 "$SCRIPT" 2>&1)"
 dry_run_code=$?
 set -e
 assert_eq "dry run exits zero" "0" "$dry_run_code"
-assert_contains "dry run prints netlify key/value/context command" "$dry_run_output" 'netlify env:set NEXT_PUBLIC_API_URL "$NEXT_PUBLIC_API_URL" --context production'
+assert_contains "dry run prints netlify key/value/context command" "$dry_run_output" 'netlify env:set NEXT_PUBLIC_API_URL "$NEXT_PUBLIC_API_URL" --context production --site ***'
 assert_contains "dry run prints fly command" "$dry_run_output" "flyctl secrets set DATABASE_URL="
 assert_contains "dry run includes stripe server key placeholder" "$dry_run_output" 'STRIPE_SECRET_KEY="$STRIPE_SECRET_KEY"'
 assert_contains "dry run includes stripe webhook placeholder" "$dry_run_output" 'STRIPE_WEBHOOK_SECRET="$STRIPE_WEBHOOK_SECRET"'
@@ -119,6 +119,7 @@ assert_not_contains "dry run redacts database password segment" "$dry_run_output
 assert_not_contains "dry run redacts jwt secret value" "$dry_run_output" "abcdefghijklmnopqrstuvwxyz123456"
 assert_not_contains "dry run redacts fly token value" "$dry_run_output" "test-fly-token"
 assert_not_contains "dry run redacts netlify token value" "$dry_run_output" "test-netlify-token"
+assert_not_contains "dry run redacts netlify site id value" "$dry_run_output" "test-site-id"
 assert_not_contains "dry run redacts stripe secret key value" "$dry_run_output" "sk_live_test"
 assert_not_contains "dry run redacts stripe webhook secret value" "$dry_run_output" "whsec_test"
 

--- a/tests/ci/bootstrap-production-secrets.test.sh
+++ b/tests/ci/bootstrap-production-secrets.test.sh
@@ -18,6 +18,17 @@ assert_contains() {
   fi
 }
 
+assert_not_contains() {
+  local description="$1"
+  local haystack="$2"
+  local needle="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    fail "$description (did not expect '$needle')"
+  else
+    pass "$description"
+  fi
+}
+
 assert_eq() {
   local description="$1"
   local expected="$2"
@@ -56,6 +67,8 @@ BASE_ENV=(
   "DATABASE_URL=postgresql://postgres:pw@localhost:5432/postgres?schema=public"
   "NEXT_PUBLIC_API_URL=https://infamous.fly.dev"
   "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_live_test"
+  "STRIPE_SECRET_KEY=sk_live_test"
+  "STRIPE_WEBHOOK_SECRET=whsec_test"
   "JWT_SECRET=abcdefghijklmnopqrstuvwxyz123456"
 )
 
@@ -79,12 +92,35 @@ assert_eq "http api url exits non-zero" "1" "$invalid_url_code"
 assert_contains "http api url has explicit message" "$invalid_url_output" "NEXT_PUBLIC_API_URL must be https:// in production"
 
 set +e
+invalid_stripe_secret_output="$(env "${BASE_ENV[@]}" STRIPE_SECRET_KEY=pk_live_wrong "$SCRIPT" 2>&1)"
+invalid_stripe_secret_code=$?
+set -e
+assert_eq "invalid stripe secret exits non-zero" "1" "$invalid_stripe_secret_code"
+assert_contains "invalid stripe secret has explicit message" "$invalid_stripe_secret_output" "STRIPE_SECRET_KEY must be a Stripe secret key"
+
+set +e
+invalid_webhook_secret_output="$(env "${BASE_ENV[@]}" STRIPE_WEBHOOK_SECRET=secret_wrong "$SCRIPT" 2>&1)"
+invalid_webhook_secret_code=$?
+set -e
+assert_eq "invalid webhook secret exits non-zero" "1" "$invalid_webhook_secret_code"
+assert_contains "invalid webhook secret has explicit message" "$invalid_webhook_secret_output" "STRIPE_WEBHOOK_SECRET must be a Stripe webhook signing secret"
+
+set +e
 dry_run_output="$(env "${BASE_ENV[@]}" DRY_RUN=1 "$SCRIPT" 2>&1)"
 dry_run_code=$?
 set -e
 assert_eq "dry run exits zero" "0" "$dry_run_code"
-assert_contains "dry run prints netlify command" "$dry_run_output" "netlify env:set NEXT_PUBLIC_API_URL production"
+assert_contains "dry run prints netlify key/value/context command" "$dry_run_output" 'netlify env:set NEXT_PUBLIC_API_URL "$NEXT_PUBLIC_API_URL" --context production'
 assert_contains "dry run prints fly command" "$dry_run_output" "flyctl secrets set DATABASE_URL="
+assert_contains "dry run includes stripe server key placeholder" "$dry_run_output" 'STRIPE_SECRET_KEY="$STRIPE_SECRET_KEY"'
+assert_contains "dry run includes stripe webhook placeholder" "$dry_run_output" 'STRIPE_WEBHOOK_SECRET="$STRIPE_WEBHOOK_SECRET"'
+assert_not_contains "dry run redacts database url value" "$dry_run_output" "postgresql://postgres:pw@localhost:5432/postgres?schema=public"
+assert_not_contains "dry run redacts database password segment" "$dry_run_output" "postgres:pw@"
+assert_not_contains "dry run redacts jwt secret value" "$dry_run_output" "abcdefghijklmnopqrstuvwxyz123456"
+assert_not_contains "dry run redacts fly token value" "$dry_run_output" "test-fly-token"
+assert_not_contains "dry run redacts netlify token value" "$dry_run_output" "test-netlify-token"
+assert_not_contains "dry run redacts stripe secret key value" "$dry_run_output" "sk_live_test"
+assert_not_contains "dry run redacts stripe webhook secret value" "$dry_run_output" "whsec_test"
 
 if [ "$FAIL" -gt 0 ]; then
   echo ""


### PR DESCRIPTION
### Motivation

- Add server-side Stripe credentials (secret key and webhook signing secret) to the production bootstrap so the API can perform server-side checkout and verify webhook events.

### Description

- Update `docs/ENV_SETUP_SECRETS_GUIDE.md` to document `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET`, include them in example exports, and show Netlify env commands with `--context`.
- Extend `scripts/bootstrap-production-secrets.sh` to require `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET`, validate their formats with regex checks, include them when applying Netlify env vars and Fly.io secrets, and improve dry-run output to redact tokens.
- Update test script `tests/ci/bootstrap-production-secrets.test.sh` to provide the new env vars in `BASE_ENV`, add `assert_not_contains` helper, and add assertions for invalid secrets as well as dry-run redaction checks for the new values.

### Testing

- Ran the automated test script `tests/ci/bootstrap-production-secrets.test.sh`, which exercises help output, missing-var handling, invalid URL handling, invalid Stripe secret/webhook handling, and dry-run redaction checks; the test suite completed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6a67d39548330b176f73da6705fbc)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds server-side Stripe credentials to the production bootstrap and docs so the API can run checkout and verify webhooks. Tightens validation (including `NETLIFY_SITE_ID` as a UUID), switches Netlify commands to pass values directly with `--site`, adds redaction in dry-run, and expands CI to cover apply-mode.

- New Features
  - Documented `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET`, added example exports, Fly.io secret entries, and Netlify commands using `--context` and `--site` (value args, no pipes); `env:list` now includes `--site`.
  - Bootstrap script now requires and validates both keys (`sk_*`, `whsec_*`) and enforces `NETLIFY_SITE_ID` is a UUID; applies to Netlify (`--context` + `--site`) and Fly.io.
  - Dry-run output redacts tokens, secret values, and site id; apply mode uses the real site id. CI tests cover invalid key formats, UUID validation, `--site` usage, value redaction, and apply-mode output.

- Migration
  - Set `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET`, and ensure `NETLIFY_SITE_ID` is your production site UUID.
  - Run `DRY_RUN=1 ./scripts/bootstrap-production-secrets.sh` to verify, then run without `DRY_RUN` to apply.

<sup>Written for commit e688debcfffe920ca900b1e055c676fa3c1b0cb8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

