### PR TITLE
bootstrap: add Stripe secret/webhook support, stricter validation, and verify/dry-run improvements

### DIFF
--- a/apps/web/lib/launchdarkly.ts
+++ b/apps/web/lib/launchdarkly.ts
@@ -23,12 +23,14 @@ export async function evaluateLaunchDarklyFlag(
   const client = initLaunchDarkly(clientSideId);
   const timeoutMs = 3000;
 
+  const initPromise = client.waitForInitialization();
   const timeoutPromise = new Promise<never>((_, reject) => {
-    setTimeout(() => reject(new Error("LaunchDarkly initialization timed out")), timeoutMs);
+    const timeout = setTimeout(() => reject(new Error("LaunchDarkly initialization timed out")), timeoutMs);
+    initPromise.finally(() => clearTimeout(timeout));
   });
 
   try {
-    await Promise.race([client.waitForInitialization(), timeoutPromise]);
+    await Promise.race([initPromise, timeoutPromise]);
     return await client.variation(flagKey, context, fallbackValue);
   } catch {
     return fallbackValue;

--- a/apps/web/lib/launchdarkly.ts
+++ b/apps/web/lib/launchdarkly.ts
@@ -21,10 +21,17 @@ export async function evaluateLaunchDarklyFlag(
   }
 
   const client = initLaunchDarkly(clientSideId);
-  await client.waitForInitialization();
+  const timeoutMs = 3000;
+
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    setTimeout(() => reject(new Error("LaunchDarkly initialization timed out")), timeoutMs);
+  });
 
   try {
+    await Promise.race([client.waitForInitialization(), timeoutPromise]);
     return await client.variation(flagKey, context, fallbackValue);
+  } catch {
+    return fallbackValue;
   } finally {
     await client.close?.();
   }

