### PR TITLE
proxy: dynamic CSP and conditional Google Analytics in edge middleware

### DIFF
--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -29,6 +29,11 @@ const PROTECTED_API_ROUTES = ["/api/admin", "/api/internal"];
 
 export function proxy(request: NextRequest) {
   const { pathname, searchParams } = request.nextUrl;
+  const isProduction =
+    process.env.NEXT_PUBLIC_ENV === "production" || process.env.NODE_ENV === "production";
+  const gaMeasurementId =
+    process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID || process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID;
+  const gaEnabled = Boolean(isProduction && gaMeasurementId);
 
   // Skip middleware for static assets and health checks
   if (SKIP_PATHS.some((path) => pathname.startsWith(path))) {
@@ -76,16 +81,41 @@ export function proxy(request: NextRequest) {
     "camera=(), microphone=(), geolocation=(), payment=()",
   );
 
+  const scriptSrc = [
+    "'self'",
+    "'unsafe-inline'",
+    "'unsafe-eval'",
+    "https://vercel.live",
+    "https://va.vercel-scripts.com",
+  ];
+
+  const connectSrc = [
+    "'self'",
+    "https://*.vercel.app",
+    "https://*.supabase.co",
+    "https://vitals.vercel-insights.com",
+    "https://*.fly.dev",
+  ];
+
+  if (gaEnabled) {
+    scriptSrc.push("https://www.googletagmanager.com");
+    connectSrc.push(
+      "https://www.googletagmanager.com",
+      "https://www.google-analytics.com",
+      "https://*.google-analytics.com",
+    );
+  }
+
   // Strengthen Content Security Policy
   response.headers.set(
     "Content-Security-Policy",
     [
       "default-src 'self'",
-      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://vercel.live https://va.vercel-scripts.com",
+      `script-src ${scriptSrc.join(" ")}`,
       "style-src 'self' 'unsafe-inline'",
       "img-src 'self' data: https: blob:",
       "font-src 'self' data:",
-      "connect-src 'self' https://*.vercel.app https://*.supabase.co https://vitals.vercel-insights.com https://*.fly.dev",
+      `connect-src ${connectSrc.join(" ")}`,
       "frame-ancestors 'none'",
       "base-uri 'self'",
       "form-action 'self'",


### PR DESCRIPTION
### Motivation

- Enable stricter, more flexible Content Security Policy management by constructing CSP sources programmatically.
- Only include Google Analytics endpoints in the CSP when running in production and a measurement ID is present to avoid leaking analytics endpoints in non-production environments.

### Description

- Add `isProduction`, `gaMeasurementId`, and `gaEnabled` checks to determine whether Google Analytics should be allowed. 
- Build `scriptSrc` and `connectSrc` arrays and append GA domains when `gaEnabled` is true, then set `Content-Security-Policy` using the joined arrays. 
- Preserve and set existing security headers and geolocation request headers, and keep existing API CORS handling and protected-route checks. 
- Keep existing skip paths (including `/monitoring`) to avoid intercepting Sentry tunnel routes.

### Testing

- Ran unit tests with `npm test`, and they passed. 
- Ran type checking with `tsc --noEmit`, and it succeeded. 
- Ran lint with `npm run lint`, and no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e55afcf98483309a2c0c713e5a5f13)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds the Content Security Policy dynamically in the edge proxy and only includes Google Analytics domains in production when a measurement ID is set. This tightens the CSP and avoids GA endpoints in non-production.

- **New Features**
  - Added `isProduction`, `gaMeasurementId`, and `gaEnabled` checks using `NEXT_PUBLIC_ENV`, `NODE_ENV`, `NEXT_PUBLIC_GA_MEASUREMENT_ID`/`NEXT_PUBLIC_GOOGLE_ANALYTICS_ID`.
  - Construct `script-src` and `connect-src` arrays and append GA domains when `gaEnabled` is true; set `Content-Security-Policy` from the joined values.
  - Kept existing security headers and skip paths (e.g., `/monitoring`) unchanged.

<sup>Written for commit f692d4b0d1c6c18c32640b6baca1be732dca9426. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

