### PR TITLE
Netlify preview gating, branch deploys, security scans, and Ops docs

### DIFF
--- a/.github/branch-protection-rules.json
+++ b/.github/branch-protection-rules.json
@@ -19,7 +19,9 @@
         "CI Sanity / sanity",
         "CI / Lint, Typecheck, Test, Build",
         "CodeQL / Analyze",
-        "Dependency Review / dependency-review"
+        "Dependency Review / dependency-review",
+        "Netlify Preview Validation / netlify preview deploy",
+        "Netlify Preview Validation / preview quality checks"
       ]
     }
   ]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+      - staging
+      - develop
+      - "release/**"
   workflow_dispatch:
 
 permissions:
@@ -118,7 +121,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: [quality-gate]
-    if: ${{ always() && github.ref_name == 'main' }}
+    if: ${{ always() && (github.ref_name == 'main' || github.ref_name == 'staging' || github.ref_name == 'develop' || startsWith(github.ref_name, 'release/')) }}
     steps:
       - uses: actions/checkout@v6
 
@@ -142,7 +145,30 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${GITHUB_REF_NAME}" = "main" ]; then
-            pnpm --package=netlify-cli dlx netlify deploy --build --prod --message "GitHub Actions deploy from ${GITHUB_REF_NAME}" --site "$NETLIFY_SITE_ID" --auth "$NETLIFY_AUTH_TOKEN"
+            pnpm --package=netlify-cli dlx netlify deploy --build --prod --context production --message "GitHub Actions production deploy from ${GITHUB_REF_NAME}" --site "$NETLIFY_SITE_ID" --auth "$NETLIFY_AUTH_TOKEN"
+          elif [ "${GITHUB_REF_NAME}" = "staging" ] || [ "${GITHUB_REF_NAME}" = "develop" ] || [[ "${GITHUB_REF_NAME}" == release/* ]]; then
+            alias_name=$(echo "${GITHUB_REF_NAME}" | tr '/' '-')
+            pnpm --package=netlify-cli dlx netlify deploy --build --context branch-deploy --alias "${alias_name}" --message "GitHub Actions branch deploy from ${GITHUB_REF_NAME}" --site "$NETLIFY_SITE_ID" --auth "$NETLIFY_AUTH_TOKEN"
           else
-            pnpm --package=netlify-cli dlx netlify deploy --build --message "GitHub Actions preview deploy from ${GITHUB_REF_NAME}" --site "$NETLIFY_SITE_ID" --auth "$NETLIFY_AUTH_TOKEN"
+            pnpm --package=netlify-cli dlx netlify deploy --build --context deploy-preview --message "GitHub Actions preview deploy from ${GITHUB_REF_NAME}" --site "$NETLIFY_SITE_ID" --auth "$NETLIFY_AUTH_TOKEN"
+          fi
+
+
+  notify-deploy:
+    name: Notify deploy status
+    runs-on: ubuntu-latest
+    needs: [deploy-api, deploy-web]
+    if: always()
+    steps:
+      - name: Post deployment notification (Slack webhook optional)
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          set -euo pipefail
+          status="${{ needs.deploy-api.result }} / ${{ needs.deploy-web.result }}"
+          summary="Unified Deploy status - API/Web: ${status} for ${GITHUB_REF_NAME}"
+          echo "$summary"
+          if [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
+            payload=$(printf '{"text":"%s"}' "$summary")
+            curl -sS -X POST -H 'Content-type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL" >/dev/null
           fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -169,6 +169,6 @@ jobs:
           summary="Unified Deploy status - API/Web: ${status} for ${GITHUB_REF_NAME}"
           echo "$summary"
           if [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
-            payload=$(printf '{"text":"%s"}' "$summary")
+            payload=$(SUMMARY="$summary" python3 -c 'import json, os; print(json.dumps({"text": os.environ["SUMMARY"]}))')
             curl -sS -X POST -H 'Content-type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL" >/dev/null
           fi

--- a/.github/workflows/netlify-preview-validation.yml
+++ b/.github/workflows/netlify-preview-validation.yml
@@ -92,6 +92,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
       - name: Smoke tests
         env:
           PREVIEW_URL: ${{ needs.preview-deploy.outputs.preview_url }}

--- a/.github/workflows/netlify-preview-validation.yml
+++ b/.github/workflows/netlify-preview-validation.yml
@@ -116,9 +116,13 @@ jobs:
           PREVIEW_URL: ${{ needs.preview-deploy.outputs.preview_url }}
         run: |
           set -euo pipefail
-          enc=$(curl -sSI -H 'Accept-Encoding: br,gzip' "$PREVIEW_URL" | awk -F': ' 'tolower($1)=="content-encoding" {print tolower($2)}' | tr -d '\r')
+          headers_file=$(mktemp)
+          body_file=$(mktemp)
+          trap 'rm -f "$headers_file" "$body_file"' EXIT
+          curl -fsS -D "$headers_file" -o "$body_file" -H 'Accept-Encoding: br,gzip' "$PREVIEW_URL/"
+          enc=$(awk -F': ' 'tolower($1)=="content-encoding" {print tolower($2)}' "$headers_file" | tr -d '\r')
           if [[ "$enc" != *"br"* && "$enc" != *"gzip"* ]]; then
-            echo "Expected Brotli or gzip content-encoding; got '${enc:-none}'" >&2
+            echo "Expected Brotli or gzip content-encoding on GET response; got '${enc:-none}'" >&2
             exit 1
           fi
 

--- a/.github/workflows/netlify-preview-validation.yml
+++ b/.github/workflows/netlify-preview-validation.yml
@@ -1,0 +1,141 @@
+name: Netlify Preview Validation
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: netlify-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  preview-deploy:
+    name: netlify preview deploy
+    runs-on: ubuntu-latest
+    outputs:
+      preview_url: ${{ steps.deploy.outputs.preview_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10.33.0
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build and deploy preview
+        id: deploy
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        run: |
+          set -euo pipefail
+          if [ -z "${NETLIFY_AUTH_TOKEN:-}" ] || [ -z "${NETLIFY_SITE_ID:-}" ]; then
+            echo "NETLIFY_AUTH_TOKEN and NETLIFY_SITE_ID must be configured for preview validation." >&2
+            exit 1
+          fi
+
+          json_output=$(pnpm --package=netlify-cli dlx netlify deploy \
+            --build \
+            --context deploy-preview \
+            --json \
+            --message "PR #${{ github.event.pull_request.number }} preview" \
+            --site "$NETLIFY_SITE_ID" \
+            --auth "$NETLIFY_AUTH_TOKEN")
+
+          preview_url=$(echo "$json_output" | node -e "const data=JSON.parse(require('fs').readFileSync(0,'utf8')); process.stdout.write(data.deploy_url || data.url || '')")
+          if [ -z "$preview_url" ]; then
+            echo "Unable to resolve preview URL from Netlify deploy output" >&2
+            echo "$json_output"
+            exit 1
+          fi
+
+          echo "preview_url=$preview_url" >> "$GITHUB_OUTPUT"
+          echo "Preview URL: $preview_url"
+
+      - name: Wait for preview readiness
+        env:
+          PREVIEW_URL: ${{ steps.deploy.outputs.preview_url }}
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 30); do
+            status=$(curl -sS -o /dev/null -w '%{http_code}' "$PREVIEW_URL" || true)
+            if [ "$status" = "200" ]; then
+              echo "Preview is ready"
+              exit 0
+            fi
+            echo "Attempt $i/30: preview returned $status, retrying..."
+            sleep 5
+          done
+          echo "Preview did not become ready in time" >&2
+          exit 1
+
+  preview-quality:
+    name: preview quality checks
+    runs-on: ubuntu-latest
+    needs: preview-deploy
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Smoke tests
+        env:
+          PREVIEW_URL: ${{ needs.preview-deploy.outputs.preview_url }}
+        run: |
+          set -euo pipefail
+          curl -fsSL "$PREVIEW_URL/" >/dev/null
+          curl -fsSL "$PREVIEW_URL/404" >/dev/null
+
+      - name: Verify compression headers
+        env:
+          PREVIEW_URL: ${{ needs.preview-deploy.outputs.preview_url }}
+        run: |
+          set -euo pipefail
+          enc=$(curl -sSI -H 'Accept-Encoding: br,gzip' "$PREVIEW_URL" | awk -F': ' 'tolower($1)=="content-encoding" {print tolower($2)}' | tr -d '\r')
+          if [[ "$enc" != *"br"* && "$enc" != *"gzip"* ]]; then
+            echo "Expected Brotli or gzip content-encoding; got '${enc:-none}'" >&2
+            exit 1
+          fi
+
+      - name: Lighthouse checks
+        uses: treosh/lighthouse-ci-action@v12
+        with:
+          urls: |
+            ${{ needs.preview-deploy.outputs.preview_url }}
+          uploadArtifacts: true
+          temporaryPublicStorage: true
+          configPath: ./lighthouserc.json
+
+      - name: Accessibility checks (pa11y)
+        env:
+          PREVIEW_URL: ${{ needs.preview-deploy.outputs.preview_url }}
+        run: |
+          set -euo pipefail
+          cat > pa11y-ci.json <<JSON
+          {
+            "defaults": {
+              "standard": "WCAG2AA",
+              "timeout": 60000,
+              "wait": 1500
+            },
+            "urls": [
+              "${PREVIEW_URL}",
+              "${PREVIEW_URL}/auth/sign-in"
+            ]
+          }
+          JSON
+          pnpm --package=pa11y-ci dlx pa11y-ci --config pa11y-ci.json

--- a/.github/workflows/netlify-preview-validation.yml
+++ b/.github/workflows/netlify-preview-validation.yml
@@ -105,7 +105,11 @@ jobs:
         run: |
           set -euo pipefail
           curl -fsSL "$PREVIEW_URL/" >/dev/null
-          curl -fsSL "$PREVIEW_URL/404" >/dev/null
+          status=$(curl -sS -o /dev/null -w '%{http_code}' "$PREVIEW_URL/404")
+          if [ "$status" != "404" ]; then
+            echo "Expected $PREVIEW_URL/404 to return HTTP 404, got $status" >&2
+            exit 1
+          fi
 
       - name: Verify compression headers
         env:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,6 +26,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+
+  sast-semgrep:
+    name: SAST (Semgrep)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run Semgrep
+        uses: returntocorp/semgrep-action@v1
+        with:
+          config: p/security-audit,p/owasp-top-ten
+
   dependency-audit:
     name: Dependency Audit
     runs-on: ubuntu-latest

--- a/apps/web/netlify.toml
+++ b/apps/web/netlify.toml
@@ -1,70 +1,132 @@
-# ─────────────────────────────────────────────────────────────────────────────
-# Infæmous Freight – Netlify Configuration (apps/web)
-# Frontend:  https://www.infamousfreight.com  (Netlify)
-# Backend:   https://api.infamousfreight.com  (Express/API – NOT on Netlify)
-# ─────────────────────────────────────────────────────────────────────────────
+# =============================================================================
+# Netlify configuration for Infamous Freight web deployment.
+#
+# Notes:
+# - Deploy previews are enabled for pull requests in Netlify site settings.
+# - Long-lived branch deploys (for staging-style QA) are enabled in Netlify site settings.
+# - Secrets must be stored in Netlify environment variables only (never committed).
+# - Keep NODE_VERSION / PNPM_VERSION aligned with .nvmrc and packageManager.
+# =============================================================================
 
 [build]
-  # Base is the repo root so pnpm workspace installs all packages correctly.
-  base    = "."
+  base = "."
   command = "pnpm install --frozen-lockfile && pnpm --filter web build"
   publish = "apps/web/.next"
   functions = "apps/web/.netlify/functions"
 
 [build.environment]
-  NODE_VERSION           = "24"
-  PNPM_VERSION           = "10.33.0"
+  NODE_VERSION = "24"
+  PNPM_VERSION = "10.33.0"
   NEXT_TELEMETRY_DISABLED = "1"
-  # Ensure Netlify UI-managed plugins with stale engine ranges do not fail
-  # dependency installation before the app build starts.
+  BUILD_TARGET = "netlify"
+  # Allow Netlify-managed plugin installs even when third-party engine ranges lag.
   NPM_CONFIG_ENGINE_STRICT = "false"
   npm_config_engine_strict = "false"
-  NEXT_PUBLIC_SITE_URL   = "https://www.infamousfreight.com"
-  NEXT_PUBLIC_API_URL    = "https://api.infamousfreight.com"
-  NEXT_PUBLIC_API_BASE   = "https://api.infamousfreight.com"
-  NEXT_PUBLIC_API_BASE_URL = "https://api.infamousfreight.com"
-  # Netlify-specific build target (not firebase, not vercel)
-  BUILD_TARGET           = "netlify"
 
-# ─── Next.js plugin (required for SSR / ISR / API routes on Netlify) ─────────
+# Explicit build contexts to enforce environment scoping and deterministic behavior.
+[context.production]
+  command = "pnpm install --frozen-lockfile && pnpm --filter web build"
+
+[context.production.environment]
+  NODE_ENV = "production"
+  NEXT_RUNTIME_ENV = "production"
+
+[context.deploy-preview]
+  command = "pnpm install --frozen-lockfile && pnpm --filter web build"
+
+[context.deploy-preview.environment]
+  NODE_ENV = "production"
+  NEXT_RUNTIME_ENV = "deploy-preview"
+
+[context.branch-deploy]
+  command = "pnpm install --frozen-lockfile && pnpm --filter web build"
+
+[context.branch-deploy.environment]
+  NODE_ENV = "production"
+  NEXT_RUNTIME_ENV = "branch-deploy"
+
 [[plugins]]
   package = "@netlify/plugin-nextjs"
 
-# ─── Apex domain → www redirect (301 permanent) ───────────────────────────────
-# Netlify also enforces this via Domain Settings → Primary domain = www.*
+# Centralized redirects / rewrites.
 [[redirects]]
-  from   = "https://infamousfreight.com/*"
-  to     = "https://www.infamousfreight.com/:splat"
+  from = "https://infamousfreight.com/*"
+  to = "https://www.infamousfreight.com/:splat"
   status = 301
-  force  = true
+  force = true
 
-# ─── Security headers ─────────────────────────────────────────────────────────
+[[redirects]]
+  from = "http://infamousfreight.com/*"
+  to = "https://www.infamousfreight.com/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "http://www.infamousfreight.com/*"
+  to = "https://www.infamousfreight.com/:splat"
+  status = 301
+  force = true
+
+# Canonicalization for duplicate-content prevention.
+[[redirects]]
+  from = "/index.html"
+  to = "/"
+  status = 301
+  force = true
+
+# Standardized error experiences.
+[[redirects]]
+  from = "/500"
+  to = "/500.html"
+  status = 500
+
+# Security headers and cache policy.
 [[headers]]
   for = "/*"
   [headers.values]
-    X-Frame-Options           = "DENY"
-    X-Content-Type-Options    = "nosniff"
-    X-XSS-Protection          = "1; mode=block"
-    Referrer-Policy           = "strict-origin-when-cross-origin"
-    Permissions-Policy        = "camera=(), microphone=(), geolocation=(self)"
+    X-Frame-Options = "DENY"
+    X-Content-Type-Options = "nosniff"
+    X-XSS-Protection = "1; mode=block"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    Permissions-Policy = "camera=(), microphone=(), geolocation=(self)"
     Strict-Transport-Security = "max-age=31536000; includeSubDomains; preload"
-    Content-Security-Policy   = "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://maps.googleapis.com https://js.stripe.com https://cdn.segment.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://api.infamousfreight.com wss://api.infamousfreight.com https://sentry.io https://o*.ingest.sentry.io; frame-src 'self' https://js.stripe.com https://checkout.stripe.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https://checkout.stripe.com"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://maps.googleapis.com https://js.stripe.com https://cdn.segment.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://api.infamousfreight.com wss://api.infamousfreight.com https://sentry.io https://o*.ingest.sentry.io; frame-src 'self' https://js.stripe.com https://checkout.stripe.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https://checkout.stripe.com"
 
-# ─── Static asset caching ─────────────────────────────────────────────────────
+# Immutable cache for fingerprinted static assets.
 [[headers]]
   for = "/_next/static/*"
   [headers.values]
     Cache-Control = "public, max-age=31536000, immutable"
 
-# ─── API routes – no caching ──────────────────────────────────────────────────
+# Short TTL for HTML entry points to speed rollback propagation.
+[[headers]]
+  for = "/*.html"
+  [headers.values]
+    Cache-Control = "public, max-age=0, must-revalidate"
+
+[[headers]]
+  for = "/"
+  [headers.values]
+    Cache-Control = "public, max-age=0, must-revalidate"
+
+# API routes should never be cached.
 [[headers]]
   for = "/api/*"
   [headers.values]
     Cache-Control = "no-store, max-age=0"
 
-# ─── Local dev settings ───────────────────────────────────────────────────────
+# Netlify Image CDN endpoint cache policy.
+[[headers]]
+  for = "/.netlify/images*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
+[functions]
+  node_bundler = "esbuild"
+  external_node_modules = []
+
 [dev]
-  command     = "pnpm dev"
-  port        = 3000
-  targetPort  = 3000
-  autoLaunch  = false
+  command = "pnpm --filter web dev"
+  port = 8888
+  targetPort = 3000
+  autoLaunch = false

--- a/docs/NETLIFY_OPERATIONS.md
+++ b/docs/NETLIFY_OPERATIONS.md
@@ -1,0 +1,107 @@
+# Netlify Operations & Production Controls
+
+This document defines the required operational baseline for the Netlify-hosted web surface.
+
+## 1) Deploy strategy and merge protection
+
+- **Deploy previews**: enabled for every PR via Netlify Git integration and CI workflow `Netlify Preview Validation`.
+- **Required checks before merge**:
+  - `Netlify Preview Validation / netlify preview deploy`
+  - `Netlify Preview Validation / preview quality checks`
+- **Branch deploys**: enabled for long-lived QA branches (`develop`, `staging`, `release/*`) in Netlify site settings.
+
+## 2) Build reproducibility
+
+- Build command is pinned in `netlify.toml`:
+  - `pnpm install --frozen-lockfile && pnpm --filter web build`
+- Publish directory is explicitly set:
+  - `apps/web/.next`
+- Node and pnpm are pinned:
+  - `.nvmrc` = `24`
+  - `netlify.toml` `NODE_VERSION=24`
+  - `netlify.toml` `PNPM_VERSION=10.33.0`
+- Lockfile enforcement is mandatory (`--frozen-lockfile`) for CI and Netlify builds.
+- Dependency caching is enabled in CI through `actions/setup-node` cache for pnpm.
+
+## 3) Environment variable governance
+
+Never commit secrets. Store secrets in Netlify environment variables only.
+
+### Context scoping
+
+| Variable | Purpose | Owner | Production | Deploy Preview | Branch Deploy |
+|---|---|---|---|---|---|
+| `NEXT_PUBLIC_SITE_URL` | canonical site URL | Web Platform | ✅ | ⚠️ preview URL override | ⚠️ branch URL override |
+| `NEXT_PUBLIC_API_URL` | browser API base URL | API Platform | ✅ | ✅ | ✅ |
+| `NEXT_PUBLIC_API_BASE_URL` | browser API base URL alias | API Platform | ✅ | ✅ | ✅ |
+| `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | Stripe client billing key | Billing | ✅ | optional test key | optional test key |
+| `SENTRY_DSN` | frontend error telemetry | Platform Observability | ✅ | optional | optional |
+| `JWT_SECRET` | server-side auth secret for serverless handlers | Security | ✅ | ✅ (preview secret) | ✅ (branch secret) |
+| `NETLIFY_AUTH_TOKEN` | CI deploy token | Platform DevOps | CI secret only | CI secret only | CI secret only |
+| `NETLIFY_SITE_ID` | Netlify target site | Platform DevOps | CI secret only | CI secret only | CI secret only |
+
+### Secret rotation schedule
+
+- Rotate **deploy tokens and integration tokens every 90 days**.
+- Rotate **high-risk auth secrets every 30 days** or immediately after personnel/incident events.
+- Rotation owner: **Platform DevOps on-call**.
+- Evidence required: ticket link + timestamp + impacted systems + validation of successful redeploy.
+
+## 4) Security and traffic controls
+
+- Security headers (CSP, HSTS, X-Frame-Options, etc.) are defined centrally in `netlify.toml`.
+- Redirects and rewrites are centralized in `netlify.toml`.
+- Canonical redirects enforce apex/http -> `https://www.infamousfreight.com`.
+- Abuse controls:
+  - use Netlify + upstream WAF/rate-limiting rules for `/api`, `/auth`, `/admin`.
+  - protect internal/admin routes with role checks in backend middleware.
+
+## 5) Performance controls
+
+- Lighthouse validation runs on each deploy preview.
+- Accessibility checks (`pa11y`) run on each deploy preview.
+- Compression is verified in preview (`br` or `gzip` content-encoding).
+- Cache policy:
+  - fingerprinted static assets: immutable / 1 year.
+  - HTML entry points: `max-age=0, must-revalidate`.
+
+### Payload budgets
+
+Use these budgets in PR reviews and Lighthouse triage:
+
+- JavaScript (initial): **<= 170 KB gzip**.
+- CSS (initial): **<= 70 KB gzip**.
+- Above-the-fold images per route: **<= 250 KB compressed**.
+
+## 6) Functions and edge guidance
+
+- Netlify Functions are preferred for logic that must not execute client-side.
+- Validate and parse request bodies at every function entry with explicit schema checks.
+- Use **Background Functions** for long-running async jobs.
+- Use **Scheduled Functions** for maintenance jobs (cleanup, sync, periodic health checks).
+- Use **Edge Functions** only for latency-sensitive or request-time personalization needs.
+- Keep edge logic deterministic, minimal, and side-effect constrained.
+
+## 7) Observability, alerting, and incident response
+
+- Function logs should be structured JSON and include request/correlation IDs.
+- Route function-level errors to Sentry/alerting with environment tags.
+- Configure deploy notifications to Slack/email for:
+  - production success
+  - production failure
+  - preview failures
+- Run synthetic uptime checks for:
+  - `/`
+  - `/auth/sign-in`
+  - API health endpoint
+
+## 8) Runbooks and review cadence
+
+- Rollback runbook: `docs/runbooks/NETLIFY_ROLLBACK_RUNBOOK.md`.
+- Incident template: `docs/templates/INCIDENT_POSTMORTEM_TEMPLATE.md`.
+- Monthly operational review must include:
+  - median/95th build time
+  - error rate and top causes
+  - traffic trends and cache hit behavior
+  - dependency freshness and vulnerability backlog
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -162,6 +162,9 @@ you find the information you need.
   troubleshooting
 - **[Secrets Configuration](deployment/SECRETS_CONFIGURED.md)** - Managing
   secrets
+- **[Netlify Operations](NETLIFY_OPERATIONS.md)** - Preview deploy gating, env scoping, caching, security headers, and incident cadence
+- **[Netlify Rollback Runbook](runbooks/NETLIFY_ROLLBACK_RUNBOOK.md)** - Emergency rollback steps and ownership
+- **[Incident Postmortem Template](templates/INCIDENT_POSTMORTEM_TEMPLATE.md)** - Standard template for incident reviews
 
 ### Deployment Status & History
 

--- a/docs/runbooks/NETLIFY_ROLLBACK_RUNBOOK.md
+++ b/docs/runbooks/NETLIFY_ROLLBACK_RUNBOOK.md
@@ -1,0 +1,33 @@
+# Netlify Rollback Runbook
+
+## Ownership
+
+- Primary: Platform DevOps
+- Secondary: Web Platform Lead
+- Incident Commander: On-call Engineering Manager
+
+## Trigger conditions
+
+- Elevated 5xx or client error rates after deploy
+- Critical user journey failures
+- Security incident requiring immediate rollback
+
+## Rollback steps
+
+1. Identify last known-good deploy in Netlify Deploys UI.
+2. Lock active incident channel and announce rollback intent.
+3. Restore/publish the previous deploy.
+4. Verify:
+   - homepage returns 200
+   - auth sign-in path renders
+   - critical API-dependent route loads
+5. Post rollback confirmation in incident channel.
+6. Create postmortem ticket using the incident template.
+
+## Validation checklist
+
+- [ ] Core smoke tests passed.
+- [ ] Error budget burn stabilizing.
+- [ ] No critical auth/billing regressions.
+- [ ] Stakeholders notified.
+

--- a/docs/templates/INCIDENT_POSTMORTEM_TEMPLATE.md
+++ b/docs/templates/INCIDENT_POSTMORTEM_TEMPLATE.md
@@ -1,0 +1,48 @@
+# Incident Postmortem Template
+
+## Summary
+
+- Incident ID:
+- Date/time detected:
+- Date/time resolved:
+- Severity:
+- Incident commander:
+
+## Impact
+
+- User impact:
+- Duration:
+- Affected systems/routes:
+
+## Detection
+
+- How detected:
+- Alert/source:
+
+## Timeline (UTC)
+
+- HH:MM - event
+- HH:MM - event
+
+## Root cause
+
+- Technical root cause:
+- Process/root cause contributors:
+
+## Resolution
+
+- Immediate mitigation:
+- Permanent fix:
+
+## Action items
+
+| Action | Owner | Due date | Status |
+|---|---|---|---|
+| | | | |
+
+## Learnings
+
+- What went well:
+- What didn't:
+- What we will change:
+

--- a/netlify.toml
+++ b/netlify.toml
@@ -90,7 +90,7 @@
     Referrer-Policy = "strict-origin-when-cross-origin"
     Permissions-Policy = "camera=(), microphone=(), geolocation=(self)"
     Strict-Transport-Security = "max-age=31536000; includeSubDomains; preload"
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://maps.googleapis.com https://js.stripe.com https://cdn.segment.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://api.infamousfreight.com wss://api.infamousfreight.com https://sentry.io https://o*.ingest.sentry.io; frame-src 'self' https://js.stripe.com https://checkout.stripe.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https://checkout.stripe.com"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' https://cdn.jsdelivr.net https://maps.googleapis.com https://js.stripe.com https://cdn.segment.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://api.infamousfreight.com wss://api.infamousfreight.com https://sentry.io https://o*.ingest.sentry.io; frame-src 'self' https://js.stripe.com https://checkout.stripe.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https://checkout.stripe.com"
 
 # Immutable cache for fingerprinted static assets.
 [[headers]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,13 @@
+# =============================================================================
+# Netlify configuration for Infamous Freight web deployment.
+#
+# Notes:
+# - Deploy previews are enabled for pull requests in Netlify site settings.
+# - Long-lived branch deploys (for staging-style QA) are enabled in Netlify site settings.
+# - Secrets must be stored in Netlify environment variables only (never committed).
+# - Keep NODE_VERSION / PNPM_VERSION aligned with .nvmrc and packageManager.
+# =============================================================================
+
 [build]
   base = "."
   command = "pnpm install --frozen-lockfile && pnpm --filter web build"
@@ -9,13 +19,111 @@
   PNPM_VERSION = "10.33.0"
   NEXT_TELEMETRY_DISABLED = "1"
   BUILD_TARGET = "netlify"
-  # Allow Netlify-managed plugin installs to proceed even when third-party
-  # plugin engine ranges lag behind current Node/npm runtime versions.
+  # Allow Netlify-managed plugin installs even when third-party engine ranges lag.
   NPM_CONFIG_ENGINE_STRICT = "false"
   npm_config_engine_strict = "false"
 
+# Explicit build contexts to enforce environment scoping and deterministic behavior.
+[context.production]
+  command = "pnpm install --frozen-lockfile && pnpm --filter web build"
+
+[context.production.environment]
+  NODE_ENV = "production"
+  NEXT_RUNTIME_ENV = "production"
+
+[context.deploy-preview]
+  command = "pnpm install --frozen-lockfile && pnpm --filter web build"
+
+[context.deploy-preview.environment]
+  NODE_ENV = "production"
+  NEXT_RUNTIME_ENV = "deploy-preview"
+
+[context.branch-deploy]
+  command = "pnpm install --frozen-lockfile && pnpm --filter web build"
+
+[context.branch-deploy.environment]
+  NODE_ENV = "production"
+  NEXT_RUNTIME_ENV = "branch-deploy"
+
 [[plugins]]
   package = "@netlify/plugin-nextjs"
+
+# Centralized redirects / rewrites.
+[[redirects]]
+  from = "https://infamousfreight.com/*"
+  to = "https://www.infamousfreight.com/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "http://infamousfreight.com/*"
+  to = "https://www.infamousfreight.com/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "http://www.infamousfreight.com/*"
+  to = "https://www.infamousfreight.com/:splat"
+  status = 301
+  force = true
+
+# Canonicalization for duplicate-content prevention.
+[[redirects]]
+  from = "/index.html"
+  to = "/"
+  status = 301
+  force = true
+
+# Standardized error experiences.
+[[redirects]]
+  from = "/500"
+  to = "/500.html"
+  status = 500
+
+# Security headers and cache policy.
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "DENY"
+    X-Content-Type-Options = "nosniff"
+    X-XSS-Protection = "1; mode=block"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    Permissions-Policy = "camera=(), microphone=(), geolocation=(self)"
+    Strict-Transport-Security = "max-age=31536000; includeSubDomains; preload"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://maps.googleapis.com https://js.stripe.com https://cdn.segment.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://api.infamousfreight.com wss://api.infamousfreight.com https://sentry.io https://o*.ingest.sentry.io; frame-src 'self' https://js.stripe.com https://checkout.stripe.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https://checkout.stripe.com"
+
+# Immutable cache for fingerprinted static assets.
+[[headers]]
+  for = "/_next/static/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
+# Short TTL for HTML entry points to speed rollback propagation.
+[[headers]]
+  for = "/*.html"
+  [headers.values]
+    Cache-Control = "public, max-age=0, must-revalidate"
+
+[[headers]]
+  for = "/"
+  [headers.values]
+    Cache-Control = "public, max-age=0, must-revalidate"
+
+# API routes should never be cached.
+[[headers]]
+  for = "/api/*"
+  [headers.values]
+    Cache-Control = "no-store, max-age=0"
+
+# Netlify Image CDN endpoint cache policy.
+[[headers]]
+  for = "/.netlify/images*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
+[functions]
+  node_bundler = "esbuild"
+  external_node_modules = []
 
 [dev]
   command = "pnpm --filter web dev"


### PR DESCRIPTION
### Motivation
- Enforce Netlify preview validation as a required check before merging and provide deterministic deploy behavior across production, preview, and branch deploys.
- Centralize Netlify site configuration (redirects, security headers, cache policy) and ensure reproducible builds across CI and Netlify.
- Improve deployment observability with notifications and provide operational runbooks and incident templates for Netlify rollbacks.
- Strengthen CI security posture by adding SAST (Semgrep) alongside existing dependency and secret scans.

### Description
- Updated branch protection rules to require `Netlify Preview Validation / netlify preview deploy` and `Netlify Preview Validation / preview quality checks` checks for `main`.
- Expanded `Unified Deploy` workflow to trigger on `main`, `staging`, `develop`, and `release/**`, added branch-aware Netlify deploy logic using `--context` and `--alias`, and added a `notify-deploy` job to post a simple deployment summary (Slack webhook optional).
- Added a new `Netlify Preview Validation` workflow that deploys PR previews, waits for readiness, runs smoke tests, verifies compression headers, runs Lighthouse (`treosh/lighthouse-ci-action`) and accessibility checks (`pa11y-ci`), and exports the preview URL as an output used by quality checks.
- Added a `sast-semgrep` job to `security.yml` using `returntocorp/semgrep-action` with `p/security-audit,p/owasp-top-ten` configurations.
- Consolidated and extended Netlify configuration in `netlify.toml` and `apps/web/netlify.toml` with explicit build contexts (`production`, `deploy-preview`, `branch-deploy`), redirects, canonicalization, security headers (CSP, HSTS, etc.), cache policies for static assets and HTML entry points, and Functions settings; also adjusted local `dev` settings.
- Added operational documentation and runbooks: `docs/NETLIFY_OPERATIONS.md`, `docs/runbooks/NETLIFY_ROLLBACK_RUNBOOK.md`, and an incident postmortem template `docs/templates/INCIDENT_POSTMORTEM_TEMPLATE.md`, and updated `docs/README.md` to reference the new docs.

### Testing
- No automated tests were executed as part of this PR.
- CI test configuration was added/updated and will run on subsequent pushes/PRs, including the `Quality Gate` job (API tests + Docker build), `Netlify Preview Validation` (deploy + smoke/Lighthouse/pa11y), dependency audits, and Semgrep SAST checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e03cab3868833084482bc3c73746b6)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates merges to `main` on Netlify preview validation and unifies deploys across production, previews, and branch deploys. Adds Semgrep SAST, tightened Netlify config, and new ops docs.

- **New Features**
  - Require Netlify preview checks before merge on `main`: `Netlify Preview Validation / netlify preview deploy` and `Netlify Preview Validation / preview quality checks`.
  - Unified deploys for `main`, `staging`, `develop`, and `release/**` using `netlify-cli` with `--context` (`production`, `deploy-preview`, `branch-deploy`) and `--alias` for branch deploys; optional Slack deploy summary.
  - New Netlify Preview Validation workflow: deploy PR preview, wait for readiness, run smoke tests, verify compression, run Lighthouse via `treosh/lighthouse-ci-action`, and a11y via `pa11y-ci`.
  - Add SAST with `returntocorp/semgrep-action` using `p/security-audit,p/owasp-top-ten`.
  - Centralize Netlify config (root and `apps/web`): explicit contexts, canonical redirects (apex/http/www and `/index.html`), 500 mapping, CSP/HSTS/security headers, cache policy (immutable assets; 0 TTL for HTML), Netlify Image CDN headers, Functions bundling, and dev settings.
  - New ops docs and runbooks for deploys, rollbacks, and incident reviews.

- **Migration**
  - Add GitHub secrets: `NETLIFY_AUTH_TOKEN`, `NETLIFY_SITE_ID` (required); `SLACK_WEBHOOK_URL` (optional).
  - Enable Netlify Deploy Previews and Branch deploys for the site.

<sup>Written for commit 936d98d3ba3a83402803b0955a4552c294b628ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

