### PR TITLE
Export captureException and add runWithSentryCapture helper with tests

### DIFF
--- a/apps/api/src/instrument.test.ts
+++ b/apps/api/src/instrument.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const captureExceptionMock = vi.fn();
+
+vi.mock("@sentry/node", () => ({
+  captureException: captureExceptionMock,
+  getClient: vi.fn(() => null),
+  init: vi.fn(),
+}));
+
+describe("runWithSentryCapture", () => {
+  let processOnSpy: ReturnType<typeof vi.spyOn>;
+  const originalDsn = process.env.SENTRY_DSN;
+
+  beforeEach(() => {
+    vi.resetModules();
+    captureExceptionMock.mockReset();
+    process.env.SENTRY_DSN = "https://placeholder@example.invalid/0";
+    processOnSpy = vi.spyOn(process, "on").mockImplementation(() => process);
+  });
+
+  afterEach(() => {
+    processOnSpy.mockRestore();
+
+    if (originalDsn === undefined) {
+      delete process.env.SENTRY_DSN;
+      return;
+    }
+
+    process.env.SENTRY_DSN = originalDsn;
+  });
+
+  it("captures and rethrows sync errors", async () => {
+    const { runWithSentryCapture } = await import("./instrument.js");
+    const error = new Error("sync boom");
+
+    expect(() =>
+      runWithSentryCapture(() => {
+        throw error;
+      }),
+    ).toThrow(error);
+
+    expect(captureExceptionMock).toHaveBeenCalledWith(error);
+  });
+
+  it("captures and rethrows async errors", async () => {
+    const { runWithSentryCapture } = await import("./instrument.js");
+    const error = new Error("async boom");
+
+    await expect(
+      runWithSentryCapture(async () => {
+        throw error;
+      }),
+    ).rejects.toThrow(error);
+
+    expect(captureExceptionMock).toHaveBeenCalledWith(error);
+  });
+});

--- a/apps/api/src/instrument.ts
+++ b/apps/api/src/instrument.ts
@@ -18,7 +18,7 @@ if (sentryEnabled && !Sentry.getClient()) {
   });
 }
 
-function captureException(error: unknown): void {
+export function captureException(error: unknown): void {
   if (!sentryEnabled) return;
 
   if (error instanceof Error) {
@@ -37,6 +37,26 @@ function captureException(error: unknown): void {
       originalThrowable: error,
     },
   });
+}
+
+export function runWithSentryCapture<T>(operation: () => T): T;
+export function runWithSentryCapture<T>(operation: () => Promise<T>): Promise<T>;
+export function runWithSentryCapture<T>(operation: () => T | Promise<T>): T | Promise<T> {
+  try {
+    const result = operation();
+
+    if (result && typeof (result as Promise<T>).then === "function") {
+      return (result as Promise<T>).catch((error: unknown) => {
+        captureException(error);
+        throw error;
+      });
+    }
+
+    return result;
+  } catch (error) {
+    captureException(error);
+    throw error;
+  }
 }
 
 process.on("unhandledRejection", (reason) => {


### PR DESCRIPTION
### Motivation

- Provide a safe wrapper to run sync and async operations while ensuring thrown values are reported to Sentry. 
- Make `captureException` available for external use and testing. 

### Description

- Exported `captureException` from `apps/api/src/instrument.ts` and preserved existing normalization logic for non-Error throwables. 
- Implemented `runWithSentryCapture` in `apps/api/src/instrument.ts` with overloads to handle both synchronous and promise-returning operations and to capture and rethrow errors. 
- Added `apps/api/src/instrument.test.ts` which mocks `@sentry/node` and verifies that `runWithSentryCapture` captures and rethrows both sync and async errors. 
- Left the `process.on("unhandledRejection")` and `process.on("uncaughtException")` handlers intact so global capture behavior remains. 

### Testing

- Ran the unit tests with `vitest` which executed the tests in `apps/api/src/instrument.test.ts`. 
- The test suite verifies that `captureException` is invoked for both synchronous and asynchronous thrown errors and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e42345e6e083309758a830f398c600)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose `captureException` and add `runWithSentryCapture` to reliably send sync and async errors to Sentry while preserving existing global error handlers. Adds tests to ensure captured errors are rethrown.

- **New Features**
  - Export `captureException` with normalization for non-Error throws.
  - Add `runWithSentryCapture` (sync and async) that captures and rethrows errors, including promise rejections.
  - Keep `process.on("unhandledRejection")` and `process.on("uncaughtException")` handlers unchanged.
  - Add unit tests with `vitest`, mocking `@sentry/node`, to verify sync/async capture behavior.

<sup>Written for commit 9027353277df07c65305b3f6fb8e8a92ebc396af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

