### PR TITLE
Fix shipment status typing in API and align web marketing tests with current routes

### DIFF
--- a/apps/api/src/services/shipments.service.ts
+++ b/apps/api/src/services/shipments.service.ts
@@ -2,12 +2,18 @@ import type { Shipment } from "@infamous-freight/shared";
 import { SHIPMENT_STATUSES } from "@infamous-freight/shared";
 import { prisma } from "../db/prisma.js";
 
-const SHIPMENT_TRANSITIONS: Record<string, readonly string[]> = {
+type MutableShipmentStatus = (typeof SHIPMENT_STATUSES)[number];
+
+const SHIPMENT_TRANSITIONS: Record<MutableShipmentStatus, readonly MutableShipmentStatus[]> = {
   CREATED: ["IN_TRANSIT", "CANCELLED"],
   IN_TRANSIT: ["DELIVERED", "CANCELLED"],
   DELIVERED: [],
   CANCELLED: [],
 };
+
+function isMutableShipmentStatus(status: Shipment["status"]): status is MutableShipmentStatus {
+  return SHIPMENT_STATUSES.includes(status as MutableShipmentStatus);
+}
 
 export async function listShipments(tenantId: string): Promise<Shipment[]> {
   const rows = await prisma.shipment.findMany({
@@ -35,20 +41,22 @@ export async function updateShipmentStatus(tenantId: string, shipmentId: string,
   const s = await prisma.shipment.findFirst({ where: { id: shipmentId, userId: tenantId } });
   if (!s) throw new Error("Shipment not found");
 
-  if (!SHIPMENT_STATUSES.includes(status)) {
+  if (!isMutableShipmentStatus(status)) {
     throw new Error(`Invalid shipment status: ${status}`);
   }
 
-  if (s.status !== status) {
-    const validNext = SHIPMENT_TRANSITIONS[s.status] || [];
-    if (!validNext.includes(status)) {
+  const nextStatus: MutableShipmentStatus = status;
+
+  if (s.status !== nextStatus) {
+    const validNext = SHIPMENT_TRANSITIONS[s.status as MutableShipmentStatus] || [];
+    if (!validNext.includes(nextStatus)) {
       throw new Error(`Invalid status transition from ${s.status} to ${status}`);
     }
   }
 
   const result = await prisma.shipment.updateMany({
     where: { id: shipmentId, userId: tenantId },
-    data: { status: status as any }
+    data: { status: nextStatus }
   });
 
   if (result.count === 0) {

--- a/apps/web/tests/marketing-landing.test.tsx
+++ b/apps/web/tests/marketing-landing.test.tsx
@@ -18,9 +18,9 @@ describe("marketing landing page navigation", () => {
     render(<InfamousFreightWebApp />);
 
     expect(screen.getByRole("link", { name: "Operations Dashboard" })).toHaveAttribute("href", "/dashboard");
-    expect(screen.getByRole("link", { name: "Loadboard" })).toHaveAttribute("href", "/loads");
-    expect(screen.getByRole("link", { name: "Shipment Tracking" })).toHaveAttribute("href", "/loads/active");
-    expect(screen.getByRole("link", { name: "Billing & Payments" })).toHaveAttribute("href", "/account/billing");
-    expect(screen.getByRole("link", { name: "Driver Workflow" })).toHaveAttribute("href", "/driver");
+    expect(screen.getByRole("link", { name: "Loadboard" })).toHaveAttribute("href", "/loadboard");
+    expect(screen.getByRole("link", { name: "Shipment Tracking" })).toHaveAttribute("href", "/shipments");
+    expect(screen.getByRole("link", { name: "Billing & Payments" })).toHaveAttribute("href", "/settings/billing");
+    expect(screen.getByRole("link", { name: "Shipment Workflow" })).toHaveAttribute("href", "/shipments");
   });
 });


### PR DESCRIPTION
### Motivation
- Resolve a TypeScript typecheck failure in `apps/api` caused by mismatched shipment status values and unsafe casts during Prisma updates. 
- Bring the marketing landing-page tests in `apps/web` into alignment with the current site links and CTA labels. 
- Keep tenant scoping and behavior unchanged while removing unsafe `any` usage and preventing regressions.

### Description
- Introduce a narrowed `MutableShipmentStatus` type derived from `SHIPMENT_STATUSES` and add an `isMutableShipmentStatus` type guard in `apps/api/src/services/shipments.service.ts` to validate inbound statuses. 
- Re-type `SHIPMENT_TRANSITIONS` to use `MutableShipmentStatus`, use a `nextStatus` variable for transition checks, and remove the `any` cast when calling `prisma.shipment.updateMany`. 
- Update the marketing landing test expectations in `apps/web/tests/marketing-landing.test.tsx` to assert the current routes and CTA label (`/loadboard`, `/shipments`, `/settings/billing`, and "Shipment Workflow").

### Testing
- Ran `pnpm --filter @infamous/api typecheck` and it completed successfully. 
- Ran `pnpm --filter web test` (Vitest) and the web test suite passed (`11 passed`). 
- Ran the monorepo checks `pnpm run typecheck` and `pnpm run test` and both completed successfully with all suites passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3226280a48330aca0e0c363022be8)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes shipment status typing in the API to enforce valid transitions and remove unsafe casts; updates marketing landing tests to match current routes and labels. Clears the typecheck error without changing tenant scoping.

- **Bug Fixes**
  - Typed status transitions in `apps/api` using `MutableShipmentStatus` and an `isMutableShipmentStatus` guard from `@infamous-freight/shared`; validated transitions and removed `any` before `prisma.shipment.updateMany`.
  - Updated `apps/web` marketing landing tests to assert current links and CTA: `/loadboard`, `/shipments`, `/settings/billing`, and "Shipment Workflow".

<sup>Written for commit 76b13157ef212fa7a47906327beca68abaaf1cfa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

