### PR TITLE
Wrap DB seed in transaction, use transactional upserts, and fix invoice upsert key

### DIFF
--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -9,29 +9,28 @@ const prisma = new PrismaClient();
 
 async function main() {
   console.log('🌱 Seeding database...');
+  await prisma.$transaction(async (tx) => {
+    // Create first carrier (demo data)
+    const carrier = await tx.carrier.upsert({
+      where: { email: 'demo@infamousfreight.com' },
+      update: {},
+      create: {
+        email: 'demo@infamousfreight.com',
+        name: 'Acme Trucking LLC',
+        mcNumber: 'MC-123456',
+        dotNumber: '1234567',
+        phone: '(214) 555-0100',
+        address: '123 Main St, Dallas, TX 75201',
+        status: 'active',
+        subscriptionTier: 'growth',
+        stripeCustomerId: 'cus_demo',
+      },
+    });
 
-  // Create first carrier (demo data)
-  const carrier = await prisma.carrier.upsert({
-    where: { email: 'demo@infamousfreight.com' },
-    update: {},
-    create: {
-      email: 'demo@infamousfreight.com',
-      name: 'Acme Trucking LLC',
-      mcNumber: 'MC-123456',
-      dotNumber: '1234567',
-      phone: '(214) 555-0100',
-      address: '123 Main St, Dallas, TX 75201',
-      status: 'active',
-      subscriptionTier: 'growth',
-      stripeCustomerId: 'cus_demo',
-    },
-  });
+    console.log(`✅ Carrier created: ${carrier.name}`);
 
-  console.log(`✅ Carrier created: ${carrier.name}`);
-
-  // Create sample drivers
-  const drivers = await Promise.all([
-    prisma.driver.upsert({
+    // Create sample drivers
+    const driver1 = await tx.driver.upsert({
       where: { id: 'driver_1' },
       update: {},
       create: {
@@ -48,8 +47,8 @@ async function main() {
         hosStatus: 'on_duty',
         hoursRemaining: 8.5,
       },
-    }),
-    prisma.driver.upsert({
+    });
+    const driver2 = await tx.driver.upsert({
       where: { id: 'driver_2' },
       update: {},
       create: {
@@ -66,8 +65,8 @@ async function main() {
         hosStatus: 'driving',
         hoursRemaining: 4.2,
       },
-    }),
-    prisma.driver.upsert({
+    });
+    const driver3 = await tx.driver.upsert({
       where: { id: 'driver_3' },
       update: {},
       create: {
@@ -84,14 +83,13 @@ async function main() {
         hosStatus: 'off_duty',
         hoursRemaining: 11.0,
       },
-    }),
-  ]);
+    });
+    const drivers = [driver1, driver2, driver3];
 
-  console.log(`✅ ${drivers.length} drivers created`);
+    console.log(`✅ ${drivers.length} drivers created`);
 
-  // Create sample loads
-  const loads = await Promise.all([
-    prisma.load.upsert({
+    // Create sample loads
+    const load1 = await tx.load.upsert({
       where: { id: 'load_1' },
       update: {},
       create: {
@@ -117,8 +115,8 @@ async function main() {
         pickupDate: new Date(),
         deliveryDate: new Date(Date.now() + 86400000),
       },
-    }),
-    prisma.load.upsert({
+    });
+    const load2 = await tx.load.upsert({
       where: { id: 'load_2' },
       update: {},
       create: {
@@ -143,33 +141,34 @@ async function main() {
         pickupDate: new Date(Date.now() + 86400000),
         deliveryDate: new Date(Date.now() + 172800000),
       },
-    }),
-  ]);
+    });
+    const loads = [load1, load2];
 
-  console.log(`✅ ${loads.length} loads created`);
+    console.log(`✅ ${loads.length} loads created`);
 
-  // Create sample invoice
-  await prisma.invoice.upsert({
-    where: { id: 'inv_1' },
-    update: {},
-    create: {
-      id: 'inv_1',
-      loadId: 'load_1',
-      carrierId: carrier.id,
-      invoiceNumber: 'INV-240421-001',
-      brokerName: 'RXO',
-      brokerEmail: 'ap@rxo.com',
-      amount: 3200,
-      status: 'sent',
-      dueDate: new Date(Date.now() + 30 * 86400000),
-    },
+    // Create sample invoice
+    await tx.invoice.upsert({
+      where: { invoiceNumber: 'INV-240421-001' },
+      update: {},
+      create: {
+        id: 'inv_1',
+        loadId: 'load_1',
+        carrierId: carrier.id,
+        invoiceNumber: 'INV-240421-001',
+        brokerName: 'RXO',
+        brokerEmail: 'ap@rxo.com',
+        amount: 3200,
+        status: 'sent',
+        dueDate: new Date(Date.now() + 30 * 86400000),
+      },
+    });
+
+    console.log('✅ Invoice created');
+
+    console.log('\n🎉 Seed complete! Login with:');
+    console.log('   Email: demo@infamousfreight.com');
+    console.log('   Password: (set via Supabase auth)');
   });
-
-  console.log('✅ Invoice created');
-
-  console.log('\n🎉 Seed complete! Login with:');
-  console.log('   Email: demo@infamousfreight.com');
-  console.log('   Password: (set via Supabase auth)');
 }
 
 main()


### PR DESCRIPTION
### Motivation
- Ensure the sample data seed runs atomically to avoid partial state on failures by wrapping operations in a transaction. 
- Remove parallel non-transactional upserts to avoid potential race conditions and ensure referential consistency.
- Fix the invoice upsert predicate to use a stable unique field for matching to prevent accidental duplicates.

### Description
- Wrap the entire seed process in `prisma.$transaction` and use the transactional client `tx` for all operations. 
- Replace the previous `Promise.all` parallel `upsert` calls with individual `await tx.*.upsert` calls and collect results into arrays (`drivers`, `loads`).
- Change the invoice `upsert` `where` clause to use `invoiceNumber` instead of `id` to match by a stable unique field. 
- Preserve existing demo carrier, driver, load, and invoice data and console output messages.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebe3b2479483309709cf849771d2da)