### PR TITLE
Add required validation commands to PR template and pin Next.js devDependency

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,6 +24,14 @@
 - [ ] codeql
 - [ ] audit
 
+### Required Validation Commands
+> Paste the exact command(s) you ran and their result summary.  
+> If you skip a command, explain why.
+
+- `pnpm test:runInBand`:
+- `pnpm build`:
+- Additional checks:
+
 
 ## Area x Validation Plan
 | Area | sanity | lint | typecheck | test | build | codeql | audit |

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@typescript-eslint/eslint-plugin": "^8.58.0",
     "@typescript-eslint/parser": "^8.58.0",
     "eslint-config-prettier": "^10.1.8",
+    "next": "16.2.3",
     "prettier": "^3.8.1"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       eslint-config-prettier:
         specifier: ^10.1.8
         version: 10.1.8(eslint@10.2.0(jiti@2.6.1))
+      next:
+        specifier: 16.2.3
+        version: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       prettier:
         specifier: ^3.8.1
         version: 3.8.1


### PR DESCRIPTION
### Motivation
- Ensure PR authors provide exact validation commands and brief results to make review and CI reproducibility easier. 
- Pin `next` in `devDependencies` to stabilize local development and align the lockfile across environments.

### Description
- Add a `### Required Validation Commands` section to `.github/pull_request_template.md` that asks authors to paste the exact commands they ran and result summaries and includes entries for `pnpm test:runInBand` and `pnpm build`.
- Add `next@16.2.3` to `devDependencies` in `package.json` and update `pnpm-lock.yaml` accordingly to record the resolved version.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e540f31a4c8330833a5fb8d9f29d1d)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Required Validation Commands section to the PR template so authors paste the exact commands they ran and brief results for `pnpm test:runInBand`, `pnpm build`, and any extra checks. Pin `next` in `devDependencies` to `16.2.3` and update `pnpm-lock.yaml` to stabilize local dev and CI.

<sup>Written for commit d89c48447e1afd83c5f0fd4226a9a6de86df077d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

