### PR TITLE
feat: add target deployment architecture and cutover artifacts

### DIFF
--- a/apps/web/.env.production.example
+++ b/apps/web/.env.production.example
@@ -1,0 +1,8 @@
+NEXT_PUBLIC_SITE_URL=https://www.infamousfreight.com
+NEXT_PUBLIC_API_URL=https://api.infamousfreight.com/api
+NEXT_PUBLIC_APP_ENV=production
+NEXT_PUBLIC_APP_NAME=Infamous Freight
+NEXT_PUBLIC_PORTAL_URL=https://portal.infamousfreight.com
+NEXT_PUBLIC_OPS_URL=https://app.infamousfreight.com
+NEXT_PUBLIC_SENTRY_DSN=
+SENTRY_AUTH_TOKEN=

--- a/apps/web/.env.production.example
+++ b/apps/web/.env.production.example
@@ -1,6 +1,6 @@
 NEXT_PUBLIC_SITE_URL=https://www.infamousfreight.com
 NEXT_PUBLIC_API_URL=https://api.infamousfreight.com/api
-NEXT_PUBLIC_APP_ENV=production
+NEXT_PUBLIC_ENV=production
 NEXT_PUBLIC_APP_NAME=Infamous Freight
 NEXT_PUBLIC_PORTAL_URL=https://portal.infamousfreight.com
 NEXT_PUBLIC_OPS_URL=https://app.infamousfreight.com

--- a/docs/deployment/CUTOVER_CHECKLIST.md
+++ b/docs/deployment/CUTOVER_CHECKLIST.md
@@ -16,7 +16,7 @@
 - [ ] `https://www.infamousfreight.com` loads correctly
 - [ ] Frontend API calls resolve against `https://api.infamousfreight.com/api`
 - [ ] Stripe webhook endpoint is reachable at `https://hooks.infamousfreight.com/api/webhooks/stripe`
-- [ ] CORS allows `www.infamousfreight.com`
+- [ ] CORS allows `www.infamousfreight.com`, `app.infamousfreight.com`, and `portal.infamousfreight.com`
 
 ## DNS cutover
 

--- a/docs/deployment/CUTOVER_CHECKLIST.md
+++ b/docs/deployment/CUTOVER_CHECKLIST.md
@@ -1,0 +1,40 @@
+# Production Cutover Checklist
+
+## Before cutover
+
+- [ ] Supabase production database is provisioned
+- [ ] Render API service is deployed and healthy
+- [ ] Render worker is deployed and connected to Redis
+- [ ] Vercel web project for `apps/web` is deployed from `main`
+- [ ] Production environment variables are set in Vercel and Render
+- [ ] Cloudflare zone is active for `infamousfreight.com`
+
+## Validation targets
+
+- [ ] `https://api.infamousfreight.com/health` returns success
+- [ ] `https://api.infamousfreight.com/api/health` returns success
+- [ ] `https://www.infamousfreight.com` loads correctly
+- [ ] Frontend API calls resolve against `https://api.infamousfreight.com/api`
+- [ ] Stripe webhook endpoint is reachable at `https://hooks.infamousfreight.com/api/webhooks/stripe`
+- [ ] CORS allows `www.infamousfreight.com`
+
+## DNS cutover
+
+- [ ] Apex redirects to `www`
+- [ ] `www` points to Vercel
+- [ ] `api` points to Render API
+- [ ] `hooks` points to Render API
+- [ ] Proxy/WAF enabled in Cloudflare for public hostnames
+
+## Security checks
+
+- [ ] Cloudflare rate limits enabled on auth and webhook paths
+- [ ] Production secrets are not stored in Git
+- [ ] JWT keys are loaded only from secret stores
+- [ ] Stripe live keys are present only in production secret stores
+
+## Decommission steps
+
+- [ ] Netlify production site removed from active DNS
+- [ ] Legacy Fly or mixed deploy references removed from operational docs
+- [ ] Team runbooks updated to the new stack

--- a/docs/deployment/NETLIFY_DOMAIN_CONSTRAINT.md
+++ b/docs/deployment/NETLIFY_DOMAIN_CONSTRAINT.md
@@ -1,0 +1,19 @@
+# Domain Constraint Record
+
+## Constraint
+
+`www.infamousfreight.com` must remain on Netlify.
+
+## Operational consequence
+
+Production architecture should be treated as:
+
+- Netlify for the public website on `www.infamousfreight.com`
+- separate backend hosting for `api.infamousfreight.com`
+- same backend service or restricted ingress for `hooks.infamousfreight.com`
+
+## Anti-pattern to avoid
+
+Do not move `www.infamousfreight.com` to Vercel if that breaks your live domain control.
+
+Use Vercel only if you later move the frontend to another subdomain or remove the Netlify domain dependency entirely.

