### PR TITLE
Remove eslint-disable comment before console.error in RevenueMonitorDashboard

### DIFF
--- a/apps/web/components/RevenueMonitorDashboard.tsx
+++ b/apps/web/components/RevenueMonitorDashboard.tsx
@@ -100,7 +100,7 @@ export const RevenueMonitorDashboard: React.FC = () => {
       setLoading(false);
     } catch (error) {
       if ((error as Error).name === "AbortError") return;
-      // eslint-disable-next-line no-console
+
       console.error("Failed to fetch metrics:", error);
       if (isMountedRef.current) setLoading(false);
     }


### PR DESCRIPTION
### Motivation
- Re-enable standard linting for `console` usage to keep in-code lint directives minimal and maintain consistent lint policy.

### Description
- Deleted the `// eslint-disable-next-line no-console` comment immediately before the `console.error` call in `RevenueMonitorDashboard.tsx`, causing no runtime or behavioral changes.

### Testing
- Built the app with `yarn build` and ran unit tests with `yarn test`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e55b1b1e2c8330b80823d9ddaa0a6b)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `// eslint-disable-next-line no-console` comment before `console.error` in `RevenueMonitorDashboard.tsx` to restore standard linting for console usage. No runtime or behavior changes.

<sup>Written for commit 02f2859fce78cfe0953f3d38547bae6adadd4513. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

