### PR TITLE
Add Stripe server/webhook secrets to production bootstrap; validate and redact sensitive values

### DIFF
--- a/docs/ENV_SETUP_SECRETS_GUIDE.md
+++ b/docs/ENV_SETUP_SECRETS_GUIDE.md
@@ -54,12 +54,15 @@ env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
   netlify env:set NEXT_PUBLIC_API_URL "$NEXT_PUBLIC_API_URL" --context production --site "$NETLIFY_SITE_ID"
 env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
   netlify env:set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY "$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY" --context production --site "$NETLIFY_SITE_ID"
+
+# For secrets, omit the value argument so Netlify CLI prompts you instead of
+# putting the secret on the command line.
 env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
-  netlify env:set STRIPE_SECRET_KEY "$STRIPE_SECRET_KEY" --context production --site "$NETLIFY_SITE_ID"
+  netlify env:set STRIPE_SECRET_KEY --context production --site "$NETLIFY_SITE_ID"
 env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
-  netlify env:set STRIPE_WEBHOOK_SECRET "$STRIPE_WEBHOOK_SECRET" --context production --site "$NETLIFY_SITE_ID"
+  netlify env:set STRIPE_WEBHOOK_SECRET --context production --site "$NETLIFY_SITE_ID"
 env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
-  netlify env:set JWT_SECRET "$JWT_SECRET" --context production --site "$NETLIFY_SITE_ID"
+  netlify env:set JWT_SECRET --context production --site "$NETLIFY_SITE_ID"
 ```
 
 ### 5) Apply to Fly.io environment

--- a/docs/ENV_SETUP_SECRETS_GUIDE.md
+++ b/docs/ENV_SETUP_SECRETS_GUIDE.md
@@ -13,7 +13,9 @@ Use this checklist when wiring production credentials for the current deployment
 | `FLY_API_TOKEN` | Fly.io CLI/API | required | Generate with `flyctl auth token`. |
 | `DATABASE_URL` | API + Prisma | required | Use the managed Postgres connection string with a real password. |
 | `NEXT_PUBLIC_API_URL` | Web frontend | required | Public API origin (for example `https://infamous.fly.dev`). |
-| `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | Stripe checkout UI | required | Must be the publishable key (`pk_...`), never a secret key. |
+| `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | Stripe checkout UI | required | Use live key (`pk_live_...`) for production bootstrap (`ALLOW_TEST_KEYS=1` only for drills). |
+| `STRIPE_SECRET_KEY` | Stripe server API | required | Use live key (`sk_live_...`) for production bootstrap (`ALLOW_TEST_KEYS=1` only for drills). |
+| `STRIPE_WEBHOOK_SECRET` | Stripe webhook verification | required | Signing secret for Stripe webhook validation (`whsec_...`). |
 | `JWT_SECRET` | API auth signing (HS256 mode + web stripe route) | required | Generate with `openssl rand -base64 32`. |
 
 ### 2) Export locally (do not commit secrets)
@@ -25,6 +27,8 @@ export FLY_API_TOKEN="$(flyctl auth token)"
 export DATABASE_URL="postgresql://postgres:<password>@<host>:5432/postgres?schema=public"
 export NEXT_PUBLIC_API_URL="https://infamous.fly.dev"
 export NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY="pk_live_..."
+export STRIPE_SECRET_KEY="sk_live_..."
+export STRIPE_WEBHOOK_SECRET="whsec_..."
 export JWT_SECRET="$(openssl rand -base64 32)"
 ```
 
@@ -40,12 +44,21 @@ Use `DRY_RUN=1` first to preview changes:
 DRY_RUN=1 ./scripts/bootstrap-production-secrets.sh
 ```
 
+If you are running a non-production drill with Stripe test credentials, set `ALLOW_TEST_KEYS=1`.
+
 ### 4) Apply to Netlify environment
 
 ```bash
-printf '%s' "$NEXT_PUBLIC_API_URL" | netlify env:set NEXT_PUBLIC_API_URL production
-printf '%s' "$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY" | netlify env:set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY production
-printf '%s' "$JWT_SECRET" | netlify env:set JWT_SECRET production
+env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
+  netlify env:set NEXT_PUBLIC_API_URL "$NEXT_PUBLIC_API_URL" --context production --site "$NETLIFY_SITE_ID"
+env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
+  netlify env:set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY "$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY" --context production --site "$NETLIFY_SITE_ID"
+env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
+  netlify env:set STRIPE_SECRET_KEY "$STRIPE_SECRET_KEY" --context production --site "$NETLIFY_SITE_ID"
+env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
+  netlify env:set STRIPE_WEBHOOK_SECRET "$STRIPE_WEBHOOK_SECRET" --context production --site "$NETLIFY_SITE_ID"
+env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
+  netlify env:set JWT_SECRET "$JWT_SECRET" --context production --site "$NETLIFY_SITE_ID"
 ```
 
 ### 5) Apply to Fly.io environment
