### PR TITLE
Bump pydantic to 2.13.2 in AI requirements

### DIFF
--- a/ai/requirements.txt
+++ b/ai/requirements.txt
@@ -1,3 +1,3 @@
 fastapi==0.115.0
 uvicorn[standard]==0.30.6
-pydantic==2.9.2
+pydantic==2.13.2

--- a/requirements-ai-workers.txt
+++ b/requirements-ai-workers.txt
@@ -1,4 +1,4 @@
 openai==1.40.0
 requests==2.33.0
-pydantic==2.7.0
+pydantic==2.13.2
 pytest==9.0.3


### PR DESCRIPTION
### Motivation
- Unify and upgrade `pydantic` to `2.13.2` across AI service and worker requirement files for compatibility and consistency.

### Description
- Updated `ai/requirements.txt` to replace `pydantic==2.9.2` with `pydantic==2.13.2`.
- Updated `requirements-ai-workers.txt` to replace `pydantic==2.7.0` with `pydantic==2.13.2`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3f5fcd4d88330ba59cb0142794ae8)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `pydantic` to 2.13.2 in ai/requirements.txt and requirements-ai-workers.txt to align service and worker pins for consistency and wheel compatibility.

<sup>Written for commit cbcf31268565a34c720966c8b8a0b34005f556e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

