### PR TITLE
Centralize instrumentation: import instrument.js and remove inline Sentry init; add @sentry/node and test script

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,6 @@
+import "./instrument.js";
 import cors from "cors";
 import express from "express";
-import * as Sentry from "@sentry/node";
 import { ENV } from "./env.js";
 import { health } from "./routes/health.js";
 import { ai } from "./routes/ai.js";
@@ -10,35 +10,6 @@ import { tenants } from "./routes/tenants.js";
 import { HttpError } from "./utils/errors.js";
 
 const app = express();
-
-const SENTRY_SEND_DEFAULT_PII = process.env.SENTRY_SEND_DEFAULT_PII === "true";
-
-const redactSentryEvent = (event: Sentry.Event): Sentry.Event => {
-  if (!event.request) {
-    return event;
-  }
-
-  if (event.request.headers) {
-    delete event.request.headers.authorization;
-    delete event.request.headers.Authorization;
-    delete event.request.headers.cookie;
-    delete event.request.headers.Cookie;
-  }
-
-  if ("cookies" in event.request) {
-    delete (event.request as Sentry.Event["request"] & { cookies?: unknown }).cookies;
-  }
-
-  return event;
-};
-
-Sentry.init({
-  dsn: process.env.SENTRY_DSN,
-  sendDefaultPii: SENTRY_SEND_DEFAULT_PII,
-  environment: process.env.NODE_ENV,
-  tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
-  beforeSend: (event) => redactSentryEvent(event),
-});
 
 app.use(cors({ origin: ENV.CORS_ORIGIN, credentials: true }));
 app.use(express.json());

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,3 +1,4 @@
+// Keep instrumentation bootstrap first so Sentry can patch runtime hooks early.
 import "./instrument.js";
 import cors from "cors";
 import express from "express";

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "deploy:work": "bash scripts/deploy-work-branch.sh",
     "health": "pnpm run lint && pnpm run typecheck && pnpm run test",
     "health:quick": "pnpm run lint && pnpm run typecheck",
-    "fly:deploy:web": "bash scripts/fly-deploy-web.sh"
+    "fly:deploy:web": "bash scripts/fly-deploy-web.sh",
+    "test:runInBand": "pnpm run prisma:generate:offline && pnpm run build:shared && pnpm --filter @infamous/api test:jest && pnpm -r --if-present --workspace-concurrency=1 test -- --runInBand --maxWorkers=1"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
@@ -94,5 +95,8 @@
       "sharp",
       "unrs-resolver"
     ]
+  },
+  "dependencies": {
+    "@sentry/node": "^10.48.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,10 @@ overrides:
 importers:
 
   .:
+    dependencies:
+      '@sentry/node':
+        specifier: ^10.48.0
+        version: 10.48.0
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1


### PR DESCRIPTION
### Motivation
- Centralize application instrumentation by moving Sentry setup out of `apps/api/src/index.ts` into a dedicated module so startup logic is simpler and easier to manage.
- Provide a deterministic test runner option for CI/debugging by adding a `--runInBand` test script.

### Description
- Added `import "./instrument.js";` to `apps/api/src/index.ts` and removed the inline `@sentry/node` import, `redactSentryEvent` function, and `Sentry.init` call from that file.
- Added `@sentry/node` to top-level `dependencies` and updated `pnpm-lock.yaml` to include the package.
- Added a new `test:runInBand` script in `package.json` to run tests with `--runInBand` and `--maxWorkers=1` for serialized test execution.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4280431c4833085ba7842af0cf76b)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes Sentry setup by moving initialization to `instrument.js` and importing it first in the API entrypoint so runtime hooks are patched early. Adds `@sentry/node` and a `test:runInBand` script for deterministic CI.

- **Refactors**
  - Import `./instrument.js` first in `apps/api/src/index.ts`; remove inline Sentry init and header/cookie redaction.
  - Add a file-level comment documenting the required import order.
  - Add `@sentry/node` as a top-level dependency.

- **New Features**
  - Add `test:runInBand` to run tests with `--runInBand --maxWorkers=1` for deterministic CI.

<sup>Written for commit 38e55b2107a9ab53fac555191dbcb23b9a90affa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