@@ -54,13 +67,15 @@ printf '%s' "$JWT_SECRET" | netlify env:set JWT_SECRET production
 flyctl secrets set \
   DATABASE_URL="$DATABASE_URL" \
   JWT_SECRET="$JWT_SECRET" \
+  STRIPE_SECRET_KEY="$STRIPE_SECRET_KEY" \
+  STRIPE_WEBHOOK_SECRET="$STRIPE_WEBHOOK_SECRET" \
   --app infamous-freight-api
 ```
 
 ### 6) Post-setup verification
 
 ```bash
-netlify env:list --context production
+netlify env:list --context production --site "$NETLIFY_SITE_ID"
 flyctl secrets list --app infamous-freight-api
 ```
 

--- a/docs/ENV_SETUP_SECRETS_GUIDE.md
+++ b/docs/ENV_SETUP_SECRETS_GUIDE.md
@@ -44,7 +44,7 @@ Use `DRY_RUN=1` first to preview changes:
 DRY_RUN=1 ./scripts/bootstrap-production-secrets.sh
 ```
 
-If you are running a non-production drill with Stripe test credentials, set `ALLOW_TEST_KEYS=1`.
+If you are running a non-production drill with Stripe test credentials, set `ALLOW_TEST_KEYS=1` (only valid values are `0` or `1`).
 
 ### 4) Apply to Netlify environment
 

--- a/docs/ENV_SETUP_SECRETS_GUIDE.md
+++ b/docs/ENV_SETUP_SECRETS_GUIDE.md
@@ -45,6 +45,7 @@ DRY_RUN=1 ./scripts/bootstrap-production-secrets.sh
 ```
 
 If you are running a non-production drill with Stripe test credentials, set `ALLOW_TEST_KEYS=1` (only valid values are `0` or `1`).
+You can also run `VERIFY_ONLY=1` to skip writes and only run `netlify env:list` / `flyctl secrets list` checks.
 
 ### 4) Apply to Netlify environment
 
@@ -78,6 +79,8 @@ flyctl secrets set \
 netlify env:list --context production --site "$NETLIFY_SITE_ID"
 flyctl secrets list --app infamous-freight-api
 ```
+
+Supported Netlify contexts for this bootstrap script are `production`, `deploy-preview`, and `branch-deploy`.
 
 > Security note: keep real token/key values in your secret manager and CI provider; commit only placeholders in tracked files.
 

--- a/scripts/bootstrap-production-secrets.sh
+++ b/scripts/bootstrap-production-secrets.sh
@@ -12,17 +12,21 @@ Required environment variables:
   DATABASE_URL
   NEXT_PUBLIC_API_URL
   NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
+  STRIPE_SECRET_KEY
+  STRIPE_WEBHOOK_SECRET
   JWT_SECRET
 
 Optional environment variables:
   FLY_APP_NAME         (default: infamous-freight-api)
   NETLIFY_CONTEXT      (default: production)
+  ALLOW_TEST_KEYS      (set to 1 to allow Stripe test keys for non-prod drills)
   DRY_RUN              (set to 1 to print actions without applying)
 
 Example:
   NETLIFY_AUTH_TOKEN=... NETLIFY_SITE_ID=... FLY_API_TOKEN=... \
   DATABASE_URL=... NEXT_PUBLIC_API_URL=https://infamous.fly.dev \
-  NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_live_... JWT_SECRET=$(openssl rand -base64 32) \
+  NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_live_... STRIPE_SECRET_KEY=sk_live_... \
+  STRIPE_WEBHOOK_SECRET=whsec_... JWT_SECRET=$(openssl rand -base64 32) \
   ./scripts/bootstrap-production-secrets.sh
 USAGE
 }
@@ -31,6 +35,8 @@ if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
   usage
   exit 0
 fi
