### PR TITLE
Refactor Dockerfile: multi-stage build, workspace-aware install, Node upgrade, and runtime user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,52 @@
-FROM node:20-alpine AS build
+# syntax = docker/dockerfile:1
 
-WORKDIR /app/apps/api
+ARG NODE_VERSION=22.21.1
+FROM node:${NODE_VERSION}-slim AS base
 
-COPY apps/api/package.json ./package.json
-RUN npm install
+LABEL fly_launch_runtime="Node.js"
+WORKDIR /app
 
-COPY apps/api ./
-RUN npx tsc -p tsconfig.build.json
+FROM base AS build
 
-FROM node:20-alpine AS runtime
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3 && \
+    rm -rf /var/lib/apt/lists/*
 
-WORKDIR /app/apps/api
+# Copy workspace manifests first so npm can resolve workspaces deterministically.
+COPY package.json package-lock.json ./
+COPY apps/api/package.json apps/api/package.json
+COPY apps/web/package.json apps/web/package.json
+
+RUN npm ci --include=dev --workspaces --include-workspace-root
+
+COPY . .
+
+# Ensure Prisma client is generated before TypeScript build.
+RUN npm --prefix apps/api run prisma:generate
+
+# Build only the API for this runtime image.
+RUN npm run build:api
+
+# Keep only production dependencies for runtime.
+RUN npm prune --omit=dev --workspaces --include-workspace-root
+
+FROM base AS final
+
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 --ingroup nodejs nodeapp
+
+COPY --from=build --chown=nodeapp:nodejs /app/node_modules ./node_modules
+COPY --from=build --chown=nodeapp:nodejs /app/apps/api/dist ./apps/api/dist
+COPY --from=build --chown=nodeapp:nodejs /app/apps/api/package.json ./apps/api/package.json
+COPY --from=build --chown=nodeapp:nodejs /app/package.json ./package.json
+
 ENV NODE_ENV=production
-
-COPY apps/api/package.json ./package.json
-RUN npm install --omit=dev
-
-COPY --from=build /app/apps/api/dist ./dist
-
-RUN addgroup -g 1001 -S nodejs
-RUN adduser -S nodejs -u 1001
-USER nodejs
-
 ENV PORT=3000
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD node -e "const port = process.env.PORT || 3000; require('http').get('http://localhost:' + port + '/health', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})"
+  CMD node -e "require('http').get('http://localhost:' + (process.env.PORT || 3000) + '/health', r => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"
 
-CMD ["node", "dist/src/server.js"]
+USER nodeapp
+
+CMD ["node", "apps/api/dist/src/server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax = docker/dockerfile:1
+# syntax=docker/dockerfile:1
 
 ARG NODE_VERSION=22.21.1
 FROM node:${NODE_VERSION}-slim AS base

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG NODE_VERSION=22.21.1
+ARG NODE_VERSION=20
 FROM node:${NODE_VERSION}-slim AS base
 
 LABEL fly_launch_runtime="Node.js"


### PR DESCRIPTION
### Motivation
- Standardize and modernize the container build by using a configurable Node version and a slimmer base image.
- Support workspace-aware dependency installation and deterministic builds for a monorepo (API + web) layout.
- Produce a smaller, production-ready runtime image with a non-root user and ensure Prisma client generation before build.

### Description
- Replace the single-stage Alpine image with a multi-stage build using `ARG NODE_VERSION`, a `base`, `build`, and `final` stage, and switch to the `-slim` Node image.
- Install build tooling in the `build` stage, copy workspace manifests, run `npm ci --include=dev --workspaces --include-workspace-root`, run `npm --prefix apps/api run prisma:generate`, and run `npm run build:api` to build only the API.
- Prune dev dependencies with `npm prune --omit=dev --workspaces --include-workspace-root` and copy only `node_modules`, `apps/api/dist`, and relevant package files into the final image.
- Create a non-root system user/group (`nodeapp`/`nodejs`) and run the final container as that user.
- Harden the healthcheck command to exit on request errors and update the container `CMD` to run the built API at `apps/api/dist/src/server.js`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec37b5873c8330914bb803e58e5819)