### PR TITLE
chore(web): disable Sentry telemetry in Next config

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -169,4 +169,5 @@ export default withSentryConfig(nextConfig, {
 
     // Additional Sentry CLI options
     url: 'https://sentry.io/',
+    telemetry: false,
 });


### PR DESCRIPTION
### Motivation

- Disable Sentry CLI/SDK telemetry reporting from the build/tooling layer to honor privacy/telemetry control and prevent Sentry telemetry from being sent by the plugin.

### Description

- Set `telemetry: false` in the `withSentryConfig` options in `apps/web/next.config.mjs` so Sentry's telemetry is explicitly turned off (configuration-only change).

### Testing

- Ran `node --check apps/web/next.config.mjs` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3fc350db88330b0295ffd0df576a7)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable Sentry telemetry in `apps/web/next.config.mjs` by adding `telemetry: false` to `withSentryConfig`, stopping Sentry CLI/SDK telemetry during builds.

<sup>Written for commit 7902384d2d6d5d4e41d51acccb404d56f6f8610c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