+
+ALLOW_TEST_KEYS="${ALLOW_TEST_KEYS:-0}"
 
 require_var() {
   local name="$1"
@@ -54,12 +60,19 @@ required_vars=(
   DATABASE_URL
   NEXT_PUBLIC_API_URL
   NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
+  STRIPE_SECRET_KEY
+  STRIPE_WEBHOOK_SECRET
   JWT_SECRET
 )
 
 for var_name in "${required_vars[@]}"; do
   require_var "$var_name"
 done
+
+if [[ ! "${NETLIFY_SITE_ID}" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ ]]; then
+  echo "[bootstrap-secrets] NETLIFY_SITE_ID must be a UUID" >&2
+  exit 1
+fi
 
 if [[ ! "${DATABASE_URL}" =~ ^postgres(ql)?:// ]]; then
   echo "[bootstrap-secrets] DATABASE_URL must start with postgres:// or postgresql://" >&2
@@ -76,6 +89,28 @@ if [[ ! "${NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY}" =~ ^pk_(live|test)_ ]]; then
   exit 1
 fi
 
+if [[ ! "${STRIPE_SECRET_KEY}" =~ ^sk_(live|test)_ ]]; then
+  echo "[bootstrap-secrets] STRIPE_SECRET_KEY must be a Stripe secret key" >&2
+  exit 1
+fi
+
+if [[ ! "${STRIPE_WEBHOOK_SECRET}" =~ ^whsec_ ]]; then
+  echo "[bootstrap-secrets] STRIPE_WEBHOOK_SECRET must be a Stripe webhook signing secret" >&2
+  exit 1
+fi
+
+if [[ "$ALLOW_TEST_KEYS" != "1" ]]; then
+  if [[ ! "${NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY}" =~ ^pk_live_ ]]; then
+    echo "[bootstrap-secrets] NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY must be a live key (set ALLOW_TEST_KEYS=1 to bypass)" >&2
+    exit 1
+  fi
+
+  if [[ ! "${STRIPE_SECRET_KEY}" =~ ^sk_live_ ]]; then
+    echo "[bootstrap-secrets] STRIPE_SECRET_KEY must be a live key (set ALLOW_TEST_KEYS=1 to bypass)" >&2
+    exit 1
+  fi
+fi
+
 if [[ ${#JWT_SECRET} -lt 32 ]]; then
   echo "[bootstrap-secrets] JWT_SECRET must be at least 32 characters" >&2
   exit 1
@@ -85,35 +120,38 @@ FLY_APP_NAME="${FLY_APP_NAME:-infamous-freight-api}"
 NETLIFY_CONTEXT="${NETLIFY_CONTEXT:-production}"
 DRY_RUN="${DRY_RUN:-0}"
 
-run_cmd() {
-  if [[ "$DRY_RUN" == "1" ]]; then
-    echo "[dry-run] $*"
-  else
-    "$@"
-  fi
-}
-
-echo "[bootstrap-secrets] Applying Netlify env vars to context '${NETLIFY_CONTEXT}' for site '${NETLIFY_SITE_ID}'."
+echo "[bootstrap-secrets] Applying Netlify env vars to context '${NETLIFY_CONTEXT}' for site '***'."
 if [[ "$DRY_RUN" == "1" ]]; then
-  echo "[dry-run] printf '%s' \"\$NEXT_PUBLIC_API_URL\" | netlify env:set NEXT_PUBLIC_API_URL ${NETLIFY_CONTEXT}"
-  echo "[dry-run] printf '%s' \"\$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY\" | netlify env:set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ${NETLIFY_CONTEXT}"
-  echo "[dry-run] printf '%s' \"\$JWT_SECRET\" | netlify env:set JWT_SECRET ${NETLIFY_CONTEXT}"
+  echo "[dry-run] env NETLIFY_AUTH_TOKEN=*** netlify env:set NEXT_PUBLIC_API_URL \"\$NEXT_PUBLIC_API_URL\" --context ${NETLIFY_CONTEXT} --site ***"
+  echo "[dry-run] env NETLIFY_AUTH_TOKEN=*** netlify env:set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY \"\$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY\" --context ${NETLIFY_CONTEXT} --site ***"
+  echo "[dry-run] env NETLIFY_AUTH_TOKEN=*** netlify env:set STRIPE_SECRET_KEY \"\$STRIPE_SECRET_KEY\" --context ${NETLIFY_CONTEXT} --site ***"
+  echo "[dry-run] env NETLIFY_AUTH_TOKEN=*** netlify env:set STRIPE_WEBHOOK_SECRET \"\$STRIPE_WEBHOOK_SECRET\" --context ${NETLIFY_CONTEXT} --site ***"
+  echo "[dry-run] env NETLIFY_AUTH_TOKEN=*** netlify env:set JWT_SECRET \"\$JWT_SECRET\" --context ${NETLIFY_CONTEXT} --site ***"
 else
-  printf '%s' "$NEXT_PUBLIC_API_URL" | env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" netlify env:set NEXT_PUBLIC_API_URL "$NETLIFY_CONTEXT"
-  printf '%s' "$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY" | env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" netlify env:set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY "$NETLIFY_CONTEXT"
-  printf '%s' "$JWT_SECRET" | env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" netlify env:set JWT_SECRET "$NETLIFY_CONTEXT"
+  env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
+    netlify env:set NEXT_PUBLIC_API_URL "$NEXT_PUBLIC_API_URL" --context "$NETLIFY_CONTEXT" --site "$NETLIFY_SITE_ID"
+  env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
+    netlify env:set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY "$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY" --context "$NETLIFY_CONTEXT" --site "$NETLIFY_SITE_ID"
+  env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
+    netlify env:set STRIPE_SECRET_KEY "$STRIPE_SECRET_KEY" --context "$NETLIFY_CONTEXT" --site "$NETLIFY_SITE_ID"
+  env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
+    netlify env:set STRIPE_WEBHOOK_SECRET "$STRIPE_WEBHOOK_SECRET" --context "$NETLIFY_CONTEXT" --site "$NETLIFY_SITE_ID"
+  env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
+    netlify env:set JWT_SECRET "$JWT_SECRET" --context "$NETLIFY_CONTEXT" --site "$NETLIFY_SITE_ID"
 fi
 
 echo "[bootstrap-secrets] Applying Fly.io secrets to app '${FLY_APP_NAME}'."
 if [[ "$DRY_RUN" == "1" ]]; then
-  echo "[dry-run] env FLY_API_TOKEN=*** flyctl secrets set DATABASE_URL=\"\$DATABASE_URL\" JWT_SECRET=\"\$JWT_SECRET\" --app ${FLY_APP_NAME}"
+  echo "[dry-run] env FLY_API_TOKEN=*** flyctl secrets set DATABASE_URL=\"\$DATABASE_URL\" JWT_SECRET=\"\$JWT_SECRET\" STRIPE_SECRET_KEY=\"\$STRIPE_SECRET_KEY\" STRIPE_WEBHOOK_SECRET=\"\$STRIPE_WEBHOOK_SECRET\" --app ${FLY_APP_NAME}"
 else
   env FLY_API_TOKEN="$FLY_API_TOKEN" flyctl secrets set \
     DATABASE_URL="$DATABASE_URL" \
     JWT_SECRET="$JWT_SECRET" \
+    STRIPE_SECRET_KEY="$STRIPE_SECRET_KEY" \
+    STRIPE_WEBHOOK_SECRET="$STRIPE_WEBHOOK_SECRET" \
     --app "$FLY_APP_NAME"
 fi
 
 echo "[bootstrap-secrets] Done. Verify with:"
-echo "  NETLIFY_AUTH_TOKEN=*** NETLIFY_SITE_ID=*** netlify env:list --context ${NETLIFY_CONTEXT}"
+echo "  NETLIFY_AUTH_TOKEN=*** netlify env:list --context ${NETLIFY_CONTEXT} --site ***"
 echo "  FLY_API_TOKEN=*** flyctl secrets list --app ${FLY_APP_NAME}"

--- a/scripts/bootstrap-production-secrets.sh
+++ b/scripts/bootstrap-production-secrets.sh
@@ -38,6 +38,11 @@ fi
 
 ALLOW_TEST_KEYS="${ALLOW_TEST_KEYS:-0}"
 
+if [[ "$ALLOW_TEST_KEYS" != "0" && "$ALLOW_TEST_KEYS" != "1" ]]; then
+  echo "[bootstrap-secrets] ALLOW_TEST_KEYS must be 0 or 1" >&2
+  exit 1
+fi
+
 require_var() {
   local name="$1"
   if [[ -z "${!name:-}" ]]; then

--- a/scripts/bootstrap-production-secrets.sh
+++ b/scripts/bootstrap-production-secrets.sh
@@ -20,6 +20,7 @@ Optional environment variables:
   FLY_APP_NAME         (default: infamous-freight-api)
   NETLIFY_CONTEXT      (default: production)
   ALLOW_TEST_KEYS      (set to 1 to allow Stripe test keys for non-prod drills)
+  VERIFY_ONLY          (set to 1 to only run post-apply verification checks)
   DRY_RUN              (set to 1 to print actions without applying)
 
 Example:
@@ -37,9 +38,18 @@ if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
 fi
 
 ALLOW_TEST_KEYS="${ALLOW_TEST_KEYS:-0}"
+VERIFY_ONLY="${VERIFY_ONLY:-0}"
+NETLIFY_CONTEXT="${NETLIFY_CONTEXT:-production}"
+FLY_APP_NAME="${FLY_APP_NAME:-infamous-freight-api}"
+DRY_RUN="${DRY_RUN:-0}"
 
 if [[ "$ALLOW_TEST_KEYS" != "0" && "$ALLOW_TEST_KEYS" != "1" ]]; then
   echo "[bootstrap-secrets] ALLOW_TEST_KEYS must be 0 or 1" >&2
+  exit 1
+fi
+
+if [[ "$VERIFY_ONLY" != "0" && "$VERIFY_ONLY" != "1" ]]; then
+  echo "[bootstrap-secrets] VERIFY_ONLY must be 0 or 1" >&2
   exit 1
 fi
 
@@ -76,6 +86,11 @@ done
 
 if [[ ! "${NETLIFY_SITE_ID}" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ ]]; then
   echo "[bootstrap-secrets] NETLIFY_SITE_ID must be a UUID" >&2
+  exit 1
+fi
+
+if [[ ! "${NETLIFY_CONTEXT}" =~ ^(production|deploy-preview|branch-deploy)$ ]]; then
+  echo "[bootstrap-secrets] NETLIFY_CONTEXT must be one of: production, deploy-preview, branch-deploy" >&2
   exit 1
 fi
 
@@ -121,9 +136,17 @@ if [[ ${#JWT_SECRET} -lt 32 ]]; then
   exit 1
 fi
 
-FLY_APP_NAME="${FLY_APP_NAME:-infamous-freight-api}"
-NETLIFY_CONTEXT="${NETLIFY_CONTEXT:-production}"
-DRY_RUN="${DRY_RUN:-0}"
+if [[ "$VERIFY_ONLY" == "1" ]]; then
+  echo "[bootstrap-secrets] VERIFY_ONLY=1: skipping apply steps and running verification checks."
+  if [[ "$DRY_RUN" == "1" ]]; then
+    echo "[dry-run] env NETLIFY_AUTH_TOKEN=*** netlify env:list --context ${NETLIFY_CONTEXT} --site ***"
+    echo "[dry-run] env FLY_API_TOKEN=*** flyctl secrets list --app ${FLY_APP_NAME}"
+  else
+    env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" netlify env:list --context "$NETLIFY_CONTEXT" --site "$NETLIFY_SITE_ID"
+    env FLY_API_TOKEN="$FLY_API_TOKEN" flyctl secrets list --app "$FLY_APP_NAME"
+  fi
+  exit 0
+fi
 
 echo "[bootstrap-secrets] Applying Netlify env vars to context '${NETLIFY_CONTEXT}' for site '***'."
 if [[ "$DRY_RUN" == "1" ]]; then

--- a/tests/ci/bootstrap-production-secrets.test.sh
+++ b/tests/ci/bootstrap-production-secrets.test.sh
@@ -18,6 +18,17 @@ assert_contains() {
   fi
 }
 
+assert_not_contains() {
+  local description="$1"
+  local haystack="$2"
+  local needle="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    fail "$description (did not expect '$needle')"
+  else
+    pass "$description"
+  fi
+}
+
 assert_eq() {
   local description="$1"
   local expected="$2"
@@ -51,11 +62,13 @@ chmod +x "$TMP_DIR/netlify" "$TMP_DIR/flyctl"
 BASE_ENV=(
   "PATH=$TMP_DIR:$PATH"
   "NETLIFY_AUTH_TOKEN=test-netlify-token"
-  "NETLIFY_SITE_ID=test-site-id"
+  "NETLIFY_SITE_ID=11111111-2222-3333-4444-555555555555"
   "FLY_API_TOKEN=test-fly-token"
   "DATABASE_URL=postgresql://postgres:pw@localhost:5432/postgres?schema=public"
   "NEXT_PUBLIC_API_URL=https://infamous.fly.dev"
   "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_live_test"
+  "STRIPE_SECRET_KEY=sk_live_test"
+  "STRIPE_WEBHOOK_SECRET=whsec_test"
   "JWT_SECRET=abcdefghijklmnopqrstuvwxyz123456"
 )
 
@@ -79,12 +92,66 @@ assert_eq "http api url exits non-zero" "1" "$invalid_url_code"
 assert_contains "http api url has explicit message" "$invalid_url_output" "NEXT_PUBLIC_API_URL must be https:// in production"
 
 set +e
+invalid_site_id_output="$(env "${BASE_ENV[@]}" NETLIFY_SITE_ID=not-a-uuid "$SCRIPT" 2>&1)"
+invalid_site_id_code=$?
+set -e
+assert_eq "invalid netlify site id exits non-zero" "1" "$invalid_site_id_code"
+assert_contains "invalid netlify site id has explicit message" "$invalid_site_id_output" "NETLIFY_SITE_ID must be a UUID"
+
+set +e
+invalid_stripe_secret_output="$(env "${BASE_ENV[@]}" STRIPE_SECRET_KEY=pk_live_wrong "$SCRIPT" 2>&1)"
+invalid_stripe_secret_code=$?
+set -e
+assert_eq "invalid stripe secret exits non-zero" "1" "$invalid_stripe_secret_code"
+assert_contains "invalid stripe secret has explicit message" "$invalid_stripe_secret_output" "STRIPE_SECRET_KEY must be a Stripe secret key"
+
+set +e
+invalid_webhook_secret_output="$(env "${BASE_ENV[@]}" STRIPE_WEBHOOK_SECRET=secret_wrong "$SCRIPT" 2>&1)"
+invalid_webhook_secret_code=$?
+set -e
+assert_eq "invalid webhook secret exits non-zero" "1" "$invalid_webhook_secret_code"
+assert_contains "invalid webhook secret has explicit message" "$invalid_webhook_secret_output" "STRIPE_WEBHOOK_SECRET must be a Stripe webhook signing secret"
+
+set +e
+test_keys_output="$(env "${BASE_ENV[@]}" NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_123 STRIPE_SECRET_KEY=sk_test_123 "$SCRIPT" 2>&1)"
+test_keys_code=$?
+set -e
+assert_eq "stripe test keys rejected by default" "1" "$test_keys_code"
+assert_contains "stripe test keys rejection has explicit message" "$test_keys_output" "must be a live key (set ALLOW_TEST_KEYS=1 to bypass)"
+
+set +e
+allow_test_keys_output="$(env "${BASE_ENV[@]}" NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_123 STRIPE_SECRET_KEY=sk_test_123 ALLOW_TEST_KEYS=1 DRY_RUN=1 "$SCRIPT" 2>&1)"
+allow_test_keys_code=$?
+set -e
+assert_eq "allow test keys override exits zero" "0" "$allow_test_keys_code"
+assert_contains "allow test keys override still prints dry-run command" "$allow_test_keys_output" "netlify env:set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY"
+
+set +e
 dry_run_output="$(env "${BASE_ENV[@]}" DRY_RUN=1 "$SCRIPT" 2>&1)"
 dry_run_code=$?
 set -e
 assert_eq "dry run exits zero" "0" "$dry_run_code"
-assert_contains "dry run prints netlify command" "$dry_run_output" "netlify env:set NEXT_PUBLIC_API_URL production"
+assert_contains "dry run prints netlify key/value/context command" "$dry_run_output" 'netlify env:set NEXT_PUBLIC_API_URL "$NEXT_PUBLIC_API_URL" --context production --site ***'
 assert_contains "dry run prints fly command" "$dry_run_output" "flyctl secrets set DATABASE_URL="
+assert_contains "dry run includes stripe server key placeholder" "$dry_run_output" 'STRIPE_SECRET_KEY="$STRIPE_SECRET_KEY"'
+assert_contains "dry run includes stripe webhook placeholder" "$dry_run_output" 'STRIPE_WEBHOOK_SECRET="$STRIPE_WEBHOOK_SECRET"'
+assert_not_contains "dry run redacts database url value" "$dry_run_output" "postgresql://postgres:pw@localhost:5432/postgres?schema=public"
+assert_not_contains "dry run redacts database password segment" "$dry_run_output" "postgres:pw@"
+assert_not_contains "dry run redacts jwt secret value" "$dry_run_output" "abcdefghijklmnopqrstuvwxyz123456"
+assert_not_contains "dry run redacts fly token value" "$dry_run_output" "test-fly-token"
+assert_not_contains "dry run redacts netlify token value" "$dry_run_output" "test-netlify-token"
+assert_not_contains "dry run redacts netlify site id value" "$dry_run_output" "11111111-2222-3333-4444-555555555555"
+assert_not_contains "dry run redacts stripe secret key value" "$dry_run_output" "sk_live_test"
+assert_not_contains "dry run redacts stripe webhook secret value" "$dry_run_output" "whsec_test"
+
+set +e
+apply_output="$(env "${BASE_ENV[@]}" "$SCRIPT" 2>&1)"
+apply_code=$?
+set -e
+assert_eq "apply mode exits zero" "0" "$apply_code"
+assert_contains "apply mode netlify command includes explicit site flag" "$apply_output" "netlify env:set NEXT_PUBLIC_API_URL https://infamous.fly.dev --context production --site 11111111-2222-3333-4444-555555555555"
+assert_contains "apply mode netlify includes stripe webhook secret key name" "$apply_output" "netlify env:set STRIPE_WEBHOOK_SECRET"
+assert_contains "apply mode fly command includes stripe server secret key name" "$apply_output" "flyctl secrets set DATABASE_URL=postgresql://postgres:pw@localhost:5432/postgres?schema=public JWT_SECRET=abcdefghijklmnopqrstuvwxyz123456 STRIPE_SECRET_KEY=sk_live_test STRIPE_WEBHOOK_SECRET=whsec_test --app infamous-freight-api"
 
 if [ "$FAIL" -gt 0 ]; then
   echo ""

--- a/tests/ci/bootstrap-production-secrets.test.sh
+++ b/tests/ci/bootstrap-production-secrets.test.sh
@@ -120,6 +120,13 @@ assert_eq "stripe test keys rejected by default" "1" "$test_keys_code"
 assert_contains "stripe test keys rejection has explicit message" "$test_keys_output" "must be a live key (set ALLOW_TEST_KEYS=1 to bypass)"
 
 set +e
+invalid_allow_test_keys_output="$(env "${BASE_ENV[@]}" ALLOW_TEST_KEYS=maybe "$SCRIPT" 2>&1)"
+invalid_allow_test_keys_code=$?
+set -e
+assert_eq "invalid ALLOW_TEST_KEYS exits non-zero" "1" "$invalid_allow_test_keys_code"
+assert_contains "invalid ALLOW_TEST_KEYS has explicit message" "$invalid_allow_test_keys_output" "ALLOW_TEST_KEYS must be 0 or 1"
+
+set +e
 allow_test_keys_output="$(env "${BASE_ENV[@]}" NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_123 STRIPE_SECRET_KEY=sk_test_123 ALLOW_TEST_KEYS=1 DRY_RUN=1 "$SCRIPT" 2>&1)"
 allow_test_keys_code=$?
 set -e

--- a/tests/ci/bootstrap-production-secrets.test.sh
+++ b/tests/ci/bootstrap-production-secrets.test.sh
@@ -92,11 +92,25 @@ assert_eq "http api url exits non-zero" "1" "$invalid_url_code"
 assert_contains "http api url has explicit message" "$invalid_url_output" "NEXT_PUBLIC_API_URL must be https:// in production"
 
 set +e
+invalid_db_output="$(env "${BASE_ENV[@]}" DATABASE_URL=mysql://localhost/db "$SCRIPT" 2>&1)"
+invalid_db_code=$?
+set -e
+assert_eq "invalid database url exits non-zero" "1" "$invalid_db_code"
+assert_contains "invalid database url has explicit message" "$invalid_db_output" "DATABASE_URL must start with postgres:// or postgresql://"
+
+set +e
 invalid_site_id_output="$(env "${BASE_ENV[@]}" NETLIFY_SITE_ID=not-a-uuid "$SCRIPT" 2>&1)"
 invalid_site_id_code=$?
 set -e
 assert_eq "invalid netlify site id exits non-zero" "1" "$invalid_site_id_code"
 assert_contains "invalid netlify site id has explicit message" "$invalid_site_id_output" "NETLIFY_SITE_ID must be a UUID"
+
+set +e
+invalid_context_output="$(env "${BASE_ENV[@]}" NETLIFY_CONTEXT=staging "$SCRIPT" 2>&1)"
+invalid_context_code=$?
+set -e
+assert_eq "invalid netlify context exits non-zero" "1" "$invalid_context_code"
+assert_contains "invalid netlify context has explicit message" "$invalid_context_output" "NETLIFY_CONTEXT must be one of: production, deploy-preview, branch-deploy"
 
 set +e
 invalid_stripe_secret_output="$(env "${BASE_ENV[@]}" STRIPE_SECRET_KEY=pk_live_wrong "$SCRIPT" 2>&1)"
@@ -125,6 +139,20 @@ invalid_allow_test_keys_code=$?
 set -e
 assert_eq "invalid ALLOW_TEST_KEYS exits non-zero" "1" "$invalid_allow_test_keys_code"
 assert_contains "invalid ALLOW_TEST_KEYS has explicit message" "$invalid_allow_test_keys_output" "ALLOW_TEST_KEYS must be 0 or 1"
+
+set +e
+invalid_verify_only_output="$(env "${BASE_ENV[@]}" VERIFY_ONLY=2 "$SCRIPT" 2>&1)"
+invalid_verify_only_code=$?
+set -e
+assert_eq "invalid VERIFY_ONLY exits non-zero" "1" "$invalid_verify_only_code"
+assert_contains "invalid VERIFY_ONLY has explicit message" "$invalid_verify_only_output" "VERIFY_ONLY must be 0 or 1"
+
+set +e
+short_jwt_output="$(env "${BASE_ENV[@]}" JWT_SECRET=short_secret "$SCRIPT" 2>&1)"
+short_jwt_code=$?
+set -e
+assert_eq "short jwt exits non-zero" "1" "$short_jwt_code"
+assert_contains "short jwt has explicit message" "$short_jwt_output" "JWT_SECRET must be at least 32 characters"
 
 set +e
 allow_test_keys_output="$(env "${BASE_ENV[@]}" NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_123 STRIPE_SECRET_KEY=sk_test_123 ALLOW_TEST_KEYS=1 DRY_RUN=1 "$SCRIPT" 2>&1)"
@@ -159,6 +187,15 @@ assert_eq "apply mode exits zero" "0" "$apply_code"
 assert_contains "apply mode netlify command includes explicit site flag" "$apply_output" "netlify env:set NEXT_PUBLIC_API_URL https://infamous.fly.dev --context production --site 11111111-2222-3333-4444-555555555555"
 assert_contains "apply mode netlify includes stripe webhook secret key name" "$apply_output" "netlify env:set STRIPE_WEBHOOK_SECRET"
 assert_contains "apply mode fly command includes stripe server secret key name" "$apply_output" "flyctl secrets set DATABASE_URL=postgresql://postgres:pw@localhost:5432/postgres?schema=public JWT_SECRET=abcdefghijklmnopqrstuvwxyz123456 STRIPE_SECRET_KEY=sk_live_test STRIPE_WEBHOOK_SECRET=whsec_test --app infamous-freight-api"
+
+set +e
+verify_only_output="$(env "${BASE_ENV[@]}" VERIFY_ONLY=1 "$SCRIPT" 2>&1)"
+verify_only_code=$?
+set -e
+assert_eq "verify-only mode exits zero" "0" "$verify_only_code"
+assert_contains "verify-only mode prints skip message" "$verify_only_output" "VERIFY_ONLY=1: skipping apply steps"
+assert_contains "verify-only mode lists netlify env" "$verify_only_output" "netlify env:list --context production --site 11111111-2222-3333-4444-555555555555"
+assert_contains "verify-only mode lists fly secrets" "$verify_only_output" "flyctl secrets list --app infamous-freight-api"
 
 if [ "$FAIL" -gt 0 ]; then
   echo ""


### PR DESCRIPTION
### Motivation

- Include server-side Stripe credentials in production bootstrapping and ensure only live keys are used by default to avoid accidental test keys in production.
- Improve safety by validating input formats (UUID, URLs, secret/key patterns) and avoid leaking secrets in `DRY_RUN` output.

### Description

- Updated `docs/ENV_SETUP_SECRETS_GUIDE.md` to document `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET` and show Netlify `--site` usage and the `ALLOW_TEST_KEYS` hint.
- Extended `scripts/bootstrap-production-secrets.sh` to require and validate `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET`, validate `NETLIFY_SITE_ID` as a UUID, enforce `https://` for `NEXT_PUBLIC_API_URL`, and add an `ALLOW_TEST_KEYS` override for non-production drills.
- Changed Netlify commands to pass `--context` and `--site`, added Fly.io secret writes for the new Stripe keys, and redacted sensitive values in `DRY_RUN` output.
- Updated `tests/ci/bootstrap-production-secrets.test.sh` to cover the new validations, `ALLOW_TEST_KEYS` behavior, redaction checks, and the adjusted Netlify/Fly command formats.

### Testing

- Ran the automated script test `tests/ci/bootstrap-production-secrets.test.sh` which exercises help output, missing/invalid variable handling, `DRY_RUN` redaction, `ALLOW_TEST_KEYS` override, and apply-mode commands, and all checks passed.
- The test confirms Netlify commands include `--site` and `--context`, Fly secret outputs include `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET`, and sensitive values are not printed in dry-run output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6a67d39548330b176f73da6705fbc)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Stripe server and webhook secrets to the production bootstrap, requires live keys by default, and adds a verify-only mode. Tightens input validation, redacts sensitive values in outputs, and updates Netlify/Fly commands and docs.

- **New Features**
  - Require and validate `STRIPE_SECRET_KEY` (`sk_`) and `STRIPE_WEBHOOK_SECRET` (`whsec_`); enforce live keys unless `ALLOW_TEST_KEYS=1`.
  - Validate `NETLIFY_SITE_ID` as a UUID and `NETLIFY_CONTEXT` as `production|deploy-preview|branch-deploy`; enforce `postgres*` for `DATABASE_URL`, `https://` for `NEXT_PUBLIC_API_URL`, and 32+ chars for `JWT_SECRET`.
  - Add `VERIFY_ONLY=1` to skip writes and run `netlify env:list` / `flyctl secrets list`.
  - Use Netlify CLI with `--context` and `--site`; push Stripe secrets to Fly. Redact tokens, site ID, and secret values in `DRY_RUN`.
  - Update `docs/ENV_SETUP_SECRETS_GUIDE.md` with contexts, `VERIFY_ONLY`, `ALLOW_TEST_KEYS`, `--site` usage, and a note to omit secret values so Netlify prompts instead. Extend tests for validations, redaction, verify-only, and command formats.

- **Migration**
  - Export `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET` (live keys for production).
  - Ensure `NETLIFY_SITE_ID` is a UUID and `NETLIFY_CONTEXT` is supported.
  - For drills, set `ALLOW_TEST_KEYS=1`; to verify only, set `VERIFY_ONLY=1`; preview with `DRY_RUN=1` before applying.

<sup>Written for commit 3c4be9952fd6f85dfedcaded6cbe98394ccb640c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

