### PR TITLE
Add A/B variant helper, use it in edge proxy, secure cookie handling, and add tests

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -125,6 +125,8 @@ NEXT_PUBLIC_SENTRY_RELEASE=
 
 # Sentry (Server-Side & Build Time)
 # ⚠️ CRITICAL FOR VERCEL DEPLOYS: Add SENTRY_AUTH_TOKEN in Vercel env vars!
+# 🔐 Never commit a real SENTRY_AUTH_TOKEN in this repository.
+# Store it only in your deployment secret manager.
 # Get from: https://sentry.io → User Settings → Auth Tokens → Create Token
 # Required scopes: project:releases, org:read
 # Without this token, source maps won't upload and stack traces will be minified

--- a/apps/web/.env.production.example
+++ b/apps/web/.env.production.example
@@ -5,6 +5,7 @@ NEXT_PUBLIC_APP_NAME=Infamous Freight
 NEXT_PUBLIC_PORTAL_URL=https://portal.infamousfreight.com
 NEXT_PUBLIC_OPS_URL=https://app.infamousfreight.com
 NEXT_PUBLIC_SENTRY_DSN=
+# Keep SENTRY_AUTH_TOKEN in secret management only (do not commit real tokens).
 SENTRY_AUTH_TOKEN=
 LAUNCHDARKLY_CLIENT_SIDE_ID=
 LAUNCHDARKLY_FLAG_KEY=enableMyNewFeature

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
+import { getAbVariant, shouldSetAbVariantCookie } from "./src/lib/ab-variant";
 
 /**
  * Edge Proxy - Runs on Vercel Edge Network
@@ -28,7 +29,7 @@ const SKIP_PATHS = [
 const PROTECTED_API_ROUTES = ["/api/admin", "/api/internal"];
 
 export function proxy(request: NextRequest) {
-  const { pathname, searchParams } = request.nextUrl;
+  const { pathname } = request.nextUrl;
 
   // Skip middleware for static assets and health checks
   if (SKIP_PATHS.some((path) => pathname.startsWith(path))) {
@@ -123,13 +124,20 @@ export function proxy(request: NextRequest) {
   }
 
   // A/B Testing support via query params or cookies
-  const variant = searchParams.get("variant") || request.cookies.get("ab-variant")?.value;
+  const variant = getAbVariant(
+    request.nextUrl.searchParams,
+    request.cookies.get("ab-variant")?.value,
+  );
   if (variant) {
-    response.cookies.set("ab-variant", variant, {
-      maxAge: 60 * 60 * 24 * 30, // 30 days
-      httpOnly: false,
-      sameSite: "lax",
-    });
+    if (shouldSetAbVariantCookie(request.cookies.get("ab-variant")?.value, variant)) {
+      response.cookies.set("ab-variant", variant, {
+        maxAge: 60 * 60 * 24 * 30, // 30 days
+        httpOnly: false,
+        sameSite: "lax",
+        secure: process.env.NODE_ENV === "production",
+        path: "/",
+      });
+    }
     response.headers.set("X-AB-Variant", variant);
   }
 

--- a/apps/web/src/lib/ab-variant.ts
+++ b/apps/web/src/lib/ab-variant.ts
@@ -1,0 +1,24 @@
+const AB_VARIANT_PATTERN = /^[a-zA-Z0-9_-]{1,64}$/;
+
+export function getAbVariant(
+  searchParams: URLSearchParams,
+  cookieVariant: string | undefined,
+): string | undefined {
+  const normalize = (value: string | undefined | null): string | undefined => {
+    if (!value) return undefined;
+    const normalized = value.trim();
+    return AB_VARIANT_PATTERN.test(normalized) ? normalized : undefined;
+  };
+
+  const queryVariant = normalize(searchParams.get("variant"));
+  if (queryVariant) return queryVariant;
+
+  return normalize(cookieVariant);
+}
+
+export function shouldSetAbVariantCookie(
+  existingCookieVariant: string | undefined,
+  resolvedVariant: string | undefined,
+): boolean {
+  return Boolean(resolvedVariant) && existingCookieVariant !== resolvedVariant;
+}

--- a/apps/web/tests/proxy-variant.test.ts
+++ b/apps/web/tests/proxy-variant.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { getAbVariant, shouldSetAbVariantCookie } from "../src/lib/ab-variant";
+
+describe("getAbVariant", () => {
+  it("prefers query param over cookie value", () => {
+    const searchParams = new URLSearchParams("variant=Treatment_A");
+    expect(getAbVariant(searchParams, "control")).toBe("Treatment_A");
+  });
+
+  it("falls back to cookie value when query param is missing", () => {
+    const searchParams = new URLSearchParams();
+    expect(getAbVariant(searchParams, "CONTROL_GROUP")).toBe("CONTROL_GROUP");
+  });
+
+  it("trims values before validation", () => {
+    const searchParams = new URLSearchParams("variant=%20variant-1%20");
+    expect(getAbVariant(searchParams, undefined)).toBe("variant-1");
+  });
+
+  it("falls back to cookie when query value is invalid", () => {
+    const searchParams = new URLSearchParams("variant=<script>alert(1)</script>");
+    expect(getAbVariant(searchParams, "cookie")).toBe("cookie");
+  });
+
+  it("falls back to valid cookie when query param is invalid", () => {
+    const searchParams = new URLSearchParams("variant=<invalid>");
+    expect(getAbVariant(searchParams, "control-group")).toBe("control-group");
+  });
+
+  it("returns undefined when both query param and cookie are invalid", () => {
+    const searchParams = new URLSearchParams("variant=<invalid>");
+    expect(getAbVariant(searchParams, "bad value")).toBeUndefined();
+  });
+
+  it("returns undefined for variants longer than 64 chars", () => {
+    const longVariant = "a".repeat(65);
+    const searchParams = new URLSearchParams(`variant=${longVariant}`);
+    expect(getAbVariant(searchParams, undefined)).toBeUndefined();
+  });
+
+  it("rejects values containing disallowed punctuation", () => {
+    const searchParams = new URLSearchParams("variant=variant.v2");
+    expect(getAbVariant(searchParams, undefined)).toBeUndefined();
+  });
+});
+
+describe("shouldSetAbVariantCookie", () => {
+  it("returns true when resolved variant exists and differs from existing cookie", () => {
+    expect(shouldSetAbVariantCookie("control", "treatment")).toBe(true);
+  });
+
+  it("returns false when resolved variant matches existing cookie", () => {
+    expect(shouldSetAbVariantCookie("control", "control")).toBe(false);
+  });
+
+  it("returns false when resolved variant is undefined", () => {
+    expect(shouldSetAbVariantCookie("control", undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
### Motivation
- Introduce robust handling for A/B test variants at the edge to prefer query params, validate input, and avoid unsafe values.  
- Only set the `ab-variant` cookie when the resolved variant differs from the existing cookie and make it secure in production.  
- Clarify environment file guidance to avoid committing real `SENTRY_AUTH_TOKEN` values.

### Description
- Add `src/lib/ab-variant.ts` implementing `getAbVariant` (query-first resolution with validation) and `shouldSetAbVariantCookie` (detects when to write cookie).  
- Update `proxy.ts` to use `getAbVariant` and `shouldSetAbVariantCookie`, conditionally set the `ab-variant` cookie only when needed, and set cookie options `secure` and `path` (`secure` is enabled when `NODE_ENV === "production"`).  
- Preserve existing behavior of emitting `X-AB-Variant` header and other proxy headers while removing the unused local `searchParams` binding.  
- Add `tests/proxy-variant.test.ts` with Vitest unit tests covering variant resolution, validation, trimming, and cookie-write decisions.  
- Update `apps/web/.env.example` and `apps/web/.env.production.example` to include a short note reminding maintainers not to commit real `SENTRY_AUTH_TOKEN` and to store it in secret management.

### Testing
- Added unit tests in `tests/proxy-variant.test.ts` run with `vitest`, which validate `getAbVariant` and `shouldSetAbVariantCookie`; the test suite passed.  
- Local type-checking and build verification were performed to ensure the new module integrates with `proxy.ts` without type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e42e7b6ba08330843be27e4b986ffd)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a safe A/B variant resolver at the edge and updates the proxy to prefer query params, validate values, and only set the `ab-variant` cookie when needed. Adds tests and clarifies `SENTRY_AUTH_TOKEN` handling.

- New Features
  - Added `getAbVariant` and `shouldSetAbVariantCookie` in `apps/web/src/lib/ab-variant.ts` (query-first, trim, validate: 1–64 chars of a–z, 0–9, `_`, `-`).
  - Updated `apps/web/proxy.ts` to use the helper, set `X-AB-Variant`, and write `ab-variant` only when it changes; cookie is `secure` in production, `path=/`, `sameSite=lax`, 30-day TTL.
  - Added `apps/web/tests/proxy-variant.test.ts` covering resolution, validation, trimming, length/punctuation rejection, and cookie-write decisions.
  - Noted in `.env.example` and `.env.production.example` to keep `SENTRY_AUTH_TOKEN` in secret management and never commit real tokens.

<sup>Written for commit 1e6a01aeb6c93217f02da7f15f8faacff30d52af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved A/B testing with enhanced variant validation and secure cookie handling.

* **Documentation**
  * Added guidance on securely managing sensitive deployment tokens in environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->