--- a/docs/deployment/NETLIFY_WWW_PRODUCTION.md
+++ b/docs/deployment/NETLIFY_WWW_PRODUCTION.md
@@ -1,0 +1,72 @@
+# Netlify Production Runbook for `www.infamousfreight.com`
+
+This runbook is the frontend hosting override for production.
+
+## Decision
+
+Keep the public frontend on Netlify at:
+
+- `https://www.infamousfreight.com`
+
+Keep the backend split out to a separate service at:
+
+- `https://api.infamousfreight.com`
+- `https://hooks.infamousfreight.com`
+
+## Why this is the right move
+
+If `www.infamousfreight.com` is the domain you can actually use on Netlify, do not fight that constraint. Keep Netlify on `www` and keep the backend on a separate hostname.
+
+This preserves:
+
+- existing domain control
+- cleaner frontend deployment
+- separate backend scaling and security boundaries
+- cleaner webhook isolation
+
+## Netlify site settings
+
+Use the existing Netlify site for the public frontend.
+
+Recommended build settings for the monorepo:
+
+- Base directory: repository root
+- Package directory: `apps/web`
+- Build command: `pnpm install --frozen-lockfile && pnpm --filter web build`
+- Publish directory: `apps/web/out`
+
+## Production domains
+
+Set the Netlify primary production domain to:
+
+- `www.infamousfreight.com`
+
+Add the apex domain as the alternate production domain:
+
+- `infamousfreight.com`
+
+Expected behavior:
+
+- `infamousfreight.com` redirects to `https://www.infamousfreight.com`
+- `www.infamousfreight.com` stays the canonical public site
+
+## Required frontend environment values
+
+Set these in Netlify:
+
+- `NEXT_PUBLIC_SITE_URL=https://www.infamousfreight.com`
+- `NEXT_PUBLIC_API_URL=https://api.infamousfreight.com/api`
+- `NEXT_PUBLIC_APP_ENV=production`
+
+## Backend split
+
+Do not put the backend under the Netlify `www` domain.
+
+Use a separate backend hostname for the API and webhooks:
+
+- `api.infamousfreight.com`
+- `hooks.infamousfreight.com`
+
+## What to ignore from older deployment notes
+
+If older docs reference Vercel as the required production home for the public frontend, treat those notes as optional rather than mandatory. The hard requirement is that `www.infamousfreight.com` remains on Netlify.

--- a/docs/deployment/NETLIFY_WWW_PRODUCTION.md
+++ b/docs/deployment/NETLIFY_WWW_PRODUCTION.md
@@ -69,4 +69,4 @@ Use a separate backend hostname for the API and webhooks:
 
 ## What to ignore from older deployment notes
 
-If older docs reference Vercel as the required production home for the public frontend, treat those notes as optional rather than mandatory. The hard requirement is that `www.infamousfreight.com` remains on Netlify.
+If older docs reference Netlify or Vercel differently, follow `docs/deployment/TARGET_PRODUCTION_ARCHITECTURE.md` as the source of truth for production cutover. Use this runbook only as a temporary fallback when domain constraints block the planned Vercel migration.

