### PR TITLE
fix(web): use Dockerfile.web in apps/web Fly config

### DIFF
--- a/apps/web/fly.toml
+++ b/apps/web/fly.toml
@@ -7,7 +7,7 @@ app = 'infamous-freight'
 primary_region = 'dfw'
 
 [build]
-  context = "."
+  context = "../.."
   dockerfile = "Dockerfile.web"
 
 [http_service]

--- a/apps/web/fly.toml
+++ b/apps/web/fly.toml
@@ -8,7 +8,7 @@ primary_region = 'dfw'
 
 [build]
   context = "../.."
-  dockerfile = "Dockerfile"
+  dockerfile = "Dockerfile.web"
 
 [http_service]
   internal_port = 3000

--- a/apps/web/fly.toml
+++ b/apps/web/fly.toml
@@ -7,7 +7,7 @@ app = 'infamous-freight'
 primary_region = 'dfw'
 
 [build]
-  context = "../.."
+  context = "."
   dockerfile = "Dockerfile.web"
 
 [http_service]


### PR DESCRIPTION
### Motivation
- The web Fly deployment was pointing at `Dockerfile`, which is not the monorepo-aware frontend Dockerfile and can cause build-context / COPY path failures during `flyctl deploy` for the web app.

### Description
- Update `apps/web/fly.toml` to set `build.dockerfile` to `Dockerfile.web` so the web app uses the intended frontend Dockerfile.

### Testing
- Parsed `apps/web/fly.toml` with Python `tomllib` (`python - <<'PY' ...`) and the TOML loaded successfully.
- Attempted `flyctl config validate -c apps/web/fly.toml` but the command could not be executed in this environment because `flyctl` is not installed (validation could not run here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2e9b232f883309e03d729d96fe4a0)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Point `apps/web/fly.toml` to `Dockerfile.web` and set the build context to the repo root (`../..`) for the web app’s Fly deployment. This uses the monorepo-aware Dockerfile and fixes COPY path errors during `flyctl deploy`.

<sup>Written for commit 9c2a8c088506bea08aae5e7db42207d6515eeb15. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated deployment build configuration to use an optimized container setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->