### PR TITLE
test(web): align marketing landing link expectations with current routes

### DIFF
--- a/apps/web/tests/marketing-landing.test.tsx
+++ b/apps/web/tests/marketing-landing.test.tsx
@@ -18,9 +18,8 @@ describe("marketing landing page navigation", () => {
     render(<InfamousFreightWebApp />);
 
     expect(screen.getByRole("link", { name: "Operations Dashboard" })).toHaveAttribute("href", "/dashboard");
-    expect(screen.getByRole("link", { name: "Loadboard" })).toHaveAttribute("href", "/loads");
-    expect(screen.getByRole("link", { name: "Shipment Tracking" })).toHaveAttribute("href", "/loads/active");
-    expect(screen.getByRole("link", { name: "Billing & Payments" })).toHaveAttribute("href", "/account/billing");
-    expect(screen.getByRole("link", { name: "Driver Workflow" })).toHaveAttribute("href", "/driver");
+    expect(screen.getByRole("link", { name: "Loadboard" })).toHaveAttribute("href", "/loadboard");
+    expect(screen.getByRole("link", { name: "Shipment Tracking" })).toHaveAttribute("href", "/shipments");
+    expect(screen.getByRole("link", { name: "Billing & Payments" })).toHaveAttribute("href", "/settings/billing");
   });
 });


### PR DESCRIPTION
### Motivation
- Fix a failing marketing landing test that was asserting stale link routes compared to the UI component, removing flaky test behavior and keeping test expectations in sync with the app.

### Description
- Updated `apps/web/tests/marketing-landing.test.tsx` to match the routes rendered by `InfamousFreightWebApp` by replacing `/loads` with `/loadboard`, `/loads/active` with `/shipments`, and `/account/billing` with `/settings/billing`.
- Removed the obsolete `Driver Workflow` link assertion which no longer exists in the component.

### Testing
- Running `pnpm -w test -- --runInBand` before the change produced a failing test due to mismatched link expectations (web marketing test failure).
- After updating the test, `pnpm --filter web test -- --runInBand` passed with all web tests green (`11 passed`).
- Full workspace run `pnpm -w test -- --runInBand` succeeded after the change with the test suite passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e326eef2208330b751a918a728dd23)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the marketing landing page test to match current routes so it stops failing and stays in sync with the UI. Replaces outdated href expectations and removes an obsolete link assertion.

- **Bug Fixes**
  - Updated hrefs: Loadboard → `/loadboard` (from `/loads`), Shipment Tracking → `/shipments` (from `/loads/active`), Billing & Payments → `/settings/billing` (from `/account/billing`).
  - Removed the obsolete "Driver Workflow" link assertion.

<sup>Written for commit f5a1343df3f8a19673180c7baa99694116424a2f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

