### PR TITLE
Add env:setup script to bootstrap .env files and install workspace dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,19 +63,19 @@ It brings together:
 
 ## ⚡ Quick Start
 
-### 1️⃣ Install dependencies
+### 1️⃣ Install dependencies + bootstrap environment files
 
 ```bash
-npm install
+npm run env:setup
 ```
 
-### 2️⃣ Copy environment config
+This installs workspace dependencies and creates local `.env` files from `*.env.example` for:
 
-```bash
-cp .env.example .env
-```
+- repo root
+- `apps/api`
+- `apps/web`
 
-Edit `.env` with the required API keys and environment values.
+Edit the generated `.env` files with the required API keys and environment values.
 
 > Prisma commands run from the repo root (for example `npm run prisma:generate`) load environment values from the root `.env` file, but API-local overrides (such as `apps/api/.env`) may also apply depending on how Prisma is invoked. If the same variable is defined in multiple places, use the effective override order for your command and verify which `DATABASE_URL` Prisma will use.
 
@@ -99,7 +99,7 @@ npm run dev
 ### Recommended local flow
 
 ```bash
-npm install
+npm run env:setup
 npm run db:setup
 npm run dev
 ```
@@ -107,7 +107,7 @@ npm run dev
 ### Common commands
 
 ```bash
-npm install
+npm run env:setup
 npm run db:setup
 npm run dev
 npm run build

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "infamous-freight",
   "version": "1.0.0",
   "private": true,
-  "description": "Infamous Freight \u2014 The freight dispatch platform built by truckers, for truckers",
+  "description": "Infamous Freight — The freight dispatch platform built by truckers, for truckers",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Infaemous-Freight/Infamous-freight.git"
@@ -24,7 +24,8 @@
     "docker:up": "docker-compose up -d",
     "docker:down": "docker-compose down",
     "docker:build": "docker-compose build",
-    "setup": "npm install && npm run db:setup"
+    "setup": "npm run env:setup && npm run db:setup",
+    "env:setup": "node scripts/setup-environment.js"
   },
   "devDependencies": {
     "concurrently": "^9.0.0"

--- a/scripts/setup-environment.js
+++ b/scripts/setup-environment.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const repoRoot = path.resolve(__dirname, '..');
+
+const envPairs = [
+  ['.env.example', '.env'],
+  [path.join('apps', 'api', '.env.example'), path.join('apps', 'api', '.env')],
+  [path.join('apps', 'web', '.env.example'), path.join('apps', 'web', '.env')],
+];
+
+for (const [sourceRelative, targetRelative] of envPairs) {
+  const source = path.join(repoRoot, sourceRelative);
+  const target = path.join(repoRoot, targetRelative);
+
+  if (!fs.existsSync(source)) {
+    console.warn(`Skipping ${targetRelative}: missing ${sourceRelative}`);
+    continue;
+  }
+
+  if (fs.existsSync(target)) {
+    console.log(`Keeping existing ${targetRelative}`);
+    continue;
+  }
+
+  fs.copyFileSync(source, target);
+  console.log(`Created ${targetRelative} from ${sourceRelative}`);
+}
+
+console.log('Installing dependencies with npm install...');
+const install = spawnSync('npm', ['install'], {
+  cwd: repoRoot,
+  stdio: 'inherit',
+  shell: process.platform === 'win32',
+});
+
+if (install.status !== 0) {
+  process.exit(install.status ?? 1);
+}


### PR DESCRIPTION
### Motivation
- Make initial developer setup simpler by automatically creating local `.env` files and installing workspace dependencies in one step.
- Reduce onboarding friction and avoid missed local env files that break commands like `prisma:generate` or `npm run test`.

### Description
- Added `scripts/setup-environment.js` which copies `.env.example` to `.env` for the repo root, `apps/api`, and `apps/web` when those targets are missing, then runs `npm install` from the repo root.
- Added a root npm script `env:setup` that runs `node scripts/setup-environment.js` and updated the `setup` script to run `env:setup` before database setup (`db:setup`).
- Updated `README.md` quick-start and development workflow to recommend `npm run env:setup` as the initial step and clarified which `.env` files are created.
- Minor metadata cleanup in `package.json` (description punctuation normalization).

### Testing
- Ran `npm run env:setup` which created `.env` files for root, `apps/api`, and `apps/web` and completed `npm install` successfully.
- Ran `npm run test -- --runInBand` which passed (`health` test succeeded).
- Ran `npm run build` which completed successfully for both `apps/api` and `apps/web`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb684d119483308f3b9181b0bd4408)