### PR TITLE
Enforce tenant context & RBAC, include requestId in error responses, add dev scripts and Docker healthcheck

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,8 +28,17 @@ WEB_BASE_URL=http://localhost:3000
 
 # Web (public)
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
+NEXT_PUBLIC_APP_URL=http://localhost:3000
 NEXT_PUBLIC_APP_ENV=development
 NEXT_PUBLIC_API_URL=http://localhost:4000/api
+
+# Supabase (Canonical Next.js setup)
+# Find in Supabase Dashboard → Project Settings → API
+NEXT_PUBLIC_SUPABASE_URL=https://your-project-id.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-eyJh...-long-anon-key
+
+# Server-only (never expose in browser)
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 
 # Observability
 SENTRY_DSN=https://...@sentry.io/...
@@ -47,6 +56,7 @@ AWS_REGION=us-east-1
 
 # Payment (Stripe)
 STRIPE_SECRET_KEY=sk_test_...
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_...
 STRIPE_PUBLISHABLE_KEY=pk_test_...
 STRIPE_WEBHOOK_SECRET=whsec_...
 STRIPE_STARTER_PRICE_ID=price_...

--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,7 @@ WEB_BASE_URL=http://localhost:3000
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 NEXT_PUBLIC_APP_ENV=development
+NEXT_PUBLIC_ENV=development
 NEXT_PUBLIC_API_URL=http://localhost:4000/api
 
 # Supabase (Canonical Next.js setup)

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ pnpm-error.log*
 
 # Codex CLI personal config
 .codex/config.toml
+.mcp.json
 
 # Temporary files
 *.yaml~

--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -1,0 +1,17 @@
+{
+  "mcpServers": {
+    "github": {
+      "command": "docker",
+      "args": [
+        "run",
+        "--rm",
+        "-i",
+        "-e",
+        "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "-e",
+        "GITHUB_API_URL",
+        "ifamousfreight/dhi-github-mcp:latest"
+      ]
+    }
+  }
+}

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -25,6 +25,6 @@ COPY --from=build /app ./
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
-  CMD node -e "require('http').get('http://127.0.0.1:3000/health', (res) => process.exit(res.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"
+  CMD node -e "const port = process.env.PORT || 3000; require('http').get('http://127.0.0.1:' + port + '/health', (res) => process.exit(res.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"
 
 CMD ["node", "apps/api/dist/server.js"]

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,7 +1,7 @@
 ARG NODE_VERSION=24
 FROM node:${NODE_VERSION}-alpine AS base
 WORKDIR /app
-RUN corepack enable
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
 
 FROM base AS deps
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
@@ -17,10 +17,14 @@ RUN pnpm --filter ./apps/api build
 FROM node:${NODE_VERSION}-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
-RUN corepack enable
+ENV PORT=3000
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
 
 COPY --from=build /app ./
 
 EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD node -e "require('http').get('http://127.0.0.1:3000/health', (res) => process.exit(res.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"
 
 CMD ["node", "apps/api/dist/server.js"]

--- a/README.md
+++ b/README.md
@@ -300,6 +300,8 @@ To verify a pulled image matches an expected SHA256 digest:
 pnpm run docker:verify-digest -- ifamousfreight/dhi-github-mcp:latest sha256:50b2c4f88e0dda38d3a163ad8ef1460fde82a70e2b28da73e6035f93c6f545d9
 ```
 
+For a quick Docker command reference, see [`docs/DOCKER_CLI_CHEATSHEET.md`](docs/DOCKER_CLI_CHEATSHEET.md).
+
 To pull and scan `ifamousfreight/dhi-github-mcp:0` with Docker Scout:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -312,6 +312,12 @@ To log into a private registry first, pass the registry and image explicitly:
 bash scripts/docker-scout-github-mcp.sh dhi.io dhi.io/github-mcp:0
 ```
 
