### PR TITLE
fix: resolve audit vulnerabilities with pnpm overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,11 @@
       "brace-expansion@5.0.4": "5.0.5",
       "defu@<=6.1.4": ">=6.1.5",
       "vite@<7.3.2": "7.3.2",
-      "@hono/node-server@<1.19.13": "1.19.13"
+      "@hono/node-server@<1.19.13": "1.19.13",
+      "hono@<4.12.14": "4.12.14",
+      "protobufjs@<7.5.5": "7.5.5",
+      "follow-redirects@<=1.15.11": "1.16.0",
+      "axios@>=1.0.0 <1.15.0": "1.15.0"
     },
     "onlyBuiltDependencies": [
       "@firebase/util",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,10 @@ overrides:
   defu@<=6.1.4: '>=6.1.5'
   vite@<7.3.2: 7.3.2
   '@hono/node-server@<1.19.13': 1.19.13
+  hono@<4.12.14: 4.12.14
+  protobufjs@<7.5.5: 7.5.5
+  follow-redirects@<=1.15.11: 1.16.0
+  axios@>=1.0.0 <1.15.0: 1.15.0
 
 importers:
 
@@ -1862,7 +1866,7 @@ packages:
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: '>=4.12.7'
+      hono: 4.12.14
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -4600,8 +4604,8 @@ packages:
     resolution: {integrity: sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==}
     engines: {node: '>=4'}
 
-  axios@1.14.0:
-    resolution: {integrity: sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==}
+  axios@1.15.0:
+    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -5901,8 +5905,8 @@ packages:
   fn.name@1.1.0:
     resolution: {integrity: sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -6161,8 +6165,8 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
-  hono@4.12.12:
-    resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
+  hono@4.12.14:
+    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
     engines: {node: '>=16.9.0'}
 
   hosted-git-info@7.0.2:
@@ -7708,8 +7712,8 @@ packages:
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
-  protobufjs@7.5.4:
-    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+  protobufjs@7.5.5:
+    resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -11192,7 +11196,7 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.5.4
+      protobufjs: 7.5.5
       yargs: 17.7.2
 
   '@hapi/hoek@9.3.0':
@@ -11203,9 +11207,9 @@ snapshots:
       '@hapi/hoek': 9.3.0
     optional: true
 
-  '@hono/node-server@1.19.13(hono@4.12.12)':
+  '@hono/node-server@1.19.13(hono@4.12.14)':
     dependencies:
-      hono: 4.12.12
+      hono: 4.12.14
 
   '@humanfs/core@0.19.1': {}
 
@@ -12019,13 +12023,13 @@ snapshots:
       '@electric-sql/pglite': 0.4.1
       '@electric-sql/pglite-socket': 0.1.1(@electric-sql/pglite@0.4.1)
       '@electric-sql/pglite-tools': 0.3.1(@electric-sql/pglite@0.4.1)
-      '@hono/node-server': 1.19.13(hono@4.12.12)
+      '@hono/node-server': 1.19.13(hono@4.12.14)
       '@prisma/get-platform': 7.2.0
       '@prisma/query-plan-executor': 7.2.0
       '@prisma/streams-local': 0.1.2
       foreground-child: 3.3.1
       get-port-please: 3.2.0
-      hono: 4.12.12
+      hono: 4.12.14
       http-status-codes: 2.3.0
       pathe: 2.0.3
       proper-lockfile: 4.1.2
@@ -12869,7 +12873,7 @@ snapshots:
   '@sendgrid/client@8.1.6':
     dependencies:
       '@sendgrid/helpers': 8.0.0
-      axios: 1.14.0
+      axios: 1.15.0
     transitivePeerDependencies:
       - debug
 
@@ -14480,9 +14484,9 @@ snapshots:
 
   axe-core@4.11.3: {}
 
-  axios@1.14.0:
+  axios@1.15.0:
     dependencies:
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -16113,7 +16117,7 @@ snapshots:
 
   fn.name@1.1.0: {}
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.16.0: {}
 
   fontfaceobserver@2.3.0: {}
 
@@ -16368,7 +16372,7 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
-  hono@4.12.12: {}
+  hono@4.12.14: {}
 
   hosted-git-info@7.0.2:
     dependencies:
@@ -18267,7 +18271,7 @@ snapshots:
       retry: 0.12.0
       signal-exit: 3.0.7
 
-  protobufjs@7.5.4:
+  protobufjs@7.5.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2


### PR DESCRIPTION
### Motivation

- `pnpm audit` reported several transitive vulnerabilities (notably in `protobufjs`, `follow-redirects`, `hono`, and `axios`) that need patching to keep the workspace secure.
- The repository is a pnpm workspace with no `package-lock.json`, so `npm audit fix --force` cannot reliably apply fixes in this layout.
- Apply targeted, minimal changes to dependency resolution to ensure patched transitive versions are installed across the workspace.

### Description

- Added root `pnpm.overrides` entries in `package.json` to pin patched versions for transitive dependencies: `hono@4.12.14`, `protobufjs@7.5.5`, `follow-redirects@1.16.0`, and `axios@1.15.0`.
- Regenerated the dependency graph by running `pnpm install`, which updated `pnpm-lock.yaml` to include the overridden, patched versions.
- Kept the change minimal and workspace-scoped (no rewrites to application code), relying on pnpm overrides to resolve the reported advisories.

### Testing

- Attempted `npm audit fix --force`, which failed because the monorepo uses pnpm workspaces and lacks an npm lockfile (the command cannot operate here).
- Ran `pnpm install` to refresh the lockfile and apply overrides, which completed successfully.
- Ran `pnpm audit` after the install and observed no known vulnerabilities remaining.
- Ran the workspace test suite via `pnpm run test:runInBand` and confirmed tests completed successfully across workspaces.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e55b95a1f88330843a7fa381a0255e)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes security advisories by forcing patched transitive versions via `pnpm.overrides`. `pnpm audit` is now clean; only the root `package.json` and `pnpm-lock.yaml` changed.

- **Dependencies**
  - Added overrides for `hono@4.12.14`, `protobufjs@7.5.5`, `follow-redirects@1.16.0`, `axios@1.15.0`.
  - Regenerated `pnpm-lock.yaml` with `pnpm install`.

<sup>Written for commit 33416715f25ab75d0c3e40060b86326dd33bbb98. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

