### PR TITLE
fix(web): set Fly build context to monorepo root

### DIFF
--- a/apps/web/fly.toml
+++ b/apps/web/fly.toml
@@ -7,6 +7,9 @@ app = 'infamous-freight'
 primary_region = 'dfw'
 
 [build]
+  # Web Dockerfile is monorepo-aware and expects workspace files from repo root.
+  context = "../.."
+  dockerfile = "Dockerfile.web"
 
 [http_service]
   internal_port = 8080


### PR DESCRIPTION
### Motivation
- The web Dockerfile is monorepo-aware and was failing during Fly builds because the Fly build context was the app folder, causing `COPY` checksum errors like `/pnpm-workspace.yaml: not found` and `/apps/web/package.json: not found`.

### Description
- Update `apps/web/fly.toml` to set the build context to the repository root with `context = "../.."` and explicitly use the root `Dockerfile.web` via `dockerfile = "Dockerfile.web"` so Docker `COPY` paths resolve against the monorepo layout.

### Testing
- Attempted to run `flyctl config validate -c apps/web/fly.toml` to validate the config, but `flyctl` is not installed in this environment so validation could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e32ab85b008330ba23186828b71d26)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Point Fly build context to the monorepo root to fix Docker COPY path errors during web deploys. Updated apps/web/fly.toml to use context `../..` and dockerfile `Dockerfile.web` so the monorepo-aware Dockerfile can access workspace files.

<sup>Written for commit 249c8b7bcd17a7aab277b0ec8dd0bcc18c8366ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

