### PR TITLE
fix: correct monorepo type check and notify logic in CI/CD workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   NODE_VERSION: '20'
   REGISTRY: ghcr.io
@@ -32,7 +36,9 @@ jobs:
         run: npm run lint
 
       - name: Type check
-        run: npx tsc --noEmit
+        run: |
+          npx tsc -p apps/api/tsconfig.json --noEmit
+          npx tsc -p apps/web/tsconfig.json --noEmit
 
       - name: Test
         run: npm run test -- --coverage
@@ -168,15 +174,25 @@ jobs:
   notify:
     name: Notify
     runs-on: ubuntu-latest
-    needs: [deploy-api, deploy-web]
-    if: always()
+    needs: [test, build-api, build-web, deploy-api, deploy-web]
+    if: always() && github.ref == 'refs/heads/main'
     steps:
       - name: Notify on failure
-        if: failure()
+        if: |
+          needs.test.result != 'success' ||
+          needs.build-api.result != 'success' ||
+          needs.build-web.result != 'success' ||
+          needs.deploy-api.result != 'success' ||
+          needs.deploy-web.result != 'success'
         run: |
           echo "::error::Deployment failed! Check the logs above."
 
       - name: Notify on success
-        if: success()
+        if: |
+          needs.test.result == 'success' &&
+          needs.build-api.result == 'success' &&
+          needs.build-web.result == 'success' &&
+          needs.deploy-api.result == 'success' &&
+          needs.deploy-web.result == 'success'
         run: |
           echo "::notice::Deployment successful! API: https://api.infamousfreight.com | Web: https://infamousfreight.com"


### PR DESCRIPTION
## Summary
- fix the CI type-check step to target the actual monorepo workspaces
- correct notify logic so success is only reported when all required jobs succeed on `main`
- grant `packages: write` so the API image push to GHCR can succeed

## Why
The workflow was failing in the root-level `npx tsc --noEmit` step because this repo does not define a root TypeScript project. The notify job could also emit a success notice even when upstream jobs were skipped or failed. In addition, the workflow token only had package read access, which would block the GHCR push in `build-api`.

## Changes
- replace root typecheck with:
  - `npx tsc -p apps/api/tsconfig.json --noEmit`
  - `npx tsc -p apps/web/tsconfig.json --noEmit`
- add top-level workflow permissions:
  - `contents: read`
  - `packages: write`
- tighten notify conditions using `needs.*.result`

## Notes
`packages/shared/tsconfig.json` was not added because that target does not exist in the current repository layout.