--- a/docs/deployment/TARGET_PRODUCTION_ARCHITECTURE.md
+++ b/docs/deployment/TARGET_PRODUCTION_ARCHITECTURE.md
@@ -1,0 +1,114 @@
+# Target Production Deployment Architecture
+
+## Goal
+
+Move Infamous Freight to a clean production topology with:
+
+- Cloudflare at the edge for DNS, SSL, WAF, and rate limiting
+- Vercel for the `apps/web` Next.js frontend
+- Render for the `apps/api` service and `apps/worker`
+- Supabase Postgres as the managed production database
+
+## Current Constraint
+
+The current API code exposes routes under `/api/*`, not `/v1/*`.
+
+That means the production API should keep this shape:
+
+- `https://api.infamousfreight.com/api/health`
+- `https://api.infamousfreight.com/api/auth/*`
+- `https://api.infamousfreight.com/api/loads/*`
+- `https://api.infamousfreight.com/api/webhooks/stripe`
+
+Do not introduce a `/v1` prefix during the hosting cutover unless the API itself is versioned in code first.
+
+## Target Route Map
+
+### Phase 1: cut over with the current codebase
+
+- `infamousfreight.com` -> redirect to `https://www.infamousfreight.com`
+- `www.infamousfreight.com` -> Vercel project for `apps/web`
+- `api.infamousfreight.com` -> Render API service for `apps/api`
+- `hooks.infamousfreight.com` -> same Render API service, restricted by Cloudflare rules to webhook traffic
+- `status.infamousfreight.com` -> optional status page provider
+
+### Phase 2: split customer and internal surfaces
+
+Once host-based UX or separate frontend surfaces are implemented, extend the map to:
+
+- `portal.infamousfreight.com` -> customer-facing portal
+- `app.infamousfreight.com` -> internal operations dashboard
+
+## Hosting Responsibilities
+
+### Cloudflare
+
+Use Cloudflare for:
+
+- authoritative DNS
+- proxied SSL termination
+- WAF rules
+- bot filtering
+- rate limiting on `/api/auth/*`, `/api/webhooks/*`, `/quote`, and `/track`
+- apex redirect from `infamousfreight.com` to `www.infamousfreight.com`
+
+### Vercel
+
+Use one Vercel project for `apps/web`.
+
+Recommended settings:
+
+- root directory: `apps/web`
+- install command: `corepack enable && corepack prepare pnpm@10.33.0 --activate && pnpm install --frozen-lockfile`
+- build command: `pnpm --filter web build`
+- output: Next.js managed output
+
+### Render
+
+Use Render for:
+
+- API web service from `apps/api`
+- background worker from `apps/worker`
+- Redis for queue workloads
+
+### Supabase
+
+Use Supabase Postgres as the primary production database.
+
+## Required Environment Direction
+
+### Frontend (`apps/web`)
+
+Point the frontend at the production API domain:
+
+- `NEXT_PUBLIC_SITE_URL=https://www.infamousfreight.com`
+- `NEXT_PUBLIC_API_URL=https://api.infamousfreight.com/api`
+- `NEXT_PUBLIC_APP_ENV=production`
+
+### API (`apps/api`)
+
+Use production hostnames in the API configuration:
+
+- `WEB_BASE_URL=https://www.infamousfreight.com`
+- `API_BASE_URL=https://api.infamousfreight.com/api`
+- `CORS_ORIGIN=https://www.infamousfreight.com,https://app.infamousfreight.com,https://portal.infamousfreight.com`
+- `CORS_ORIGINS=https://www.infamousfreight.com,https://app.infamousfreight.com,https://portal.infamousfreight.com`
+
+## Cutover Order
+
+1. Provision database and cache.
+2. Deploy API and worker on Render.
+3. Attach `api.infamousfreight.com` and validate `/health` and `/api/health`.
+4. Deploy `apps/web` to Vercel.
+5. Attach `www.infamousfreight.com` to Vercel.
+6. Put Cloudflare in front of both domains.
+7. Create redirect from apex to `www`.
+8. Add `hooks.infamousfreight.com` to the same API service and lock it down with Cloudflare rules.
+9. Decommission Netlify after the new stack is verified.
+
+## What not to do
+
+- Do not keep production on a mixed Netlify + Fly + dormant Vercel setup.
+- Do not move the public frontend to the `app` subdomain.
+- Do not move webhook traffic through the same public hostname as the website.
+- Do not change API path prefixes during hosting migration.

--- a/infra/cloudflare/DNS_RECORDS.example.md
+++ b/infra/cloudflare/DNS_RECORDS.example.md
@@ -1,0 +1,26 @@
+# Cloudflare DNS Records (Example)
+
+Use these as the target records for the production cutover.
+
+## Core records
+
+- `@` -> redirect to `https://www.infamousfreight.com`
+- `www` -> CNAME to the Vercel-assigned frontend target
+- `api` -> CNAME to the Render API service hostname
+- `hooks` -> CNAME to the same Render API service hostname
+- `status` -> CNAME to your chosen status page provider
+
+## Recommended edge controls
+
+Apply Cloudflare WAF and rate limiting to:
+
+- `/api/auth/*`
+- `/api/webhooks/*`
+- `/quote`
+- `/track`
+
+## Notes
+
+- `hooks.infamousfreight.com` should terminate on the same API service as `api.infamousfreight.com`.
+- Keep webhook traffic path-based in the application (`/api/webhooks/*`) and hostname-based at the edge.
+- Only decommission the current Netlify production site after `www` and `api` are both verified on the new stack.