+To scan a different public image without registry login:
+
+```bash
+bash scripts/docker-scout-github-mcp.sh ifamousfreight/dhi-github-mcp:0
+```
+
 If Docker is not installed yet on Ubuntu, install and validate it first:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -225,6 +225,99 @@ Install dependencies.
 pnpm install
 ```
 
+Or run the one-command API quickstart (installs deps, builds, and starts API):
+
+```bash
+pnpm run quickstart:api
+```
+
+This quickstart seeds missing env files from templates:
+`./.env`, `apps/api/.env`, and `apps/web/.env.local`.
+
+### Optional: GitHub MCP server (Docker)
+
+```bash
+cp .mcp.json.example .mcp.json
+export GITHUB_PERSONAL_ACCESS_TOKEN=your-personal-access-token
+export GITHUB_API_URL=https://github.example.com/api/v3 # optional (GitHub Enterprise)
+docker run --rm -i \
+  -e GITHUB_PERSONAL_ACCESS_TOKEN=your-personal-access-token \
+  -e GITHUB_API_URL=https://github.example.com/api/v3 \
+  ifamousfreight/dhi-github-mcp:latest
+```
+
+The local `.mcp.json` file is gitignored to avoid committing personal tokens.
+You can also run:
+
+```bash
+pnpm run mcp:github
+```
+
+To query the structure of the main branch from Git:
+
+```bash
+pnpm run repo:structure:main
+# full tree:
+TREE_FULL=true pnpm run repo:structure:main
+```
+
+To create a GitHub issue from CLI (title + description + optional labels):
+
+```bash
+bash scripts/create-github-issue.sh project/repo "Bug title" "Bug description" "bug,priority:high"
+```
+
+To create a PR from your current feature branch to `main`:
+
+```bash
+bash scripts/create-github-pr.sh main "PR title" "PR description" "reviewer1,reviewer2"
+```
+
+To check the latest CI run status for a PR:
+
+```bash
+# current PR inferred by gh:
+pnpm run github:pr:ci-status
+# or provide PR number:
+bash scripts/check-latest-pr-ci-status.sh 123
+```
+
+To check your current GitHub API rate limit:
+
+```bash
+pnpm run github:rate-limit
+```
+
+To find all files using a deprecated API function:
+
+```bash
+pnpm run repo:find-deprecated-api -- "<deprecated_function_name>"
+```
+
+To verify a pulled image matches an expected SHA256 digest:
+
+```bash
+pnpm run docker:verify-digest -- ifamousfreight/dhi-github-mcp:latest sha256:50b2c4f88e0dda38d3a163ad8ef1460fde82a70e2b28da73e6035f93c6f545d9
+```
+
+To pull and scan `ifamousfreight/dhi-github-mcp:0` with Docker Scout:
+
+```bash
+pnpm run docker:scout:github-mcp
+```
+
+To log into a private registry first, pass the registry and image explicitly:
+
+```bash
+bash scripts/docker-scout-github-mcp.sh dhi.io dhi.io/github-mcp:0
+```
+
+If Docker is not installed yet on Ubuntu, install and validate it first:
+
+```bash
+pnpm run docker:install:ubuntu
+```
+
 > **Runtime requirement:** this repo enforces Node.js **24.x** (see `.node-version` / `.nvmrc`). If you are not on the pinned Node version, `pnpm` will fail with `ERR_PNPM_UNSUPPORTED_ENGINE`.
 >
 > If you hit that error, switch to the version defined by the repo and retry install:

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/server.js",
     "typecheck": "pnpm --filter @infamous-freight/shared build && tsc --noEmit -p tsconfig.json",
     "lint": "eslint src --ext .ts",
-    "test": "node scripts/run-vitest.mjs",
+    "test": "pnpm --filter @infamous-freight/shared build && node scripts/run-vitest.mjs",
     "smoke": "node -e \"const base = (process.env.API_URL || 'http://localhost:4000').replace(/\\/$/, ''); fetch(base + '/health').then((res) => { if (!res.ok) process.exit(1); }).catch(() => process.exit(1));\"",
     "prisma:generate": "node scripts/prisma-generate-safe.mjs",
     "db:migrate": "PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 prisma migrate deploy --schema=prisma/schema.prisma",

--- a/apps/api/scripts/run-vitest.mjs
+++ b/apps/api/scripts/run-vitest.mjs
@@ -14,7 +14,10 @@ for (const arg of forwardedArgs) {
   sanitizedArgs.push(arg);
 }
 
-const vitestArgs = ['run', '--passWithNoTests', 'src/**/*.test.{ts,js,mjs}'];
+const vitestArgs = [
+  'run',
+  'src/**/*.test.ts',
+];
 
 if (forceSingleWorker && !sanitizedArgs.some((arg) => arg.startsWith('--maxWorkers'))) {
   vitestArgs.push('--maxWorkers=1');

--- a/apps/api/scripts/run-vitest.mjs
+++ b/apps/api/scripts/run-vitest.mjs
@@ -16,7 +16,7 @@ for (const arg of forwardedArgs) {
 
 const vitestArgs = [
   'run',
-  'src/**/*.test.ts',
+  'src/**/*.test.{ts,js,mjs}',
 ];
 
 if (forceSingleWorker && !sanitizedArgs.some((arg) => arg.startsWith('--maxWorkers'))) {

--- a/apps/api/src/middleware/auth.test.ts
+++ b/apps/api/src/middleware/auth.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+import type { NextFunction, Request, Response } from "express";
+import { ApiError } from "../utils/errors.js";
+import { getRequiredTenantId, requireAnyRole, requireTenantContext } from "./auth.js";
+
+describe("requireTenantContext", () => {
+  it("returns TENANT_CONTEXT_REQUIRED when auth or tenant context is missing", () => {
+    const req = { headers: {} } as Request;
+    const next = vi.fn();
+
+    requireTenantContext(req, {} as Response, next as NextFunction);
+
+    const err = next.mock.calls[0]?.[0] as ApiError;
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.statusCode).toBe(403);
+    expect(err.code).toBe("TENANT_CONTEXT_REQUIRED");
+  });
+
+  it("hydrates req.user.tenantId from auth organizationId when missing", () => {
+    const req = {
+      headers: {},
+      auth: {
+        userId: "user_1",
+        role: "SHIPPER",
+        tokenType: "access",
+        organizationId: "tenant_from_auth",
+      },
+      user: {
+        id: "user_1",
+        sub: "user_1",
+        email: "user@example.com",
+        role: "SHIPPER",
+      },
+    } as unknown as Request;
+
+    const next = vi.fn();
+
+    requireTenantContext(req, {} as Response, next as NextFunction);
+
+    expect(next).toHaveBeenCalledWith();
+    expect(req.user?.tenantId).toBe("tenant_from_auth");
+    expect(req.tenantId).toBe("tenant_from_auth");
+  });
+
+  it("getRequiredTenantId returns tenantId when present", () => {
+    const req = { tenantId: "tenant_123", headers: {} } as Request;
+    expect(getRequiredTenantId(req)).toBe("tenant_123");
+  });
+
+  it("getRequiredTenantId throws ApiError when tenantId is missing", () => {
+    const req = { headers: {} } as Request;
+    expect(() => getRequiredTenantId(req)).toThrowError(ApiError);
+    expect(() => getRequiredTenantId(req)).toThrowError("Tenant context is required");
+  });
+
+  it("requireAnyRole allows when role is in allow-list", () => {
+    const req = { auth: { role: "ADMIN" }, headers: {} } as unknown as Request;
+    const next = vi.fn();
+    const middleware = requireAnyRole(["admin", "shipper"]);
+
+    middleware(req, {} as Response, next as NextFunction);
+
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it("requireAnyRole rejects when role is outside allow-list", () => {
+    const req = { auth: { role: "viewer" }, headers: {} } as unknown as Request;
+    const next = vi.fn();
+    const middleware = requireAnyRole(["admin", "shipper"]);
+
+    middleware(req, {} as Response, next as NextFunction);
+
+    const err = next.mock.calls[0]?.[0] as ApiError;
+    expect(err.code).toBe("PERMISSION_DENIED");
+  });
+
+  it("requireAnyRole normalizes whitespace and case before comparing roles", () => {
+    const req = { auth: { role: "  ShIpPeR  " }, headers: {} } as unknown as Request;
+    const next = vi.fn();
+    const middleware = requireAnyRole(["shipper"]);
+
+    middleware(req, {} as Response, next as NextFunction);
+
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it("requireAnyRole returns ROLE_REQUIRED when role is not a string", () => {
+    const req = { auth: { role: 42 }, headers: {} } as unknown as Request;
+    const next = vi.fn();
+    const middleware = requireAnyRole(["admin"]);
+
+    middleware(req, {} as Response, next as NextFunction);
+
+    const err = next.mock.calls[0]?.[0] as ApiError;
+    expect(err.code).toBe("ROLE_REQUIRED");
+  });
+});

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -49,3 +49,54 @@ export function requireAuth(req: Request, _res: Response, next: NextFunction): v
     next(new ApiError(401, "INVALID_ACCESS_TOKEN", "Invalid or expired access token"));
   }
 }
+
+export function requireTenantContext(req: Request, _res: Response, next: NextFunction): void {
+  const tenantId = req.user?.tenantId ?? req.auth?.organizationId ?? req.tenantId;
+  if (!tenantId || !req.auth) {
+    next(new ApiError(403, "TENANT_CONTEXT_REQUIRED", "Tenant context is required"));
+    return;
+  }
+
+  req.user = {
+    ...req.user,
+    id: req.user?.id ?? req.auth?.userId ?? "",
+    sub: req.user?.sub ?? req.auth?.userId ?? "",
+    email: req.user?.email ?? "",
+    role: req.user?.role ?? req.auth.role,
+    tenantId,
+  };
+  req.tenantId = tenantId;
+  next();
+}
+
+export function getRequiredTenantId(req: Request): string {
+  const tenantId = req.user?.tenantId ?? req.tenantId;
+  if (!tenantId) {
+    throw new ApiError(403, "TENANT_CONTEXT_REQUIRED", "Tenant context is required");
+  }
+  return tenantId;
+}
+
+export function requireAnyRole(allowedRoles: string[]) {
+  const normalizedAllowedRoles = new Set(
+    allowedRoles
+      .map((role) => role.trim().toLowerCase())
+      .filter((role) => role.length > 0),
+  );
+
+  return (req: Request, _res: Response, next: NextFunction): void => {
+    const rawRole = req.auth?.role ?? req.user?.role;
+    const role = typeof rawRole === "string" ? rawRole.trim().toLowerCase() : null;
+    if (!role) {
+      next(new ApiError(403, "ROLE_REQUIRED", "Role is required for this operation"));
+      return;
+    }
+
+    if (!normalizedAllowedRoles.has(role)) {
+      next(new ApiError(403, "PERMISSION_DENIED", "You do not have permission for this operation"));
+      return;
+    }
+
+    next();
+  };
+}

--- a/apps/api/src/middleware/error-handler.test.ts
+++ b/apps/api/src/middleware/error-handler.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+import type { NextFunction, Request, Response } from "express";
+import { ZodError, z } from "zod";
+import { ApiError } from "../utils/errors.js";
+import { errorHandler, notFound } from "./error-handler.js";
+
+function mockResponse(): Response {
+  const res = {} as Response;
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn().mockReturnValue(res);
+  return res;
+}
+
+describe("error-handler middleware", () => {
+  it("returns notFound response with requestId when available", () => {
+    const req = {
+      requestId: "req-123",
+      headers: {},
+    } as unknown as Request;
+    const res = mockResponse();
+
+    notFound(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      error: {
+        code: "NOT_FOUND",
+        message: "Route not found",
+        requestId: "req-123",
+      },
+    });
+  });
+
+  it("returns ApiError payload with x-request-id fallback", () => {
+    const req = {
+      headers: { "x-request-id": "req-from-header" },
+    } as unknown as Request;
+    const res = mockResponse();
+    const next = vi.fn() as unknown as NextFunction;
+
+    errorHandler(new ApiError(403, "FORBIDDEN", "Access denied"), req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      error: {
+        code: "FORBIDDEN",
+        message: "Access denied",
+        requestId: "req-from-header",
+      },
+    });
+  });
+
+  it("returns validation payload for zod errors", () => {
+    const req = {
+      headers: {},
+      requestId: "req-zod",
+    } as unknown as Request;
+    const res = mockResponse();
+    const next = vi.fn() as unknown as NextFunction;
+
+    let validationError: ZodError;
+    try {
+      z.object({ tenantId: z.string().uuid() }).parse({ tenantId: "bad-id" });
+      throw new Error("Expected parse to fail");
+    } catch (error) {
+      validationError = error as ZodError;
+    }
+
+    errorHandler(validationError!, req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        error: expect.objectContaining({
+          code: "VALIDATION_ERROR",
+          requestId: "req-zod",
+        }),
+      }),
+    );
+  });
+});

--- a/apps/api/src/middleware/error-handler.ts
+++ b/apps/api/src/middleware/error-handler.ts
@@ -2,28 +2,51 @@ import type { NextFunction, Request, Response } from "express";
 import { ZodError } from "zod";
 import { ApiError } from "../utils/errors.js";
 
-export function notFound(_req: Request, res: Response): void {
+function resolveRequestId(req: Request): string | null {
+  if (typeof req.requestId === "string" && req.requestId.length > 0) {
+    return req.requestId;
+  }
+
+  const headerRequestId = req.headers["x-request-id"];
+  if (typeof headerRequestId === "string" && headerRequestId.length > 0) {
+    return headerRequestId;
+  }
+
+  if (Array.isArray(headerRequestId) && headerRequestId.length > 0) {
+    const firstRequestId = headerRequestId[0];
+    return typeof firstRequestId === "string" && firstRequestId.length > 0 ? firstRequestId : null;
+  }
+
+  return null;
+}
+
+export function notFound(req: Request, res: Response): void {
+  const requestId = resolveRequestId(req);
   res.status(404).json({
     success: false,
     error: {
       code: "NOT_FOUND",
       message: "Route not found",
+      ...(requestId ? { requestId } : {}),
     },
   });
 }
 
 export function errorHandler(
   err: unknown,
-  _req: Request,
+  req: Request,
   res: Response,
   _next: NextFunction,
 ): void {
+  const requestId = resolveRequestId(req);
+
   if (err instanceof ZodError) {
     res.status(400).json({
       success: false,
       error: {
         code: "VALIDATION_ERROR",
         message: "Request validation failed",
+        ...(requestId ? { requestId } : {}),
         details: err.flatten(),
       },
     });
@@ -36,6 +59,7 @@ export function errorHandler(
       error: {
         code: err.code,
         message: err.message,
+        ...(requestId ? { requestId } : {}),
         ...(err.details ? { details: err.details } : {}),
       },
     });
@@ -47,6 +71,7 @@ export function errorHandler(
     error: {
       code: "INTERNAL_SERVER_ERROR",
       message: "Internal server error",
+      ...(requestId ? { requestId } : {}),
     },
   });
 }

--- a/apps/api/src/routes/dispatches.ts
+++ b/apps/api/src/routes/dispatches.ts
@@ -1,9 +1,11 @@
 import { Router } from "express";
 import { z } from "zod";
-import { requireAuth, type AuthenticatedRequest } from "../middleware/auth.js";
+import { getRequiredTenantId, requireAnyRole, requireAuth, requireTenantContext } from "../middleware/auth.js";
 import { prisma } from "../db/prisma.js";
 
 const router: Router = Router();
+
+const tenantRouteRoles = ["owner", "admin", "dispatcher", "shipper", "user"];
 
 const createDispatchSchema = z.object({
   loadId: z.string().min(1),
@@ -11,9 +13,9 @@ const createDispatchSchema = z.object({
   notes: z.string().optional(),
 });
 
-router.get("/", requireAuth, async (req, res, next) => {
+router.get("/", requireAuth, requireTenantContext, requireAnyRole(tenantRouteRoles), async (req, res, next) => {
   try {
-    const tenantId = (req as AuthenticatedRequest).user?.tenantId ?? "";
+    const tenantId = getRequiredTenantId(req);
     const dispatches = await prisma.dispatch.findMany({
       where: { tenantId },
       orderBy: { createdAt: "desc" },
@@ -24,9 +26,9 @@ router.get("/", requireAuth, async (req, res, next) => {
   }
 });
 
-router.post("/", requireAuth, async (req, res, next) => {
+router.post("/", requireAuth, requireTenantContext, requireAnyRole(tenantRouteRoles), async (req, res, next) => {
   try {
-    const tenantId = (req as AuthenticatedRequest).user?.tenantId ?? "";
+    const tenantId = getRequiredTenantId(req);
     const body = createDispatchSchema.parse(req.body);
     const dispatch = await prisma.dispatch.create({
       data: { tenantId, ...body },
@@ -37,9 +39,9 @@ router.post("/", requireAuth, async (req, res, next) => {
   }
 });
 
-router.patch("/:id", requireAuth, async (req, res, next) => {
+router.patch("/:id", requireAuth, requireTenantContext, requireAnyRole(tenantRouteRoles), async (req, res, next) => {
   try {
-    const tenantId = (req as AuthenticatedRequest).user?.tenantId ?? "";
+    const tenantId = getRequiredTenantId(req);
     const { status } = z.object({ status: z.string() }).parse(req.body);
     const id = req.params.id as string;
     const existing = await prisma.dispatch.findFirst({

--- a/apps/api/src/routes/dispatches.ts
+++ b/apps/api/src/routes/dispatches.ts
@@ -5,7 +5,7 @@ import { prisma } from "../db/prisma.js";
 
 const router: Router = Router();
 
-const tenantRouteRoles = ["owner", "admin", "dispatcher", "shipper", "user"];
+const tenantRouteRoles = ["admin", "dispatcher", "driver"];
 
 const createDispatchSchema = z.object({
   loadId: z.string().min(1),

--- a/apps/api/src/routes/drivers.ts
+++ b/apps/api/src/routes/drivers.ts
@@ -1,9 +1,11 @@
 import { Router } from "express";
 import { z } from "zod";
-import { requireAuth, type AuthenticatedRequest } from "../middleware/auth.js";
+import { getRequiredTenantId, requireAnyRole, requireAuth, requireTenantContext } from "../middleware/auth.js";
 import { prisma } from "../db/prisma.js";
 
 const router: Router = Router();
+
+const tenantRouteRoles = ["owner", "admin", "dispatcher", "shipper", "user"];
 
 const createDriverSchema = z.object({
   name: z.string().min(1),
@@ -12,9 +14,9 @@ const createDriverSchema = z.object({
   status: z.enum(["AVAILABLE", "ON_DUTY", "OFF_DUTY"]).default("AVAILABLE"),
 });
 
-router.get("/", requireAuth, async (req, res, next) => {
+router.get("/", requireAuth, requireTenantContext, requireAnyRole(tenantRouteRoles), async (req, res, next) => {
   try {
-    const tenantId = (req as AuthenticatedRequest).user?.tenantId ?? "";
+    const tenantId = getRequiredTenantId(req);
     const drivers = await prisma.driver.findMany({
       where: { tenantId },
       orderBy: { name: "asc" },
@@ -25,9 +27,9 @@ router.get("/", requireAuth, async (req, res, next) => {
   }
 });
 
-router.post("/", requireAuth, async (req, res, next) => {
+router.post("/", requireAuth, requireTenantContext, requireAnyRole(tenantRouteRoles), async (req, res, next) => {
   try {
-    const tenantId = (req as AuthenticatedRequest).user?.tenantId ?? "";
+    const tenantId = getRequiredTenantId(req);
     const body = createDriverSchema.parse(req.body);
     const driver = await prisma.driver.create({
       data: { tenantId, ...body },
@@ -38,9 +40,9 @@ router.post("/", requireAuth, async (req, res, next) => {
   }
 });
 
-router.patch("/:id/status", requireAuth, async (req, res, next) => {
+router.patch("/:id/status", requireAuth, requireTenantContext, requireAnyRole(tenantRouteRoles), async (req, res, next) => {
   try {
-    const tenantId = (req as AuthenticatedRequest).user?.tenantId ?? "";
+    const tenantId = getRequiredTenantId(req);
     const { status } = z
       .object({
         status: z.enum(["AVAILABLE", "ON_DUTY", "OFF_DUTY"]),

--- a/apps/api/src/routes/drivers.ts
+++ b/apps/api/src/routes/drivers.ts
@@ -5,7 +5,7 @@ import { prisma } from "../db/prisma.js";
 
 const router: Router = Router();
 
-const tenantRouteRoles = ["owner", "admin", "dispatcher", "shipper", "user"];
+const tenantRouteRoles = ["admin", "dispatcher", "driver"] as const;
 
 const createDriverSchema = z.object({
   name: z.string().min(1),

--- a/apps/api/src/routes/loads.ts
+++ b/apps/api/src/routes/loads.ts
@@ -1,9 +1,11 @@
 import { Router } from "express";
 import { z } from "zod";
-import { requireAuth, type AuthenticatedRequest } from "../middleware/auth.js";
+import { getRequiredTenantId, requireAnyRole, requireAuth, requireTenantContext } from "../middleware/auth.js";
 import { prisma } from "../db/prisma.js";
 
 const router: Router = Router();
+
+const tenantRouteRoles = ["owner", "admin", "dispatcher", "shipper", "user"];
 
 const createLoadSchema = z.object({
   originCity: z.string().min(1),
@@ -16,9 +18,9 @@ const createLoadSchema = z.object({
   status: z.literal("OPEN").default("OPEN"),
 });
 
-router.get("/", requireAuth, async (req, res, next) => {
+router.get("/", requireAuth, requireTenantContext, requireAnyRole(tenantRouteRoles), async (req, res, next) => {
   try {
-    const tenantId = (req as AuthenticatedRequest).user?.tenantId ?? "";
+    const tenantId = getRequiredTenantId(req);
     const loads = await prisma.load.findMany({
       where: { tenantId },
       orderBy: { createdAt: "desc" },
@@ -29,9 +31,9 @@ router.get("/", requireAuth, async (req, res, next) => {
   }
 });
 
-router.post("/", requireAuth, async (req, res, next) => {
+router.post("/", requireAuth, requireTenantContext, requireAnyRole(tenantRouteRoles), async (req, res, next) => {
   try {
-    const tenantId = (req as AuthenticatedRequest).user?.tenantId ?? "";
+    const tenantId = getRequiredTenantId(req);
     const body = createLoadSchema.parse(req.body);
     const load = await prisma.load.create({ data: { tenantId, ...body } });
     res.status(201).json({ ok: true, data: load });
@@ -40,9 +42,9 @@ router.post("/", requireAuth, async (req, res, next) => {
   }
 });
 
-router.patch("/:id/status", requireAuth, async (req, res, next) => {
+router.patch("/:id/status", requireAuth, requireTenantContext, requireAnyRole(tenantRouteRoles), async (req, res, next) => {
   try {
-    const tenantId = (req as AuthenticatedRequest).user?.tenantId ?? "";
+    const tenantId = getRequiredTenantId(req);
     const { status } = z.object({ status: z.string() }).parse(req.body);
     const id = req.params.id as string;
     const load = await prisma.load.findFirst({ where: { id, tenantId } });

--- a/apps/api/src/routes/loads.ts
+++ b/apps/api/src/routes/loads.ts
@@ -5,7 +5,7 @@ import { prisma } from "../db/prisma.js";
 
 const router: Router = Router();
 
-const tenantRouteRoles = ["owner", "admin", "dispatcher", "shipper", "user"];
+const tenantRouteRoles = ["admin", "dispatcher", "driver"];
 
 const createLoadSchema = z.object({
   originCity: z.string().min(1),

--- a/apps/api/src/types/express.d.ts
+++ b/apps/api/src/types/express.d.ts
@@ -34,6 +34,7 @@ declare global {
       tenantId?: string;
       orgId?: string;
       organizationId?: string;
+      requestId?: string;
     }
   }
 }

--- a/docs/DOCKER_CLI_CHEATSHEET.md
+++ b/docs/DOCKER_CLI_CHEATSHEET.md
@@ -25,7 +25,7 @@ docker info
 docker build -t <image_name> .
 
 # Build without cache
-docker build -t <image_name> . --no-cache
+docker build --no-cache -t <image_name> .
 
 # List local images
 docker images

--- a/docs/DOCKER_CLI_CHEATSHEET.md
+++ b/docs/DOCKER_CLI_CHEATSHEET.md
@@ -1,0 +1,111 @@
+# Docker CLI Cheat Sheet
+
+Quick reference for common Docker commands used in local development and operations.
+
+## Installation & Docs
+
+- Docker Desktop (Mac, Linux, Windows): https://docs.docker.com/desktop
+- Example compose projects: https://github.com/docker/awesome-compose
+- Docker docs: https://docs.docker.com
+
+## General Commands
+
+```bash
+# Docker help
+docker --help
+
+# System-wide Docker information
+docker info
+```
+
+## Images
+
+```bash
+# Build image from Dockerfile
+docker build -t <image_name> .
+
+# Build without cache
+docker build -t <image_name> . --no-cache
+
+# List local images
+docker images
+
+# Delete an image
+docker rmi <image_name>
+
+# Remove unused images
+docker image prune
+```
+
+## Containers
+
+```bash
+# Run a container with custom name
+docker run --name <container_name> <image_name>
+
+# Run and publish ports
+docker run -p <host_port>:<container_port> <image_name>
+
+# Run detached
+docker run -d <image_name>
+
+# Start / stop by name
+docker start <container_name>
+docker stop <container_name>
+
+# Start / stop by id
+docker start <container_id>
+docker stop <container_id>
+
+# Remove stopped container
+docker rm <container_name>
+
+# Shell into running container
+docker exec -it <container_name> sh
+
+# Follow logs
+docker logs -f <container_name>
+
+# Inspect container
+docker inspect <container_name>
+docker inspect <container_id>
+
+# List running containers
+docker ps
+
+# List all containers
+docker ps --all
+
+# Container resource usage
+docker container stats
+```
+
+## Docker Hub
+
+```bash
+# Login
+docker login -u <username>
+
+# Push
+docker push <username>/<image_name>
+
+# Search
+docker search <image_name>
+
+# Pull
+docker pull <image_name>
+```
+
+## Fast Practical Subset
+
+```bash
+docker build -t myapp .
+docker images
+docker run -d -p 8080:80 --name myapp-container myapp
+docker ps
+docker logs -f myapp-container
+docker exec -it myapp-container sh
+docker stop myapp-container
+docker rm myapp-container
+docker rmi myapp
+```

--- a/docs/PRODUCTION_RECOMMENDATIONS_2026-04-16.md
+++ b/docs/PRODUCTION_RECOMMENDATIONS_2026-04-16.md
@@ -1,0 +1,54 @@
+# Production Recommendations (April 16, 2026)
+
+These recommendations are prioritized to keep Infamous Freight stable, secure, and deployment-ready.
+
+## 1) Authentication hardening
+- Enforce a single auth middleware path for all API routes that touch tenant data.
+- Add a CI guard that fails if protected routes are registered without auth middleware.
+- Standardize token verification errors to avoid leaking internals.
+
+## 2) Tenant isolation guarantees
+- Introduce a Prisma query helper that requires `tenantId` for all tenant-scoped models.
+- Add integration tests that assert cross-tenant access always returns 403/404.
+- Add static checks (eslint/custom rule) for unsafe tenant queries in `apps/api`.
+
+## 3) RBAC consistency
+- Centralize permission checks in one reusable service or middleware layer.
+- Add route-level tests that verify unauthorized roles cannot access protected endpoints.
+- Audit routes for mixed inline permission logic and migrate to shared guards.
+
+## 4) Configuration and environment safety
+- Validate all required env vars at process startup (fail fast).
+- Separate required vars by runtime (`api`, `web`, `worker`) and environment (`dev`, `staging`, `prod`).
+- Ensure `SENTRY_DSN` is optional and Sentry remains disabled when unset.
+
+## 5) Shared contracts and type safety
+- Move API request/response contracts to shared packages and consume from both API and web.
+- Gate merges on `tsc --noEmit` for all workspaces.
+- Add API schema drift checks in CI.
+
+## 6) Audit logging completeness
+- Require `AiDecisionLog` writes for all AI decision points.
+- Add explicit correlation IDs so decisions can be traced to requests and billing events.
+- Add tests that fail when decision-producing code paths skip audit writes.
+
+## 7) Error handling and resilience
+- Standardize error envelopes (`code`, `message`, `requestId`, optional `details`).
+- Keep Sentry capture middleware after routes and before custom error middleware.
+- Add non-production `GET /debug/sentry` verification only when Sentry is configured.
+
+## 8) Billing idempotency safety
+- Use `BillingEvent` idempotency keys for all Stripe webhook and mutation handlers.
+- Add replay tests for duplicate webhook events.
+- Ensure idempotency key uniqueness scope is documented (event type + provider ID + tenant).
+
+## 9) Build/test/deploy reliability
+- In CI: run `prisma generate` before build/tests for every app relying on Prisma.
+- Enforce `pnpm -r test -- --runInBand` for stability-sensitive suites.
+- Verify Docker startup path binds to `PORT=3000` and `/health` returns 200.
+
+## Suggested execution order (next 2 sprints)
+1. Tenant query guardrails + RBAC centralization.
+2. Env validation + shared error envelope.
+3. Billing idempotency replay coverage + AI decision audit test coverage.
+4. CI enforcement for protected routes/auth and tenant-safe query checks.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,17 @@
   "packageManager": "pnpm@10.33.0",
   "scripts": {
     "dev": "pnpm run dev:api",
+    "quickstart:api": "bash scripts/quickstart-api.sh",
+    "mcp:github": "bash scripts/run-github-mcp.sh",
+    "repo:structure:main": "bash scripts/main-branch-structure.sh origin main",
+    "github:issue:create": "bash scripts/create-github-issue.sh",
+    "github:pr:create": "bash scripts/create-github-pr.sh",
+    "github:pr:ci-status": "bash scripts/check-latest-pr-ci-status.sh",
+    "github:rate-limit": "bash scripts/github-rate-limit.sh",
+    "repo:find-deprecated-api": "bash scripts/find-deprecated-api-usage.sh",
+    "docker:verify-digest": "bash scripts/verify-image-digest.sh",
+    "docker:scout:github-mcp": "bash scripts/docker-scout-github-mcp.sh",
+    "docker:install:ubuntu": "bash scripts/install-docker-ubuntu.sh",
     "predev:api": "pnpm run build:shared",
     "dev:api": "pnpm --filter @infamous/api dev",
     "dev:web": "pnpm --filter web dev",
@@ -36,12 +47,14 @@
     "fly:preflight": "bash scripts/fly-preflight.sh",
     "fly:deploy:api": "bash scripts/fly-deploy-api.sh",
     "validate": "pnpm run build && pnpm run typecheck && pnpm run lint && pnpm run test",
+    "infamous:100": "bash scripts/setup.sh && pnpm -r --if-present --workspace-concurrency=1 test -- --runInBand && pnpm run typecheck && pnpm run lint",
     "smoke:release": "bash scripts/release-smoke-check.sh",
     "deploy:check": "pnpm validate && pnpm audit:prod && pnpm smoke:release",
     "deploy:work": "bash scripts/deploy-work-branch.sh",
     "health": "pnpm run lint && pnpm run typecheck && pnpm run test",
     "health:quick": "pnpm run lint && pnpm run typecheck",
-    "fly:deploy:web": "bash scripts/fly-deploy-web.sh"
+    "fly:deploy:web": "bash scripts/fly-deploy-web.sh",
+    "security:scan:image": "bash scripts/security-scan-image.sh"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "fly:preflight": "bash scripts/fly-preflight.sh",
     "fly:deploy:api": "bash scripts/fly-deploy-api.sh",
     "validate": "pnpm run build && pnpm run typecheck && pnpm run lint && pnpm run test",
-    "infamous:100": "bash scripts/setup.sh && pnpm -r --if-present --workspace-concurrency=1 test -- --runInBand && pnpm run typecheck && pnpm run lint",
+    "infamous:100": "bash scripts/setup.sh && pnpm -r --if-present --workspace-concurrency=1 test && pnpm run typecheck && pnpm run lint",
     "smoke:release": "bash scripts/release-smoke-check.sh",
     "deploy:check": "pnpm validate && pnpm audit:prod && pnpm smoke:release",
     "deploy:work": "bash scripts/deploy-work-branch.sh",

--- a/scripts/check-latest-pr-ci-status.sh
+++ b/scripts/check-latest-pr-ci-status.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+PR_NUMBER="${1:-}"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "GitHub CLI (gh) is required to check PR CI status." >&2
+  exit 1
+fi
+
+if [ -z "${PR_NUMBER}" ]; then
+  PR_NUMBER="$(gh pr view --json number --jq '.number' 2>/dev/null || true)"
+fi
+
+if [ -z "${PR_NUMBER}" ]; then
+  echo "Unable to determine PR number. Provide it explicitly: <pr_number>" >&2
+  exit 1
+fi
+
+echo "==> Latest CI run status for PR #${PR_NUMBER}"
+gh run list \
+  --branch "$(gh pr view "${PR_NUMBER}" --json headRefName --jq '.headRefName')" \
+  --limit 1 \
+  --json databaseId,workflowName,displayTitle,status,conclusion,url,createdAt \
+  --jq '.[] | {workflowName, displayTitle, status, conclusion, url, createdAt}'

--- a/scripts/create-github-issue.sh
+++ b/scripts/create-github-issue.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+REPO="${1:-}"
+TITLE="${2:-}"
+BODY="${3:-}"
+LABELS="${4:-}"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "GitHub CLI (gh) is required to create issues from this script." >&2
+  exit 1
+fi
+
+if [ -z "${REPO}" ] || [ -z "${TITLE}" ] || [ -z "${BODY}" ]; then
+  echo "Usage: bash scripts/create-github-issue.sh <owner/repo> <title> <description> [labels_csv]" >&2
+  echo "Example: bash scripts/create-github-issue.sh project/repo \"Bug title\" \"Steps + expected + actual\" \"bug,priority:high\"" >&2
+  exit 1
+fi
+
+cmd=(gh issue create --repo "${REPO}" --title "${TITLE}" --body "${BODY}")
+
+if [ -n "${LABELS}" ]; then
+  cmd+=(--label "${LABELS}")
+fi
+
+"${cmd[@]}"

--- a/scripts/create-github-pr.sh
+++ b/scripts/create-github-pr.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+BASE_BRANCH="${1:-main}"
+TITLE="${2:-}"
+BODY="${3:-}"
+REVIEWERS="${4:-}"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "GitHub CLI (gh) is required to create pull requests from this script." >&2
+  exit 1
+fi
+
+HEAD_BRANCH="$(git branch --show-current)"
+if [ -z "${HEAD_BRANCH}" ]; then
+  echo "Unable to determine current branch." >&2
+  exit 1
+fi
+
+if [ -z "${TITLE}" ] || [ -z "${BODY}" ]; then
+  echo "Usage: bash scripts/create-github-pr.sh <base_branch> <title> <body> [reviewers_csv]" >&2
+  echo "Example: bash scripts/create-github-pr.sh main \"PR title\" \"PR description\" \"reviewer1,reviewer2\"" >&2
+  exit 1
+fi
+
+cmd=(gh pr create --base "${BASE_BRANCH}" --head "${HEAD_BRANCH}" --title "${TITLE}" --body "${BODY}")
+
+if [ -n "${REVIEWERS}" ]; then
+  cmd+=(--reviewer "${REVIEWERS}")
+fi
+
+"${cmd[@]}"

--- a/scripts/docker-scout-github-mcp.sh
+++ b/scripts/docker-scout-github-mcp.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+REGISTRY="${1:-}"
+IMAGE="${2:-ifamousfreight/dhi-github-mcp:0}"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker is required for registry login, pull, and scout CVE scan." >&2
+  echo "Install Docker on Ubuntu with: bash scripts/install-docker-ubuntu.sh" >&2
+  exit 1
+fi
+
+if ! docker scout --help >/dev/null 2>&1; then
+  echo "Docker Scout is required but not available in this Docker installation." >&2
+  echo "Reinstall Docker with Docker's official packages (includes Scout plugin)." >&2
+  exit 1
+fi
+
+if [[ -n "${REGISTRY}" ]]; then
+  echo "==> Logging into ${REGISTRY}"
+  docker login "${REGISTRY}"
+else
+  echo "==> Skipping docker login (no registry argument provided)"
+fi
+
+echo "==> Pulling ${IMAGE}"
+docker pull "${IMAGE}"
+
+echo "==> Running Docker Scout CVE scan for ${IMAGE}"
+docker scout cves "${IMAGE}"

--- a/scripts/docker-scout-github-mcp.sh
+++ b/scripts/docker-scout-github-mcp.sh
@@ -1,8 +1,19 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-REGISTRY="${1:-}"
-IMAGE="${2:-ifamousfreight/dhi-github-mcp:0}"
+DEFAULT_IMAGE="ifamousfreight/dhi-github-mcp:0"
+REGISTRY=""
+IMAGE="${DEFAULT_IMAGE}"
+
+if [[ $# -ge 1 ]]; then
+  if [[ "$1" == *"/"* || "$1" == *":"* ]]; then
+    IMAGE="$1"
+    REGISTRY="${2:-}"
+  else
+    REGISTRY="$1"
+    IMAGE="${2:-$DEFAULT_IMAGE}"
+  fi
+fi
 
 if ! command -v docker >/dev/null 2>&1; then
   echo "Docker is required for registry login, pull, and scout CVE scan." >&2

--- a/scripts/find-deprecated-api-usage.sh
+++ b/scripts/find-deprecated-api-usage.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+PATTERN="${1:-deprecatedApiFunction}"
+
+echo "==> Searching repository for deprecated API usage pattern: ${PATTERN}"
+
+if ! command -v rg >/dev/null 2>&1; then
+  echo "ripgrep (rg) is required." >&2
+  exit 1
+fi
+
+matches="$(rg -n --glob '!node_modules/**' --glob '!.next/**' --glob '!dist/**' "${PATTERN}" . || true)"
+
+if [ -z "${matches}" ]; then
+  echo "No matches found for pattern: ${PATTERN}"
+  exit 0
+fi
+
+echo "${matches}"

--- a/scripts/find-deprecated-api-usage.sh
+++ b/scripts/find-deprecated-api-usage.sh
@@ -10,7 +10,7 @@ if ! command -v rg >/dev/null 2>&1; then
   exit 1
 fi
 
-matches="$(rg -n --glob '!node_modules/**' --glob '!.next/**' --glob '!dist/**' "${PATTERN}" . || true)"
+matches="$(rg -n --glob '!node_modules/**' --glob '!.next/**' --glob '!dist/**' -- "${PATTERN}" . || true)"
 
 if [ -z "${matches}" ]; then
   echo "No matches found for pattern: ${PATTERN}"

--- a/scripts/github-rate-limit.sh
+++ b/scripts/github-rate-limit.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "GitHub CLI (gh) is required to check API rate limits." >&2
+  exit 1
+fi
+
+echo "==> GitHub API rate limit (core)"
+gh api rate_limit --jq '{
+  limit: .resources.core.limit,
+  remaining: .resources.core.remaining,
+  used: .resources.core.used,
+  reset_epoch: .resources.core.reset
+}'

--- a/scripts/install-docker-ubuntu.sh
+++ b/scripts/install-docker-ubuntu.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+if [[ "${EUID}" -eq 0 ]]; then
+  SUDO=""
+else
+  if ! command -v sudo >/dev/null 2>&1; then
+    echo "sudo is required when running as non-root." >&2
+    exit 1
+  fi
+  SUDO="sudo"
+fi
+
+if [[ ! -r /etc/os-release ]]; then
+  echo "Unable to detect OS from /etc/os-release." >&2
+  exit 1
+fi
+
+# shellcheck source=/etc/os-release
+. /etc/os-release
+if [[ "${ID:-}" != "ubuntu" ]]; then
+  echo "This installer currently supports Ubuntu only. Detected ID='${ID:-unknown}'." >&2
+  exit 1
+fi
+
+$SUDO apt update
+$SUDO apt install -y ca-certificates curl
+$SUDO install -m 0755 -d /etc/apt/keyrings
+$SUDO curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+$SUDO chmod a+r /etc/apt/keyrings/docker.asc
+
+ARCH="$(dpkg --print-architecture)"
+CODENAME="${UBUNTU_CODENAME:-${VERSION_CODENAME:-}}"
+if [[ -z "${CODENAME}" ]]; then
+  echo "Could not resolve Ubuntu codename." >&2
+  exit 1
+fi
+
+$SUDO tee /etc/apt/sources.list.d/docker.sources >/dev/null <<EOF2
+Types: deb
+URIs: https://download.docker.com/linux/ubuntu
+Suites: ${CODENAME}
+Components: stable
+Architectures: ${ARCH}
+Signed-By: /etc/apt/keyrings/docker.asc
+EOF2
+
+$SUDO apt update
+$SUDO apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+$SUDO docker run hello-world

--- a/scripts/main-branch-structure.sh
+++ b/scripts/main-branch-structure.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+REMOTE="${1:-origin}"
+BRANCH="${2:-main}"
+REF="${REMOTE}/${BRANCH}"
+
+echo "==> Fetching ${REF}"
+git fetch --depth=1 "${REMOTE}" "${BRANCH}" >/dev/null 2>&1 || true
+
+if ! git rev-parse --verify "${REF}" >/dev/null 2>&1; then
+  if [ "${BRANCH}" = "main" ]; then
+    default_remote_ref="$(git symbolic-ref --short "refs/remotes/${REMOTE}/HEAD" 2>/dev/null || true)"
+    if [ -n "${default_remote_ref}" ] && git rev-parse --verify "${default_remote_ref}" >/dev/null 2>&1; then
+      REF="${default_remote_ref}"
+      echo "==> ${REMOTE}/main not found, falling back to ${REF}"
+    elif git rev-parse --verify "main" >/dev/null 2>&1; then
+      REF="main"
+      echo "==> ${REMOTE}/main not found, falling back to local ${REF}"
+    elif git rev-parse --verify "master" >/dev/null 2>&1; then
+      REF="master"
+      echo "==> ${REMOTE}/main not found, falling back to local ${REF}"
+    elif git rev-parse --verify "HEAD" >/dev/null 2>&1; then
+      REF="HEAD"
+      echo "==> ${REMOTE}/main not found, falling back to ${REF}"
+    else
+      echo "Unable to resolve ${REF}. Ensure remote/branch exists." >&2
+      exit 1
+    fi
+  else
+    echo "Unable to resolve ${REF}. Ensure remote/branch exists." >&2
+    exit 1
+  fi
+fi
+
+echo "==> Top-level structure for ${REF}"
+git ls-tree --name-only "${REF}"
+
+if [ "${TREE_FULL:-false}" = "true" ]; then
+  echo ""
+  echo "==> Full file tree for ${REF}"
+  git ls-tree -r --name-only "${REF}"
+fi

--- a/scripts/quickstart-api.sh
+++ b/scripts/quickstart-api.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+if [ -s "$NVM_DIR/nvm.sh" ]; then
+  # shellcheck disable=SC1090
+  . "$NVM_DIR/nvm.sh"
+  nvm install
+  nvm use
+fi
+
+seed_env_file() {
+  local source_file=$1
+  local target_file=$2
+  if [ -f "$source_file" ] && [ ! -f "$target_file" ]; then
+    echo "==> Creating ${target_file} from ${source_file}"
+    cp "$source_file" "$target_file"
+  fi
+}
+
+echo "==> Enabling pnpm via Corepack"
+corepack enable
+corepack prepare pnpm@10.33.0 --activate
+
+if [ ! -f ".env" ] && [ -f ".env.example" ]; then
+  echo "==> Creating .env from .env.example"
+  cp .env.example .env
+fi
+seed_env_file "apps/api/.env.example" "apps/api/.env"
+seed_env_file "apps/web/.env.example" "apps/web/.env.local"
+
+echo "==> Installing dependencies"
+pnpm install --frozen-lockfile
+
+echo "==> Building workspace"
+pnpm build
+
+if [ "${QUICKSTART_SKIP_DEV:-false}" = "true" ]; then
+  echo "==> QUICKSTART_SKIP_DEV=true, skipping pnpm dev:api"
+  exit 0
+fi
+
+echo "==> Starting API"
+pnpm dev:api

--- a/scripts/run-github-mcp.sh
+++ b/scripts/run-github-mcp.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+IMAGE="${GITHUB_MCP_IMAGE:-ifamousfreight/dhi-github-mcp:latest}"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker not found. Install Docker to run ${IMAGE}." >&2
+  exit 1
+fi
+
+if [ -z "${GITHUB_PERSONAL_ACCESS_TOKEN:-}" ]; then
+  echo "GITHUB_PERSONAL_ACCESS_TOKEN is required." >&2
+  echo "Example: export GITHUB_PERSONAL_ACCESS_TOKEN=your-personal-access-token" >&2
+  exit 1
+fi
+
+docker run --rm -i \
+  -e GITHUB_PERSONAL_ACCESS_TOKEN="${GITHUB_PERSONAL_ACCESS_TOKEN}" \
+  -e GITHUB_API_URL="${GITHUB_API_URL:-}" \
+  "${IMAGE}"

--- a/scripts/security-scan-image.sh
+++ b/scripts/security-scan-image.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+IMAGE="${IMAGE:-ifamousfreight/dhi-github-mcp:latest}"
+REGISTRY="${REGISTRY:-docker.io}"
+VEX_FILE="${VEX_FILE:-vex.json}"
+
+echo "==> Target image: ${IMAGE}"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker not found, skipping Docker-based scans."
+  exit 0
+fi
+
+echo "==> Logging into registry (${REGISTRY})"
+docker login "${REGISTRY}"
+
+echo "==> Pulling image"
+docker pull "${IMAGE}"
+
+echo "==> Docker Scout scan"
+docker scout cves "${IMAGE}"
+
+echo "==> Trivy scan"
+if command -v trivy >/dev/null 2>&1; then
+  trivy image --scanners vuln --vex repo "${IMAGE}"
+else
+  echo "Trivy not installed, skipping"
+fi
+
+echo "==> Grype scan"
+if command -v grype >/dev/null 2>&1; then
+  if [ -f "${VEX_FILE}" ]; then
+    grype "${IMAGE}" --vex "${VEX_FILE}"
+  else
+    echo "${VEX_FILE} not found, running Grype without VEX file"
+    grype "${IMAGE}"
+  fi
+else
+  echo "Grype not installed, skipping"
+fi
+
+echo "==> Done"

--- a/scripts/security-scan-image.sh
+++ b/scripts/security-scan-image.sh
@@ -19,7 +19,11 @@ echo "==> Pulling image"
 docker pull "${IMAGE}"
 
 echo "==> Docker Scout scan"
-docker scout cves "${IMAGE}"
+if docker scout version >/dev/null 2>&1; then
+  docker scout cves "${IMAGE}"
+else
+  echo "Docker Scout not installed, skipping"
+fi
 
 echo "==> Trivy scan"
 if command -v trivy >/dev/null 2>&1; then

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -15,7 +15,28 @@ sanitize_npm_proxy_env() {
   unset NPM_CONFIG_HTTP_PROXY || true
 }
 
+seed_env_file() {
+  local source_file=$1
+  local target_file=$2
+  if [ -f "$source_file" ] && [ ! -f "$target_file" ]; then
+    echo "==> Creating ${target_file} from ${source_file}"
+    cp "$source_file" "$target_file"
+  fi
+}
+
+bootstrap_node_runtime() {
+  export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+  if [ -s "$NVM_DIR/nvm.sh" ]; then
+    # shellcheck disable=SC1090
+    . "$NVM_DIR/nvm.sh"
+    nvm install
+    nvm use
+  fi
+}
+
 sanitize_npm_proxy_env
+echo "==> Initializing Node runtime"
+bootstrap_node_runtime
 
 echo "==> Enabling pnpm via Corepack"
 corepack enable
@@ -25,9 +46,14 @@ if [ -f ".env.example" ] && [ ! -f ".env" ]; then
   echo "==> Creating .env from .env.example"
   cp .env.example .env
 fi
+seed_env_file "apps/api/.env.example" "apps/api/.env"
+seed_env_file "apps/web/.env.example" "apps/web/.env.local"
 
 echo "==> Installing dependencies"
-pnpm install
+pnpm install --frozen-lockfile
+
+echo "==> Generating Prisma client"
+pnpm prisma:generate
 
 echo "==> Building shared package and workspaces"
 pnpm build

--- a/scripts/verify-image-digest.sh
+++ b/scripts/verify-image-digest.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+IMAGE="${1:-ifamousfreight/dhi-github-mcp:latest}"
+EXPECTED_DIGEST="${2:-sha256:50b2c4f88e0dda38d3a163ad8ef1460fde82a70e2b28da73e6035f93c6f545d9}"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker is required to verify image digest." >&2
+  exit 1
+fi
+
+echo "==> Pulling image: ${IMAGE}"
+docker pull "${IMAGE}" >/dev/null
+
+actual_digest="$(
+  docker image inspect "${IMAGE}" --format '{{range .RepoDigests}}{{println .}}{{end}}' \
+    | awk -F'@' 'NF==2 {print $2; exit}'
+)"
+
+if [ -z "${actual_digest}" ]; then
+  echo "Unable to determine image digest for ${IMAGE}" >&2
+  exit 1
+fi
+
+echo "Expected: ${EXPECTED_DIGEST}"
+echo "Actual:   ${actual_digest}"
+
+if [ "${actual_digest}" != "${EXPECTED_DIGEST}" ]; then
+  echo "Digest mismatch." >&2
+  exit 1
+fi
+
+echo "Digest verified."


### PR DESCRIPTION
### Motivation
- Ensure tenant-scoped routes consistently enforce tenant context and role-based access to prevent cross-tenant access.
- Standardize error envelopes to include a `requestId` (from `req.requestId` or `x-request-id`) for better observability and debugging.
- Improve developer ergonomics for local development and infra workflows with quickstart scripts, CI helpers, and image health checks.

### Description
- Added `requireTenantContext`, `getRequiredTenantId`, and `requireAnyRole` to `apps/api/src/middleware/auth.ts` to centralize tenant and RBAC checks and normalized role comparisons.
- Updated `apps/api/src/routes/loads.ts`, `drivers.ts`, and `dispatches.ts` to require tenant context and role checks and to use `getRequiredTenantId` for tenant-scoped Prisma queries.
- Enhanced error handling in `apps/api/src/middleware/error-handler.ts` to resolve `requestId` from `req.requestId` or `x-request-id` and include it in `notFound`, validation, ApiError, and internal error responses.
- Added unit tests `auth.test.ts` and `error-handler.test.ts` under `apps/api/src/middleware/` to cover tenant/context/role behavior and error envelope formatting.
- Extended Express types with `requestId` in `apps/api/src/types/express.d.ts` and updated tests and middleware accordingly.
- Dockerfile changes: pinned `pnpm` via Corepack, set `PORT=3000` in runner, and added a `HEALTHCHECK` that probes `/health`.
- Developer tooling: added numerous helper scripts (quickstart, GH issue/PR helpers, docker/image scanning, health checks, etc.), added `.mcp.json.example`, updated `.gitignore` to ignore `.mcp.json`, and expanded `package.json` scripts.
- Updated `.env.example` with Supabase and Stripe publishable keys plus `NEXT_PUBLIC_APP_URL`, and expanded `README.md` with quickstart and MCP guidance, and added `docs/PRODUCTION_RECOMMENDATIONS_2026-04-16.md`.

### Testing
- Added Vitest unit tests for the API middleware and executed the API test suite with `pnpm --filter @infamous/api exec vitest`, which passed.
- Ran the full workspace test command `pnpm test` (which runs `prisma:generate` and workspace tests), and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e165ef75fc8330a8b7e14fb16e4448)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces tenant context and RBAC on tenant-scoped API routes and standardizes error envelopes with a `requestId` for better tracing. Adds a one-command API quickstart, GitHub/MCP helpers, pinned `pnpm@10.33.0`, a Docker `/health` healthcheck, and registry-aware image scan/verify tooling.

- **New Features**
  - Guards: `requireTenantContext`, `getRequiredTenantId`, `requireAnyRole`; applied to `loads`, `drivers`, `dispatches` with tenant-scoped Prisma queries.
  - Errors: include `requestId` (from `req.requestId` or `x-request-id`) for 404, Zod, `ApiError`, and 500; Express types updated; middleware unit tests added; API tests prebuild `@infamous-freight/shared`.
  - Docker & images: `Dockerfile.api` pins `pnpm@10.33.0`, sets `PORT=3000`, adds `/health` `HEALTHCHECK`; digest verification; `security:scan:image` logs into registry, pulls image, and scans with Docker Scout, Trivy, Grype (optional VEX); `docker:scout:github-mcp`.
  - DX: `quickstart:api`; `.mcp.json.example` (gitignored); GitHub helpers (issue/PR, rate limit, PR CI status, repo structure).
  - Docs/env: `DOCKER_CLI_CHEATSHEET.md`, production recommendations; `.env.example` expanded (Supabase keys incl. service role, `NEXT_PUBLIC_APP_URL`, `NEXT_PUBLIC_ENV`, Stripe publishable key).

<sup>Written for commit 8260e8a918b755b3ed25f09bdfdaf5e2a3044ad3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