--- a/apps/web/lib/launchdarkly.ts
+++ b/apps/web/lib/launchdarkly.ts
@@ -1,0 +1,31 @@
+import { init as initLaunchDarkly } from "@netlify/launchdarkly-server-sdk";
+
+type LDContext = {
+  kind: string;
+  key: string;
+  [key: string]: string | number | boolean | undefined;
+};
+
+/**
+ * Evaluate a LaunchDarkly flag using Netlify's LaunchDarkly SDK.
+ * Returns fallbackValue when LaunchDarkly is not configured.
+ */
+export async function evaluateLaunchDarklyFlag(
+  flagKey: string,
+  context: LDContext,
+  fallbackValue = false,
+): Promise<boolean> {
+  const clientSideId = process.env.LAUNCHDARKLY_CLIENT_SIDE_ID;
+  if (!clientSideId) {
+    return fallbackValue;
+  }
+
+  const client = initLaunchDarkly(clientSideId);
+  await client.waitForInitialization();
+
+  try {
+    return await client.variation(flagKey, context, fallbackValue);
+  } finally {
+    await client.close?.();
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@datadog/browser-rum": "^6.32.0",
     "@infamous-freight/shared": "workspace:*",
+    "@netlify/launchdarkly-server-sdk": "^0.1.5",
     "@sentry/nextjs": "^10.47.0",
     "@stripe/react-stripe-js": "^6.1.0",
     "@stripe/stripe-js": "^9.1.0",

--- a/docs/ENV_SETUP_SECRETS_GUIDE.md
+++ b/docs/ENV_SETUP_SECRETS_GUIDE.md
@@ -51,6 +51,13 @@ If you are running a non-production drill with Stripe test credentials, set `ALL
 You can also run `VERIFY_ONLY=1` to skip writes and only run `netlify env:list` / `flyctl secrets list` checks.
 Stripe publishable/secret keys must use the same mode (`pk_live_` with `sk_live_`, or `pk_test_` with `sk_test_` when `ALLOW_TEST_KEYS=1`).
 
+### 3a) Decision tree
+
+- **Preview changes only**: `DRY_RUN=1 ./scripts/bootstrap-production-secrets.sh`
+- **Verify current provider state only**: `VERIFY_ONLY=1 ./scripts/bootstrap-production-secrets.sh`
+- **Non-production Stripe drill with test keys**: `ALLOW_TEST_KEYS=1 NETLIFY_CONTEXT=deploy-preview ./scripts/bootstrap-production-secrets.sh`
+- **Production apply**: `./scripts/bootstrap-production-secrets.sh` (with live Stripe keys)
+
 ### 4) Apply to Netlify environment
 
 ```bash
@@ -96,6 +103,14 @@ Supported Netlify contexts for this bootstrap script are `production`, `deploy-p
 1. In Netlify, enable the LaunchDarkly integration for your site and redeploy.
 2. In LaunchDarkly, add the Netlify integration and provide your Netlify Site ID and Syncing token from Netlify UI.
 3. Store `LAUNCHDARKLY_CLIENT_SIDE_ID` as an environment variable and bootstrap it with this script.
+
+### Troubleshooting quick map
+
+- `NETLIFY_SITE_ID must be a UUID` → copy Site ID from Netlify site settings and retry.
+- `NETLIFY_CONTEXT must be one of...` → use one of `production`, `deploy-preview`, `branch-deploy`.
+- `...must be a live key` → use `pk_live_...` / `sk_live_...` (or explicitly set `ALLOW_TEST_KEYS=1` for drills).
+- `Stripe key mode mismatch` → ensure publishable and secret keys are both `live` or both `test`.
+- `Required command not found` → install/authenticate `netlify` and `flyctl` CLIs first.
 
 ---
 

--- a/docs/ENV_SETUP_SECRETS_GUIDE.md
+++ b/docs/ENV_SETUP_SECRETS_GUIDE.md
@@ -13,7 +13,9 @@ Use this checklist when wiring production credentials for the current deployment
 | `FLY_API_TOKEN` | Fly.io CLI/API | required | Generate with `flyctl auth token`. |
 | `DATABASE_URL` | API + Prisma | required | Use the managed Postgres connection string with a real password. |
 | `NEXT_PUBLIC_API_URL` | Web frontend | required | Public API origin (for example `https://infamous.fly.dev`). |
-| `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | Stripe checkout UI | required | Must be the publishable key (`pk_...`), never a secret key. |
+| `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | Stripe checkout UI | required | Use live key (`pk_live_...`) for production bootstrap (`ALLOW_TEST_KEYS=1` only for drills). |
+| `STRIPE_SECRET_KEY` | Stripe server API | required | Use live key (`sk_live_...`) for production bootstrap (`ALLOW_TEST_KEYS=1` only for drills). |
+| `STRIPE_WEBHOOK_SECRET` | Stripe webhook verification | required | Signing secret for Stripe webhook validation (`whsec_...`). |
 | `JWT_SECRET` | API auth signing (HS256 mode + web stripe route) | required | Generate with `openssl rand -base64 32`. |
 
 ### 2) Export locally (do not commit secrets)
@@ -25,6 +27,8 @@ export FLY_API_TOKEN="$(flyctl auth token)"
 export DATABASE_URL="postgresql://postgres:<password>@<host>:5432/postgres?schema=public"
 export NEXT_PUBLIC_API_URL="https://infamous.fly.dev"
 export NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY="pk_live_..."
+export STRIPE_SECRET_KEY="sk_live_..."
+export STRIPE_WEBHOOK_SECRET="whsec_..."
 export JWT_SECRET="$(openssl rand -base64 32)"
 ```
 
@@ -40,12 +44,23 @@ Use `DRY_RUN=1` first to preview changes:
 DRY_RUN=1 ./scripts/bootstrap-production-secrets.sh
 ```
 
+If you are running a non-production drill with Stripe test credentials, set `ALLOW_TEST_KEYS=1` (only valid values are `0` or `1`).
+You can also run `VERIFY_ONLY=1` to skip writes and only run `netlify env:list` / `flyctl secrets list` checks.
+Stripe publishable/secret keys must use the same mode (`pk_live_` with `sk_live_`, or `pk_test_` with `sk_test_` when `ALLOW_TEST_KEYS=1`).
+
 ### 4) Apply to Netlify environment
 
 ```bash
-printf '%s' "$NEXT_PUBLIC_API_URL" | netlify env:set NEXT_PUBLIC_API_URL production
-printf '%s' "$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY" | netlify env:set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY production
-printf '%s' "$JWT_SECRET" | netlify env:set JWT_SECRET production
+env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
+  netlify env:set NEXT_PUBLIC_API_URL "$NEXT_PUBLIC_API_URL" --context production --site "$NETLIFY_SITE_ID"
+env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
+  netlify env:set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY "$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY" --context production --site "$NETLIFY_SITE_ID"
+env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
+  netlify env:set STRIPE_SECRET_KEY "$STRIPE_SECRET_KEY" --context production --site "$NETLIFY_SITE_ID"
+env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
+  netlify env:set STRIPE_WEBHOOK_SECRET "$STRIPE_WEBHOOK_SECRET" --context production --site "$NETLIFY_SITE_ID"
+env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
+  netlify env:set JWT_SECRET "$JWT_SECRET" --context production --site "$NETLIFY_SITE_ID"
 ```
 
 ### 5) Apply to Fly.io environment
@@ -54,15 +69,19 @@ printf '%s' "$JWT_SECRET" | netlify env:set JWT_SECRET production
 flyctl secrets set \
   DATABASE_URL="$DATABASE_URL" \
   JWT_SECRET="$JWT_SECRET" \
+  STRIPE_SECRET_KEY="$STRIPE_SECRET_KEY" \
+  STRIPE_WEBHOOK_SECRET="$STRIPE_WEBHOOK_SECRET" \
   --app infamous-freight-api
 ```
 
 ### 6) Post-setup verification
 
 ```bash
-netlify env:list --context production
+netlify env:list --context production --site "$NETLIFY_SITE_ID"
 flyctl secrets list --app infamous-freight-api
 ```
+
+Supported Netlify contexts for this bootstrap script are `production`, `deploy-preview`, and `branch-deploy`.
 
 > Security note: keep real token/key values in your secret manager and CI provider; commit only placeholders in tracked files.
 

--- a/docs/ENV_SETUP_SECRETS_GUIDE.md
+++ b/docs/ENV_SETUP_SECRETS_GUIDE.md
@@ -17,6 +17,7 @@ Use this checklist when wiring production credentials for the current deployment
 | `STRIPE_SECRET_KEY` | Stripe server API | required | Use live key (`sk_live_...`) for production bootstrap (`ALLOW_TEST_KEYS=1` only for drills). |
 | `STRIPE_WEBHOOK_SECRET` | Stripe webhook verification | required | Signing secret for Stripe webhook validation (`whsec_...`). |
 | `JWT_SECRET` | API auth signing (HS256 mode + web stripe route) | required | Generate with `openssl rand -base64 32`. |
+| `LAUNCHDARKLY_CLIENT_SIDE_ID` | LaunchDarkly flag evaluation | optional | Client-side ID used by Netlify LaunchDarkly SDK integration. |
 
 ### 2) Export locally (do not commit secrets)
 
@@ -30,6 +31,8 @@ export NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY="pk_live_..."
 export STRIPE_SECRET_KEY="sk_live_..."
 export STRIPE_WEBHOOK_SECRET="whsec_..."
 export JWT_SECRET="$(openssl rand -base64 32)"
+# Optional if using LaunchDarkly integration
+export LAUNCHDARKLY_CLIENT_SIDE_ID="<your-launchdarkly-client-side-id>"
 ```
 
 ### 3) Apply automatically with one script (recommended)
@@ -61,6 +64,8 @@ env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
   netlify env:set STRIPE_WEBHOOK_SECRET "$STRIPE_WEBHOOK_SECRET" --context production --site "$NETLIFY_SITE_ID"
 env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
   netlify env:set JWT_SECRET "$JWT_SECRET" --context production --site "$NETLIFY_SITE_ID"
+env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
+  netlify env:set LAUNCHDARKLY_CLIENT_SIDE_ID "$LAUNCHDARKLY_CLIENT_SIDE_ID" --context production --site "$NETLIFY_SITE_ID"
 ```
 
 ### 5) Apply to Fly.io environment
@@ -71,6 +76,7 @@ flyctl secrets set \
   JWT_SECRET="$JWT_SECRET" \
   STRIPE_SECRET_KEY="$STRIPE_SECRET_KEY" \
   STRIPE_WEBHOOK_SECRET="$STRIPE_WEBHOOK_SECRET" \
+  LAUNCHDARKLY_CLIENT_SIDE_ID="$LAUNCHDARKLY_CLIENT_SIDE_ID" \
   --app infamous-freight-api
 ```
 
@@ -84,6 +90,12 @@ flyctl secrets list --app infamous-freight-api
 Supported Netlify contexts for this bootstrap script are `production`, `deploy-preview`, and `branch-deploy`.
 
 > Security note: keep real token/key values in your secret manager and CI provider; commit only placeholders in tracked files.
+
+### LaunchDarkly Netlify integration notes
+
+1. In Netlify, enable the LaunchDarkly integration for your site and redeploy.
+2. In LaunchDarkly, add the Netlify integration and provide your Netlify Site ID and Syncing token from Netlify UI.
+3. Store `LAUNCHDARKLY_CLIENT_SIDE_ID` as an environment variable and bootstrap it with this script.
 
 ---
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,6 +251,9 @@ importers:
       '@infamous-freight/shared':
         specifier: workspace:*
         version: link:../../packages/shared
+      '@netlify/launchdarkly-server-sdk':
+        specifier: ^0.1.5
+        version: 0.1.5
       '@sentry/nextjs':
         specifier: ^10.47.0
         version: 10.47.0(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.105.4)
@@ -2031,8 +2034,17 @@ packages:
   '@launchdarkly/js-sdk-common@2.24.0':
     resolution: {integrity: sha512-f/xRD8gl/bSOVljat79nAzX0V0QjJ76R54aAbB6PJDWL+7BWBSFMxduaeokzbX53cs3oOVajL8ej/ps7+ojMeQ==}
 
+  '@launchdarkly/js-sdk-common@2.8.0':
+    resolution: {integrity: sha512-XLYhB0A0vec1gwbnVNU+rzMd1JxdtMJXSA76y3ASJ6X0cG0qTRKQdFba4n4RwIs0y1bX3rncFHJMhBjrXtyPhA==}
+
+  '@launchdarkly/js-server-sdk-common-edge@2.3.9':
+    resolution: {integrity: sha512-pgQatwvb3WKBdaSpZPDdv1whmTUuuYmJlVu/XdgEFFLd5r90Ixf4LZXmNyGW6+x1VEDgxj9kOkbUfSGJf0EO0g==}
+
   '@launchdarkly/js-server-sdk-common@2.18.3':
     resolution: {integrity: sha512-9lf1IRLJSghtDZlUT04KmmJOwRnAUuqXUcn7C2S9jNPDvrsmFJeD9Dpn7PoCUOR5rZgqAEveWdlBw9qjWeY6jw==}
+
+  '@launchdarkly/js-server-sdk-common@2.6.1':
+    resolution: {integrity: sha512-PcyglkUi/P1fBT3GqwZ/K9MvLj2e5Rw5XLP/gC2qIIHJxIbni8oy8Zon+6bP890DYgZtqqeX6tKhAw/gwOYkhQ==}
 
   '@launchdarkly/node-server-sdk@9.10.10':
     resolution: {integrity: sha512-qJNVrHbX+FKUhVUl7FWK9ICsL4lJmHBE7vOCkvERFFODRxYrrf8HdiyYDf79aI8JMSOLCKZgcJJKNXAvRJXThg==}
@@ -2069,6 +2081,13 @@ packages:
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
+
+  '@netlify/blobs@8.2.0':
+    resolution: {integrity: sha512-9djLZHBKsoKk8XCgwWSEPK9QnT8qqxEQGuYh48gFIcNLvpBKkLnHbDZuyUxmNemCfDz7h0HnMXgSPnnUVgARhg==}
+    engines: {node: ^14.16.0 || >=16.0.0}
+
+  '@netlify/launchdarkly-server-sdk@0.1.5':
+    resolution: {integrity: sha512-/IHNwM1cz3s01OQYbOgiUNeXFVkGnZv+4Rj/7rtyGKb+b/jBXHsqySHbzDZ1M67DyUT8086yhsGua2ru/7q4vA==}
 
   '@next/env@16.2.2':
     resolution: {integrity: sha512-LqSGz5+xGk9EL/iBDr2yo/CgNQV6cFsNhRR2xhSXYh7B/hb4nePCxlmDvGEKG30NMHDFf0raqSyOZiQrO7BkHQ==}
@@ -4695,6 +4714,9 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  crypto-js@4.2.0:
+    resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
 
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
@@ -10665,9 +10687,21 @@ snapshots:
 
   '@launchdarkly/js-sdk-common@2.24.0': {}
 
+  '@launchdarkly/js-sdk-common@2.8.0': {}
+
+  '@launchdarkly/js-server-sdk-common-edge@2.3.9':
+    dependencies:
+      '@launchdarkly/js-server-sdk-common': 2.6.1
+      crypto-js: 4.2.0
+
   '@launchdarkly/js-server-sdk-common@2.18.3':
     dependencies:
       '@launchdarkly/js-sdk-common': 2.24.0
+      semver: 7.5.4
+
+  '@launchdarkly/js-server-sdk-common@2.6.1':
+    dependencies:
+      '@launchdarkly/js-sdk-common': 2.8.0
       semver: 7.5.4
 
   '@launchdarkly/node-server-sdk@9.10.10':
@@ -10702,6 +10736,14 @@ snapshots:
       '@emnapi/runtime': 1.9.2
       '@tybys/wasm-util': 0.10.1
     optional: true
+
+  '@netlify/blobs@8.2.0': {}
+
+  '@netlify/launchdarkly-server-sdk@0.1.5':
+    dependencies:
+      '@launchdarkly/js-server-sdk-common-edge': 2.3.9
+      '@netlify/blobs': 8.2.0
+      crypto-js: 4.2.0
 
   '@next/env@16.2.2': {}
 
@@ -13918,6 +13960,8 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  crypto-js@4.2.0: {}
 
   css-tree@3.2.1:
     dependencies:

--- a/scripts/bootstrap-production-secrets.sh
+++ b/scripts/bootstrap-production-secrets.sh
@@ -20,6 +20,7 @@ Optional environment variables:
   FLY_APP_NAME         (default: infamous-freight-api)
   NETLIFY_CONTEXT      (default: production)
   ALLOW_TEST_KEYS      (set to 1 to allow Stripe test keys for non-prod drills)
+  LAUNCHDARKLY_CLIENT_SIDE_ID (optional; if set, applied to Netlify/Fly)
   VERIFY_ONLY          (set to 1 to only run post-apply verification checks)
   DRY_RUN              (set to 1 to print actions without applying)
 
@@ -42,6 +43,7 @@ VERIFY_ONLY="${VERIFY_ONLY:-0}"
 NETLIFY_CONTEXT="${NETLIFY_CONTEXT:-production}"
 FLY_APP_NAME="${FLY_APP_NAME:-infamous-freight-api}"
 DRY_RUN="${DRY_RUN:-0}"
+LAUNCHDARKLY_CLIENT_SIDE_ID="${LAUNCHDARKLY_CLIENT_SIDE_ID:-}"
 
 if [[ "$ALLOW_TEST_KEYS" != "0" && "$ALLOW_TEST_KEYS" != "1" ]]; then
   echo "[bootstrap-secrets] ALLOW_TEST_KEYS must be 0 or 1" >&2
@@ -153,6 +155,11 @@ if [[ ${#JWT_SECRET} -lt 32 ]]; then
   exit 1
 fi
 
+if [[ -n "$LAUNCHDARKLY_CLIENT_SIDE_ID" && ${#LAUNCHDARKLY_CLIENT_SIDE_ID} -lt 6 ]]; then
+  echo "[bootstrap-secrets] LAUNCHDARKLY_CLIENT_SIDE_ID looks invalid (too short)" >&2
+  exit 1
+fi
+
 if [[ "$VERIFY_ONLY" == "1" ]]; then
   echo "[bootstrap-secrets] VERIFY_ONLY=1: skipping apply steps and running verification checks."
   if [[ "$DRY_RUN" == "1" ]]; then
@@ -172,6 +179,9 @@ if [[ "$DRY_RUN" == "1" ]]; then
   echo "[dry-run] env NETLIFY_AUTH_TOKEN=*** netlify env:set STRIPE_SECRET_KEY \"\$STRIPE_SECRET_KEY\" --context ${NETLIFY_CONTEXT} --site ***"
   echo "[dry-run] env NETLIFY_AUTH_TOKEN=*** netlify env:set STRIPE_WEBHOOK_SECRET \"\$STRIPE_WEBHOOK_SECRET\" --context ${NETLIFY_CONTEXT} --site ***"
   echo "[dry-run] env NETLIFY_AUTH_TOKEN=*** netlify env:set JWT_SECRET \"\$JWT_SECRET\" --context ${NETLIFY_CONTEXT} --site ***"
+  if [[ -n "$LAUNCHDARKLY_CLIENT_SIDE_ID" ]]; then
+    echo "[dry-run] env NETLIFY_AUTH_TOKEN=*** netlify env:set LAUNCHDARKLY_CLIENT_SIDE_ID \"\$LAUNCHDARKLY_CLIENT_SIDE_ID\" --context ${NETLIFY_CONTEXT} --site ***"
+  fi
 else
   env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
     netlify env:set NEXT_PUBLIC_API_URL "$NEXT_PUBLIC_API_URL" --context "$NETLIFY_CONTEXT" --site "$NETLIFY_SITE_ID"
@@ -183,18 +193,32 @@ else
     netlify env:set STRIPE_WEBHOOK_SECRET "$STRIPE_WEBHOOK_SECRET" --context "$NETLIFY_CONTEXT" --site "$NETLIFY_SITE_ID"
   env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
     netlify env:set JWT_SECRET "$JWT_SECRET" --context "$NETLIFY_CONTEXT" --site "$NETLIFY_SITE_ID"
+  if [[ -n "$LAUNCHDARKLY_CLIENT_SIDE_ID" ]]; then
+    env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
+      netlify env:set LAUNCHDARKLY_CLIENT_SIDE_ID "$LAUNCHDARKLY_CLIENT_SIDE_ID" --context "$NETLIFY_CONTEXT" --site "$NETLIFY_SITE_ID"
+  fi
 fi
 
 echo "[bootstrap-secrets] Applying Fly.io secrets to app '${FLY_APP_NAME}'."
 if [[ "$DRY_RUN" == "1" ]]; then
-  echo "[dry-run] env FLY_API_TOKEN=*** flyctl secrets set DATABASE_URL=\"\$DATABASE_URL\" JWT_SECRET=\"\$JWT_SECRET\" STRIPE_SECRET_KEY=\"\$STRIPE_SECRET_KEY\" STRIPE_WEBHOOK_SECRET=\"\$STRIPE_WEBHOOK_SECRET\" --app ${FLY_APP_NAME}"
+  echo "[dry-run] env FLY_API_TOKEN=*** flyctl secrets set DATABASE_URL=\"\$DATABASE_URL\" JWT_SECRET=\"\$JWT_SECRET\" STRIPE_SECRET_KEY=\"\$STRIPE_SECRET_KEY\" STRIPE_WEBHOOK_SECRET=\"\$STRIPE_WEBHOOK_SECRET\"${LAUNCHDARKLY_CLIENT_SIDE_ID:+ LAUNCHDARKLY_CLIENT_SIDE_ID=\"\$LAUNCHDARKLY_CLIENT_SIDE_ID\"} --app ${FLY_APP_NAME}"
 else
-  env FLY_API_TOKEN="$FLY_API_TOKEN" flyctl secrets set \
-    DATABASE_URL="$DATABASE_URL" \
-    JWT_SECRET="$JWT_SECRET" \
-    STRIPE_SECRET_KEY="$STRIPE_SECRET_KEY" \
-    STRIPE_WEBHOOK_SECRET="$STRIPE_WEBHOOK_SECRET" \
-    --app "$FLY_APP_NAME"
+  if [[ -n "$LAUNCHDARKLY_CLIENT_SIDE_ID" ]]; then
+    env FLY_API_TOKEN="$FLY_API_TOKEN" flyctl secrets set \
+      DATABASE_URL="$DATABASE_URL" \
+      JWT_SECRET="$JWT_SECRET" \
+      STRIPE_SECRET_KEY="$STRIPE_SECRET_KEY" \
+      STRIPE_WEBHOOK_SECRET="$STRIPE_WEBHOOK_SECRET" \
+      LAUNCHDARKLY_CLIENT_SIDE_ID="$LAUNCHDARKLY_CLIENT_SIDE_ID" \
+      --app "$FLY_APP_NAME"
+  else
+    env FLY_API_TOKEN="$FLY_API_TOKEN" flyctl secrets set \
+      DATABASE_URL="$DATABASE_URL" \
+      JWT_SECRET="$JWT_SECRET" \
+      STRIPE_SECRET_KEY="$STRIPE_SECRET_KEY" \
+      STRIPE_WEBHOOK_SECRET="$STRIPE_WEBHOOK_SECRET" \
+      --app "$FLY_APP_NAME"
+  fi
 fi
 
 echo "[bootstrap-secrets] Done. Verify with:"

--- a/scripts/bootstrap-production-secrets.sh
+++ b/scripts/bootstrap-production-secrets.sh
@@ -12,17 +12,22 @@ Required environment variables:
   DATABASE_URL
   NEXT_PUBLIC_API_URL
   NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
+  STRIPE_SECRET_KEY
+  STRIPE_WEBHOOK_SECRET
   JWT_SECRET
 
 Optional environment variables:
   FLY_APP_NAME         (default: infamous-freight-api)
   NETLIFY_CONTEXT      (default: production)
+  ALLOW_TEST_KEYS      (set to 1 to allow Stripe test keys for non-prod drills)
+  VERIFY_ONLY          (set to 1 to only run post-apply verification checks)
   DRY_RUN              (set to 1 to print actions without applying)
 
 Example:
   NETLIFY_AUTH_TOKEN=... NETLIFY_SITE_ID=... FLY_API_TOKEN=... \
   DATABASE_URL=... NEXT_PUBLIC_API_URL=https://infamous.fly.dev \
-  NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_live_... JWT_SECRET=$(openssl rand -base64 32) \
+  NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_live_... STRIPE_SECRET_KEY=sk_live_... \
+  STRIPE_WEBHOOK_SECRET=whsec_... JWT_SECRET=$(openssl rand -base64 32) \
   ./scripts/bootstrap-production-secrets.sh
 USAGE
 }
@@ -30,6 +35,22 @@ USAGE
 if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
   usage
   exit 0
+fi
+
+ALLOW_TEST_KEYS="${ALLOW_TEST_KEYS:-0}"
+VERIFY_ONLY="${VERIFY_ONLY:-0}"
+NETLIFY_CONTEXT="${NETLIFY_CONTEXT:-production}"
+FLY_APP_NAME="${FLY_APP_NAME:-infamous-freight-api}"
+DRY_RUN="${DRY_RUN:-0}"
+
+if [[ "$ALLOW_TEST_KEYS" != "0" && "$ALLOW_TEST_KEYS" != "1" ]]; then
+  echo "[bootstrap-secrets] ALLOW_TEST_KEYS must be 0 or 1" >&2
+  exit 1
+fi
+
+if [[ "$VERIFY_ONLY" != "0" && "$VERIFY_ONLY" != "1" ]]; then
+  echo "[bootstrap-secrets] VERIFY_ONLY must be 0 or 1" >&2
+  exit 1
 fi
 
 require_var() {
@@ -54,12 +75,24 @@ required_vars=(
   DATABASE_URL
   NEXT_PUBLIC_API_URL
   NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
+  STRIPE_SECRET_KEY
+  STRIPE_WEBHOOK_SECRET
   JWT_SECRET
 )
 
 for var_name in "${required_vars[@]}"; do
   require_var "$var_name"
 done
+
+if [[ ! "${NETLIFY_SITE_ID}" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ ]]; then
+  echo "[bootstrap-secrets] NETLIFY_SITE_ID must be a UUID" >&2
+  exit 1
+fi
+
+if [[ ! "${NETLIFY_CONTEXT}" =~ ^(production|deploy-preview|branch-deploy)$ ]]; then
+  echo "[bootstrap-secrets] NETLIFY_CONTEXT must be one of: production, deploy-preview, branch-deploy" >&2
+  exit 1
+fi
 
 if [[ ! "${DATABASE_URL}" =~ ^postgres(ql)?:// ]]; then
   echo "[bootstrap-secrets] DATABASE_URL must start with postgres:// or postgresql://" >&2
@@ -76,44 +109,94 @@ if [[ ! "${NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY}" =~ ^pk_(live|test)_ ]]; then
   exit 1
 fi
 
+if [[ ! "${STRIPE_SECRET_KEY}" =~ ^sk_(live|test)_ ]]; then
+  echo "[bootstrap-secrets] STRIPE_SECRET_KEY must be a Stripe secret key" >&2
+  exit 1
+fi
+
+if [[ ! "${STRIPE_WEBHOOK_SECRET}" =~ ^whsec_ ]]; then
+  echo "[bootstrap-secrets] STRIPE_WEBHOOK_SECRET must be a Stripe webhook signing secret" >&2
+  exit 1
+fi
+
+if [[ "$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY" =~ ^pk_(live|test)_ ]]; then
+  publishable_mode="${BASH_REMATCH[1]}"
+else
+  publishable_mode=""
+fi
+
+if [[ "$STRIPE_SECRET_KEY" =~ ^sk_(live|test)_ ]]; then
+  secret_mode="${BASH_REMATCH[1]}"
+else
+  secret_mode=""
+fi
+
+if [[ "$publishable_mode" != "$secret_mode" ]]; then
+  echo "[bootstrap-secrets] Stripe key mode mismatch: NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY and STRIPE_SECRET_KEY must both be live or both be test" >&2
+  exit 1
+fi
+
+if [[ "$ALLOW_TEST_KEYS" != "1" ]]; then
+  if [[ ! "${NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY}" =~ ^pk_live_ ]]; then
+    echo "[bootstrap-secrets] NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY must be a live key (set ALLOW_TEST_KEYS=1 to bypass)" >&2
+    exit 1
+  fi
+
+  if [[ ! "${STRIPE_SECRET_KEY}" =~ ^sk_live_ ]]; then
+    echo "[bootstrap-secrets] STRIPE_SECRET_KEY must be a live key (set ALLOW_TEST_KEYS=1 to bypass)" >&2
+    exit 1
+  fi
+fi
+
 if [[ ${#JWT_SECRET} -lt 32 ]]; then
   echo "[bootstrap-secrets] JWT_SECRET must be at least 32 characters" >&2
   exit 1
 fi
 
-FLY_APP_NAME="${FLY_APP_NAME:-infamous-freight-api}"
-NETLIFY_CONTEXT="${NETLIFY_CONTEXT:-production}"
-DRY_RUN="${DRY_RUN:-0}"
-
-run_cmd() {
+if [[ "$VERIFY_ONLY" == "1" ]]; then
+  echo "[bootstrap-secrets] VERIFY_ONLY=1: skipping apply steps and running verification checks."
   if [[ "$DRY_RUN" == "1" ]]; then
-    echo "[dry-run] $*"
+    echo "[dry-run] env NETLIFY_AUTH_TOKEN=*** netlify env:list --context ${NETLIFY_CONTEXT} --site ***"
+    echo "[dry-run] env FLY_API_TOKEN=*** flyctl secrets list --app ${FLY_APP_NAME}"
   else
-    "$@"
+    env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" netlify env:list --context "$NETLIFY_CONTEXT" --site "$NETLIFY_SITE_ID"
+    env FLY_API_TOKEN="$FLY_API_TOKEN" flyctl secrets list --app "$FLY_APP_NAME"
   fi
-}
+  exit 0
+fi
 
-echo "[bootstrap-secrets] Applying Netlify env vars to context '${NETLIFY_CONTEXT}' for site '${NETLIFY_SITE_ID}'."
+echo "[bootstrap-secrets] Applying Netlify env vars to context '${NETLIFY_CONTEXT}' for site '***'."
 if [[ "$DRY_RUN" == "1" ]]; then
-  echo "[dry-run] printf '%s' \"\$NEXT_PUBLIC_API_URL\" | netlify env:set NEXT_PUBLIC_API_URL ${NETLIFY_CONTEXT}"
-  echo "[dry-run] printf '%s' \"\$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY\" | netlify env:set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ${NETLIFY_CONTEXT}"
-  echo "[dry-run] printf '%s' \"\$JWT_SECRET\" | netlify env:set JWT_SECRET ${NETLIFY_CONTEXT}"
+  echo "[dry-run] env NETLIFY_AUTH_TOKEN=*** netlify env:set NEXT_PUBLIC_API_URL \"\$NEXT_PUBLIC_API_URL\" --context ${NETLIFY_CONTEXT} --site ***"
+  echo "[dry-run] env NETLIFY_AUTH_TOKEN=*** netlify env:set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY \"\$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY\" --context ${NETLIFY_CONTEXT} --site ***"
+  echo "[dry-run] env NETLIFY_AUTH_TOKEN=*** netlify env:set STRIPE_SECRET_KEY \"\$STRIPE_SECRET_KEY\" --context ${NETLIFY_CONTEXT} --site ***"
+  echo "[dry-run] env NETLIFY_AUTH_TOKEN=*** netlify env:set STRIPE_WEBHOOK_SECRET \"\$STRIPE_WEBHOOK_SECRET\" --context ${NETLIFY_CONTEXT} --site ***"
+  echo "[dry-run] env NETLIFY_AUTH_TOKEN=*** netlify env:set JWT_SECRET \"\$JWT_SECRET\" --context ${NETLIFY_CONTEXT} --site ***"
 else
-  printf '%s' "$NEXT_PUBLIC_API_URL" | env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" netlify env:set NEXT_PUBLIC_API_URL "$NETLIFY_CONTEXT"
-  printf '%s' "$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY" | env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" netlify env:set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY "$NETLIFY_CONTEXT"
-  printf '%s' "$JWT_SECRET" | env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" NETLIFY_SITE_ID="$NETLIFY_SITE_ID" netlify env:set JWT_SECRET "$NETLIFY_CONTEXT"
+  env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
+    netlify env:set NEXT_PUBLIC_API_URL "$NEXT_PUBLIC_API_URL" --context "$NETLIFY_CONTEXT" --site "$NETLIFY_SITE_ID"
+  env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
+    netlify env:set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY "$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY" --context "$NETLIFY_CONTEXT" --site "$NETLIFY_SITE_ID"
+  env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
+    netlify env:set STRIPE_SECRET_KEY "$STRIPE_SECRET_KEY" --context "$NETLIFY_CONTEXT" --site "$NETLIFY_SITE_ID"
+  env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
+    netlify env:set STRIPE_WEBHOOK_SECRET "$STRIPE_WEBHOOK_SECRET" --context "$NETLIFY_CONTEXT" --site "$NETLIFY_SITE_ID"
+  env NETLIFY_AUTH_TOKEN="$NETLIFY_AUTH_TOKEN" \
+    netlify env:set JWT_SECRET "$JWT_SECRET" --context "$NETLIFY_CONTEXT" --site "$NETLIFY_SITE_ID"
 fi
 
 echo "[bootstrap-secrets] Applying Fly.io secrets to app '${FLY_APP_NAME}'."
 if [[ "$DRY_RUN" == "1" ]]; then
-  echo "[dry-run] env FLY_API_TOKEN=*** flyctl secrets set DATABASE_URL=\"\$DATABASE_URL\" JWT_SECRET=\"\$JWT_SECRET\" --app ${FLY_APP_NAME}"
+  echo "[dry-run] env FLY_API_TOKEN=*** flyctl secrets set DATABASE_URL=\"\$DATABASE_URL\" JWT_SECRET=\"\$JWT_SECRET\" STRIPE_SECRET_KEY=\"\$STRIPE_SECRET_KEY\" STRIPE_WEBHOOK_SECRET=\"\$STRIPE_WEBHOOK_SECRET\" --app ${FLY_APP_NAME}"
 else
   env FLY_API_TOKEN="$FLY_API_TOKEN" flyctl secrets set \
     DATABASE_URL="$DATABASE_URL" \
     JWT_SECRET="$JWT_SECRET" \
+    STRIPE_SECRET_KEY="$STRIPE_SECRET_KEY" \
+    STRIPE_WEBHOOK_SECRET="$STRIPE_WEBHOOK_SECRET" \
     --app "$FLY_APP_NAME"
 fi
 
 echo "[bootstrap-secrets] Done. Verify with:"
-echo "  NETLIFY_AUTH_TOKEN=*** NETLIFY_SITE_ID=*** netlify env:list --context ${NETLIFY_CONTEXT}"
+echo "  NETLIFY_AUTH_TOKEN=*** netlify env:list --context ${NETLIFY_CONTEXT} --site ***"
 echo "  FLY_API_TOKEN=*** flyctl secrets list --app ${FLY_APP_NAME}"

--- a/tests/ci/bootstrap-production-secrets.test.sh
+++ b/tests/ci/bootstrap-production-secrets.test.sh
@@ -247,6 +247,27 @@ assert_contains "verify-only mode prints skip message" "$verify_only_output" "VE
 assert_contains "verify-only mode lists netlify env" "$verify_only_output" "netlify env:list --context production --site 11111111-2222-3333-4444-555555555555"
 assert_contains "verify-only mode lists fly secrets" "$verify_only_output" "flyctl secrets list --app infamous-freight-api"
 
+VERIFY_ONLY_ENV=()
+for env_var in "${BASE_ENV[@]}"; do
+  case "$env_var" in
+    DATABASE_URL=*|JWT_SECRET=*|STRIPE_SECRET_KEY=*|STRIPE_WEBHOOK_SECRET=*|NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=*)
+      ;;
+    *)
+      VERIFY_ONLY_ENV+=("$env_var")
+      ;;
+  esac
+done
+
+set +e
+verify_only_without_secrets_output="$(env "${VERIFY_ONLY_ENV[@]}" VERIFY_ONLY=1 "$SCRIPT" 2>&1)"
+verify_only_without_secrets_code=$?
+set -e
+assert_eq "verify-only mode without apply-time secrets exits zero" "0" "$verify_only_without_secrets_code"
+assert_contains "verify-only mode without apply-time secrets prints skip message" "$verify_only_without_secrets_output" "VERIFY_ONLY=1: skipping apply steps"
+assert_contains "verify-only mode without apply-time secrets lists netlify env" "$verify_only_without_secrets_output" "netlify env:list --context production --site 11111111-2222-3333-4444-555555555555"
+assert_contains "verify-only mode without apply-time secrets lists fly secrets" "$verify_only_without_secrets_output" "flyctl secrets list --app infamous-freight-api"
+assert_not_contains "verify-only mode without apply-time secrets does not run netlify apply" "$verify_only_without_secrets_output" "netlify env:set"
+assert_not_contains "verify-only mode without apply-time secrets does not run fly apply" "$verify_only_without_secrets_output" "flyctl secrets set"
 set +e
 verify_only_dry_run_output="$(env "${BASE_ENV[@]}" VERIFY_ONLY=1 DRY_RUN=1 "$SCRIPT" 2>&1)"
 verify_only_dry_run_code=$?

--- a/tests/ci/bootstrap-production-secrets.test.sh
+++ b/tests/ci/bootstrap-production-secrets.test.sh
@@ -85,6 +85,42 @@ assert_eq "missing vars exits non-zero" "1" "$missing_code"
 assert_contains "missing vars prints specific var" "$missing_output" "Missing required env var"
 
 set +e
+TMP_DIR_NO_NETLIFY="$(mktemp -d)"
+cp "$TMP_DIR/flyctl" "$TMP_DIR_NO_NETLIFY/flyctl"
+chmod +x "$TMP_DIR_NO_NETLIFY/flyctl"
+missing_netlify_output="$(env \
+  PATH="$TMP_DIR_NO_NETLIFY:/usr/bin:/bin" \
+  NETLIFY_AUTH_TOKEN=test-netlify-token \
+  NETLIFY_SITE_ID=11111111-2222-3333-4444-555555555555 \
+  FLY_API_TOKEN=test-fly-token \
+  DATABASE_URL=postgresql://postgres:pw@localhost:5432/postgres?schema=public \
+  NEXT_PUBLIC_API_URL=https://infamous.fly.dev \
+  NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_live_test \
+  STRIPE_SECRET_KEY=sk_live_test \
+  STRIPE_WEBHOOK_SECRET=whsec_test \
+  JWT_SECRET=abcdefghijklmnopqrstuvwxyz123456 \
+  "$SCRIPT" 2>&1)"
+missing_netlify_code=$?
+set -e
+assert_eq "missing netlify command exits non-zero" "1" "$missing_netlify_code"
+assert_contains "missing netlify command has explicit message" "$missing_netlify_output" "Required command not found: netlify"
+rm -rf "$TMP_DIR_NO_NETLIFY"
+
+set +e
+context_deploy_preview_output="$(env "${BASE_ENV[@]}" NETLIFY_CONTEXT=deploy-preview DRY_RUN=1 "$SCRIPT" 2>&1)"
+context_deploy_preview_code=$?
+set -e
+assert_eq "deploy-preview context exits zero" "0" "$context_deploy_preview_code"
+assert_contains "deploy-preview context appears in dry-run output" "$context_deploy_preview_output" "--context deploy-preview"
+
+set +e
+context_branch_deploy_output="$(env "${BASE_ENV[@]}" NETLIFY_CONTEXT=branch-deploy DRY_RUN=1 "$SCRIPT" 2>&1)"
+context_branch_deploy_code=$?
+set -e
+assert_eq "branch-deploy context exits zero" "0" "$context_branch_deploy_code"
+assert_contains "branch-deploy context appears in dry-run output" "$context_branch_deploy_output" "--context branch-deploy"
+
+set +e
 invalid_url_output="$(env "${BASE_ENV[@]}" NEXT_PUBLIC_API_URL=http://insecure.example "$SCRIPT" 2>&1)"
 invalid_url_code=$?
 set -e
@@ -210,6 +246,16 @@ assert_eq "verify-only mode exits zero" "0" "$verify_only_code"
 assert_contains "verify-only mode prints skip message" "$verify_only_output" "VERIFY_ONLY=1: skipping apply steps"
 assert_contains "verify-only mode lists netlify env" "$verify_only_output" "netlify env:list --context production --site 11111111-2222-3333-4444-555555555555"
 assert_contains "verify-only mode lists fly secrets" "$verify_only_output" "flyctl secrets list --app infamous-freight-api"
+
+set +e
+verify_only_dry_run_output="$(env "${BASE_ENV[@]}" VERIFY_ONLY=1 DRY_RUN=1 "$SCRIPT" 2>&1)"
+verify_only_dry_run_code=$?
+set -e
+assert_eq "verify-only dry-run exits zero" "0" "$verify_only_dry_run_code"
+assert_contains "verify-only dry-run prints netlify list command" "$verify_only_dry_run_output" "netlify env:list --context production --site ***"
+assert_contains "verify-only dry-run prints fly list command" "$verify_only_dry_run_output" "flyctl secrets list --app infamous-freight-api"
+assert_not_contains "verify-only dry-run does not apply netlify env:set" "$verify_only_dry_run_output" "netlify env:set"
+assert_not_contains "verify-only dry-run does not apply fly secrets set" "$verify_only_dry_run_output" "flyctl secrets set"
 
 set +e
 ld_apply_output="$(env "${BASE_ENV[@]}" LAUNCHDARKLY_CLIENT_SIDE_ID=client-side-id-123 "$SCRIPT" 2>&1)"

--- a/tests/ci/bootstrap-production-secrets.test.sh
+++ b/tests/ci/bootstrap-production-secrets.test.sh
@@ -162,6 +162,13 @@ assert_eq "short jwt exits non-zero" "1" "$short_jwt_code"
 assert_contains "short jwt has explicit message" "$short_jwt_output" "JWT_SECRET must be at least 32 characters"
 
 set +e
+invalid_ld_id_output="$(env "${BASE_ENV[@]}" LAUNCHDARKLY_CLIENT_SIDE_ID=abc "$SCRIPT" 2>&1)"
+invalid_ld_id_code=$?
+set -e
+assert_eq "invalid launchdarkly client side id exits non-zero" "1" "$invalid_ld_id_code"
+assert_contains "invalid launchdarkly client side id has explicit message" "$invalid_ld_id_output" "LAUNCHDARKLY_CLIENT_SIDE_ID looks invalid"
+
+set +e
 allow_test_keys_output="$(env "${BASE_ENV[@]}" NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_123 STRIPE_SECRET_KEY=sk_test_123 ALLOW_TEST_KEYS=1 DRY_RUN=1 "$SCRIPT" 2>&1)"
 allow_test_keys_code=$?
 set -e
@@ -203,6 +210,14 @@ assert_eq "verify-only mode exits zero" "0" "$verify_only_code"
 assert_contains "verify-only mode prints skip message" "$verify_only_output" "VERIFY_ONLY=1: skipping apply steps"
 assert_contains "verify-only mode lists netlify env" "$verify_only_output" "netlify env:list --context production --site 11111111-2222-3333-4444-555555555555"
 assert_contains "verify-only mode lists fly secrets" "$verify_only_output" "flyctl secrets list --app infamous-freight-api"
+
+set +e
+ld_apply_output="$(env "${BASE_ENV[@]}" LAUNCHDARKLY_CLIENT_SIDE_ID=client-side-id-123 "$SCRIPT" 2>&1)"
+ld_apply_code=$?
+set -e
+assert_eq "launchdarkly id apply mode exits zero" "0" "$ld_apply_code"
+assert_contains "launchdarkly id apply mode sets netlify env var" "$ld_apply_output" "netlify env:set LAUNCHDARKLY_CLIENT_SIDE_ID client-side-id-123 --context production --site 11111111-2222-3333-4444-555555555555"
+assert_contains "launchdarkly id apply mode sets fly secret" "$ld_apply_output" "LAUNCHDARKLY_CLIENT_SIDE_ID=client-side-id-123 --app infamous-freight-api"
 
 if [ "$FAIL" -gt 0 ]; then
   echo ""

--- a/tests/ci/bootstrap-production-secrets.test.sh
+++ b/tests/ci/bootstrap-production-secrets.test.sh
@@ -18,6 +18,17 @@ assert_contains() {
   fi
 }
 
+assert_not_contains() {
+  local description="$1"
+  local haystack="$2"
+  local needle="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    fail "$description (did not expect '$needle')"
+  else
+    pass "$description"
+  fi
+}
+
 assert_eq() {
   local description="$1"
   local expected="$2"
@@ -51,11 +62,13 @@ chmod +x "$TMP_DIR/netlify" "$TMP_DIR/flyctl"
 BASE_ENV=(
   "PATH=$TMP_DIR:$PATH"
   "NETLIFY_AUTH_TOKEN=test-netlify-token"
-  "NETLIFY_SITE_ID=test-site-id"
+  "NETLIFY_SITE_ID=11111111-2222-3333-4444-555555555555"
   "FLY_API_TOKEN=test-fly-token"
   "DATABASE_URL=postgresql://postgres:pw@localhost:5432/postgres?schema=public"
   "NEXT_PUBLIC_API_URL=https://infamous.fly.dev"
   "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_live_test"
+  "STRIPE_SECRET_KEY=sk_live_test"
+  "STRIPE_WEBHOOK_SECRET=whsec_test"
   "JWT_SECRET=abcdefghijklmnopqrstuvwxyz123456"
 )
 
@@ -79,12 +92,117 @@ assert_eq "http api url exits non-zero" "1" "$invalid_url_code"
 assert_contains "http api url has explicit message" "$invalid_url_output" "NEXT_PUBLIC_API_URL must be https:// in production"
 
 set +e
+invalid_db_output="$(env "${BASE_ENV[@]}" DATABASE_URL=mysql://localhost/db "$SCRIPT" 2>&1)"
+invalid_db_code=$?
+set -e
+assert_eq "invalid database url exits non-zero" "1" "$invalid_db_code"
+assert_contains "invalid database url has explicit message" "$invalid_db_output" "DATABASE_URL must start with postgres:// or postgresql://"
+
+set +e
+invalid_site_id_output="$(env "${BASE_ENV[@]}" NETLIFY_SITE_ID=not-a-uuid "$SCRIPT" 2>&1)"
+invalid_site_id_code=$?
+set -e
+assert_eq "invalid netlify site id exits non-zero" "1" "$invalid_site_id_code"
+assert_contains "invalid netlify site id has explicit message" "$invalid_site_id_output" "NETLIFY_SITE_ID must be a UUID"
+
+set +e
+invalid_context_output="$(env "${BASE_ENV[@]}" NETLIFY_CONTEXT=staging "$SCRIPT" 2>&1)"
+invalid_context_code=$?
+set -e
+assert_eq "invalid netlify context exits non-zero" "1" "$invalid_context_code"
+assert_contains "invalid netlify context has explicit message" "$invalid_context_output" "NETLIFY_CONTEXT must be one of: production, deploy-preview, branch-deploy"
+
+set +e
+invalid_stripe_secret_output="$(env "${BASE_ENV[@]}" STRIPE_SECRET_KEY=pk_live_wrong "$SCRIPT" 2>&1)"
+invalid_stripe_secret_code=$?
+set -e
+assert_eq "invalid stripe secret exits non-zero" "1" "$invalid_stripe_secret_code"
+assert_contains "invalid stripe secret has explicit message" "$invalid_stripe_secret_output" "STRIPE_SECRET_KEY must be a Stripe secret key"
+
+set +e
+invalid_webhook_secret_output="$(env "${BASE_ENV[@]}" STRIPE_WEBHOOK_SECRET=secret_wrong "$SCRIPT" 2>&1)"
+invalid_webhook_secret_code=$?
+set -e
+assert_eq "invalid webhook secret exits non-zero" "1" "$invalid_webhook_secret_code"
+assert_contains "invalid webhook secret has explicit message" "$invalid_webhook_secret_output" "STRIPE_WEBHOOK_SECRET must be a Stripe webhook signing secret"
+
+set +e
+mismatched_stripe_modes_output="$(env "${BASE_ENV[@]}" NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_live_123 STRIPE_SECRET_KEY=sk_test_123 ALLOW_TEST_KEYS=1 "$SCRIPT" 2>&1)"
+mismatched_stripe_modes_code=$?
+set -e
+assert_eq "mismatched stripe key modes exit non-zero" "1" "$mismatched_stripe_modes_code"
+assert_contains "mismatched stripe key modes has explicit message" "$mismatched_stripe_modes_output" "Stripe key mode mismatch"
+
+set +e
+test_keys_output="$(env "${BASE_ENV[@]}" NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_123 STRIPE_SECRET_KEY=sk_test_123 "$SCRIPT" 2>&1)"
+test_keys_code=$?
+set -e
+assert_eq "stripe test keys rejected by default" "1" "$test_keys_code"
+assert_contains "stripe test keys rejection has explicit message" "$test_keys_output" "must be a live key (set ALLOW_TEST_KEYS=1 to bypass)"
+
+set +e
+invalid_allow_test_keys_output="$(env "${BASE_ENV[@]}" ALLOW_TEST_KEYS=maybe "$SCRIPT" 2>&1)"
+invalid_allow_test_keys_code=$?
+set -e
+assert_eq "invalid ALLOW_TEST_KEYS exits non-zero" "1" "$invalid_allow_test_keys_code"
+assert_contains "invalid ALLOW_TEST_KEYS has explicit message" "$invalid_allow_test_keys_output" "ALLOW_TEST_KEYS must be 0 or 1"
+
+set +e
+invalid_verify_only_output="$(env "${BASE_ENV[@]}" VERIFY_ONLY=2 "$SCRIPT" 2>&1)"
+invalid_verify_only_code=$?
+set -e
+assert_eq "invalid VERIFY_ONLY exits non-zero" "1" "$invalid_verify_only_code"
+assert_contains "invalid VERIFY_ONLY has explicit message" "$invalid_verify_only_output" "VERIFY_ONLY must be 0 or 1"
+
+set +e
+short_jwt_output="$(env "${BASE_ENV[@]}" JWT_SECRET=short_secret "$SCRIPT" 2>&1)"
+short_jwt_code=$?
+set -e
+assert_eq "short jwt exits non-zero" "1" "$short_jwt_code"
+assert_contains "short jwt has explicit message" "$short_jwt_output" "JWT_SECRET must be at least 32 characters"
+
+set +e
+allow_test_keys_output="$(env "${BASE_ENV[@]}" NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_123 STRIPE_SECRET_KEY=sk_test_123 ALLOW_TEST_KEYS=1 DRY_RUN=1 "$SCRIPT" 2>&1)"
+allow_test_keys_code=$?
+set -e
+assert_eq "allow test keys override exits zero" "0" "$allow_test_keys_code"
+assert_contains "allow test keys override still prints dry-run command" "$allow_test_keys_output" "netlify env:set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY"
+
+set +e
 dry_run_output="$(env "${BASE_ENV[@]}" DRY_RUN=1 "$SCRIPT" 2>&1)"
 dry_run_code=$?
 set -e
 assert_eq "dry run exits zero" "0" "$dry_run_code"
-assert_contains "dry run prints netlify command" "$dry_run_output" "netlify env:set NEXT_PUBLIC_API_URL production"
+assert_contains "dry run prints netlify key/value/context command" "$dry_run_output" 'netlify env:set NEXT_PUBLIC_API_URL "$NEXT_PUBLIC_API_URL" --context production --site ***'
 assert_contains "dry run prints fly command" "$dry_run_output" "flyctl secrets set DATABASE_URL="
+assert_contains "dry run includes stripe server key placeholder" "$dry_run_output" 'STRIPE_SECRET_KEY="$STRIPE_SECRET_KEY"'
+assert_contains "dry run includes stripe webhook placeholder" "$dry_run_output" 'STRIPE_WEBHOOK_SECRET="$STRIPE_WEBHOOK_SECRET"'
+assert_not_contains "dry run redacts database url value" "$dry_run_output" "postgresql://postgres:pw@localhost:5432/postgres?schema=public"
+assert_not_contains "dry run redacts database password segment" "$dry_run_output" "postgres:pw@"
+assert_not_contains "dry run redacts jwt secret value" "$dry_run_output" "abcdefghijklmnopqrstuvwxyz123456"
+assert_not_contains "dry run redacts fly token value" "$dry_run_output" "test-fly-token"
+assert_not_contains "dry run redacts netlify token value" "$dry_run_output" "test-netlify-token"
+assert_not_contains "dry run redacts netlify site id value" "$dry_run_output" "11111111-2222-3333-4444-555555555555"
+assert_not_contains "dry run redacts stripe secret key value" "$dry_run_output" "sk_live_test"
+assert_not_contains "dry run redacts stripe webhook secret value" "$dry_run_output" "whsec_test"
+
+set +e
+apply_output="$(env "${BASE_ENV[@]}" "$SCRIPT" 2>&1)"
+apply_code=$?
+set -e
+assert_eq "apply mode exits zero" "0" "$apply_code"
+assert_contains "apply mode netlify command includes explicit site flag" "$apply_output" "netlify env:set NEXT_PUBLIC_API_URL https://infamous.fly.dev --context production --site 11111111-2222-3333-4444-555555555555"
+assert_contains "apply mode netlify includes stripe webhook secret key name" "$apply_output" "netlify env:set STRIPE_WEBHOOK_SECRET"
+assert_contains "apply mode fly command includes stripe server secret key name" "$apply_output" "flyctl secrets set DATABASE_URL=postgresql://postgres:pw@localhost:5432/postgres?schema=public JWT_SECRET=abcdefghijklmnopqrstuvwxyz123456 STRIPE_SECRET_KEY=sk_live_test STRIPE_WEBHOOK_SECRET=whsec_test --app infamous-freight-api"
+
+set +e
+verify_only_output="$(env "${BASE_ENV[@]}" VERIFY_ONLY=1 "$SCRIPT" 2>&1)"
+verify_only_code=$?
+set -e
+assert_eq "verify-only mode exits zero" "0" "$verify_only_code"
+assert_contains "verify-only mode prints skip message" "$verify_only_output" "VERIFY_ONLY=1: skipping apply steps"
+assert_contains "verify-only mode lists netlify env" "$verify_only_output" "netlify env:list --context production --site 11111111-2222-3333-4444-555555555555"
+assert_contains "verify-only mode lists fly secrets" "$verify_only_output" "flyctl secrets list --app infamous-freight-api"
 
 if [ "$FAIL" -gt 0 ]; then
   echo ""


### PR DESCRIPTION
### Motivation
- Add support for provisioning Stripe server-side secrets and webhook signing secrets during production bootstrap. 
- Improve safety and correctness by validating input formats (Netlify site UUID, Stripe key forms, DB URL, context) and preventing accidental use of test keys in production. 
- Make the bootstrap flow more usable with `DRY_RUN` and `VERIFY_ONLY` modes and clearer Netlify `--site`/`--context` behavior. 

### Description
- Added new required env vars `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET` and documented them in `docs/ENV_SETUP_SECRETS_GUIDE.md`. 
- Enhanced `scripts/bootstrap-production-secrets.sh` to validate `NETLIFY_SITE_ID` is a UUID, restrict `NETLIFY_CONTEXT` to `production|deploy-preview|branch-deploy`, validate Stripe key formats, and enforce matching publishable/secret key modes. 
- Added `ALLOW_TEST_KEYS` flag to allow test Stripe keys for non-production drills and `VERIFY_ONLY` to skip writes and only run verification checks, and tightened `DRY_RUN` output to redact sensitive values while showing intended commands. 
- Updated Netlify apply commands to use `--context` and `--site` flags and added Fly.io secrets for the new Stripe vars. 
- Updated the CI test script `tests/ci/bootstrap-production-secrets.test.sh` with new assertions and a helper `assert_not_contains` to validate redaction and the new validation behavior. 

### Testing
- Ran the updated automated test script `tests/ci/bootstrap-production-secrets.test.sh` which exercises help output, missing/invalid-var failures, Stripe key mode enforcement, `ALLOW_TEST_KEYS` behavior, `DRY_RUN` redaction, normal apply output, and `VERIFY_ONLY` mode; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6a67d39548330b176f73da6705fbc)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Stripe server secrets/webhook setup and LaunchDarkly bootstrap with a safe web flag helper. Tightens validation and adds verify-only/dry-run modes to prevent misconfig and test-key mistakes.

- **New Features**
  - Provisions `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, and optional `LAUNCHDARKLY_CLIENT_SIDE_ID` to Netlify (`--site`, `--context`) and Fly; adds `@netlify/launchdarkly-server-sdk` and `evaluateLaunchDarklyFlag(...)` with a 3s init timeout, safe fallback, and clean shutdown.
  - Stricter checks: UUID `NETLIFY_SITE_ID`, `NETLIFY_CONTEXT` ∈ `production|deploy-preview|branch-deploy`, HTTPS `NEXT_PUBLIC_API_URL`, Postgres `DATABASE_URL`, Stripe key formats and mode match, live keys unless `ALLOW_TEST_KEYS=1`, `JWT_SECRET` length, and basic LaunchDarkly ID validity.
  - Modes: `VERIFY_ONLY=1` to list Netlify/Fly state without applying; improved `DRY_RUN=1` with token/secret redaction; `ALLOW_TEST_KEYS=1` for drills.
  - Docs expanded with commands, decision tree, integration notes, and troubleshooting; CI tests cover missing CLI, context/UUID validation, Stripe mode rules, verify-only (incl. dry-run), redaction, and LaunchDarkly flows.

<sup>Written for commit fc36b0e3cee6cefe25772ac7387da672a6caeae4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