--- a/render.production.yaml
+++ b/render.production.yaml
@@ -1,0 +1,48 @@
+# Production Render blueprint skeleton for the current monorepo.
+# Frontend hosting remains on Vercel. This blueprint covers backend services only.
+# Fill sensitive environment variables in the Render dashboard.
+
+services:
+  - type: web
+    name: infamous-freight-api-prod
+    env: node
+    rootDir: .
+    region: ohio
+    plan: starter
+    autoDeploy: true
+    healthCheckPath: /health
+    buildCommand: |
+      corepack enable
+      corepack prepare pnpm@10.33.0 --activate
+      pnpm install --frozen-lockfile
+      pnpm --filter @infamous-freight/shared build
+      pnpm --filter @infamous/api build
+    startCommand: pnpm --filter @infamous/api start
+
+  - type: worker
+    name: infamous-freight-worker-prod
+    env: node
+    rootDir: .
+    region: ohio
+    plan: starter
+    autoDeploy: true
+    buildCommand: |
+      corepack enable
+      corepack prepare pnpm@10.33.0 --activate
+      pnpm install --frozen-lockfile
+      pnpm --filter @infamous-freight/shared build
+      pnpm --filter worker build
+    startCommand: pnpm --filter worker start
+
+  - type: redis
+    name: infamous-freight-redis-prod
+    region: ohio
+    plan: starter
+    maxmemoryPolicy: allkeys-lru
+
+databases:
+  - name: infamous-freight-db-prod
+    region: ohio
+    plan: basic-256mb
+    databaseName: infamous_freight
+    user: infamous_freight


### PR DESCRIPTION
## Summary
- add a production target architecture doc for the Cloudflare + Vercel + Render + Supabase stack
- add a Render production blueprint skeleton for API and worker deployment
- add web production env example and Cloudflare DNS guidance
- add a concrete production cutover checklist

## Why
The repo already contains split web, API, and worker surfaces, but the live hosting state is drifting across Netlify, Fly, and dormant Vercel configuration. This PR gives the repo a single target production shape and an execution checklist for cutover.

## Included
- `docs/deployment/TARGET_PRODUCTION_ARCHITECTURE.md`
- `render.production.yaml`
- `apps/web/.env.production.example`
- `infra/cloudflare/DNS_RECORDS.example.md`
- `docs/deployment/CUTOVER_CHECKLIST.md`

## Not included
- live Cloudflare DNS changes
- live Render service provisioning
- live Supabase project provisioning
- live Vercel project/domain attachment

Those still need to be completed in the connected vendor dashboards.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defines a production deployment target with Cloudflare (DNS/WAF), Render (API/worker), Supabase (DB), and a web frontend on Vercel or Netlify based on the `www.infamousfreight.com` constraint. Adds concrete docs, DNS templates, and refined cutover runbooks to replace the current mixed hosting.

- **New Features**
  - Target architecture doc with route map and hosting roles; adds and refines the Netlify `www` production runbook with monorepo build settings, required env vars, and apex redirect guidance; includes a domain constraint record to keep `www.infamousfreight.com` on Netlify when required.
  - `render.production.yaml` for API, worker, Redis, and Postgres; builds `@infamous-freight/shared`, `@infamous/api`, and `worker` via `pnpm`.
  - `apps/web/.env.production.example` with production URLs, Sentry placeholders, and portal/ops host URLs.
  - Cloudflare DNS examples with apex redirect, `www`, `api`, `hooks`, and WAF/rate-limit guidance.
  - Cutover checklist expanded with validation targets, DNS steps, CORS, security checks, and decommission steps.

- **Migration**
  - No live infra changes here; use the docs to provision services, attach domains, set prod env in Netlify/Render/Vercel, and validate `/health` and `/api/health`. If `www` must remain on Netlify, follow the updated Netlify runbook and skip Vercel for the public site.

<sup>Written for commit 607dea9988d05639da8c5cc26b9b566af8fc0583. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a production deployment architecture guide with hosting, DNS, and cutover strategy.
  * Added a production cutover checklist covering pre-deploy validation, DNS steps, security checks, and decommissioning.
  * Added DNS records guidance and Netlify hosting/runbook constraints for the public site.

* **Chores**
  * Added a production environment variables template.

* **Infrastructure**
  * Added a production blueprint for backend services and managed data/cache provisioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->