### PR TITLE
deploy: add pnpm support and optional Fly image deploy; update docs

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -43,13 +43,16 @@ run_pm_script() {
 echo ""
 echo "Checking prerequisites..."
 check_prereq node
-if command -v pnpm &> /dev/null; then
+if [ -f "pnpm-lock.yaml" ]; then
     PACKAGE_MANAGER="pnpm"
-    echo -e "${GREEN}✅ pnpm found${NC}"
+elif [ -f "package-lock.json" ]; then
+    PACKAGE_MANAGER="npm"
+elif command -v pnpm &> /dev/null; then
+    PACKAGE_MANAGER="pnpm"
 else
     PACKAGE_MANAGER="npm"
-    check_prereq npm
 fi
+check_prereq "$PACKAGE_MANAGER"
 check_prereq git
 
 # Check environment variables

--- a/deploy.sh
+++ b/deploy.sh
@@ -3,12 +3,17 @@ set -e
 
 # ============================================================
 # INFAMOUS FREIGHT — One-Command Deploy Script
-# Usage: ./deploy.sh [environment]
+# Usage: ./deploy.sh [environment] [fly-image]
 #   environment: "prod" (default) or "staging"
+#   fly-image: optional image reference for rollback/redeploy
 # ============================================================
 
 ENV=${1:-prod}
+FLY_IMAGE=${2:-}
 echo "🚛 Deploying Infamous Freight to $ENV..."
+if [ -n "$FLY_IMAGE" ]; then
+    echo "📦 Using prebuilt Fly image: $FLY_IMAGE"
+fi
 
 # Colors
 RED='\033[0;31m'
@@ -25,10 +30,26 @@ check_prereq() {
     echo -e "${GREEN}✅ $1 found${NC}"
 }
 
+run_pm_script() {
+    local script_name=$1
+    shift || true
+    if [ "$PACKAGE_MANAGER" = "pnpm" ]; then
+        pnpm "$script_name" "$@"
+    else
+        npm run "$script_name" "$@"
+    fi
+}
+
 echo ""
 echo "Checking prerequisites..."
 check_prereq node
-check_prereq npm
+if command -v pnpm &> /dev/null; then
+    PACKAGE_MANAGER="pnpm"
+    echo -e "${GREEN}✅ pnpm found${NC}"
+else
+    PACKAGE_MANAGER="npm"
+    check_prereq npm
+fi
 check_prereq git
 
 # Check environment variables
@@ -44,30 +65,44 @@ fi
 # Install dependencies
 echo ""
 echo "📦 Installing dependencies..."
-npm install
+if [ "$PACKAGE_MANAGER" = "pnpm" ]; then
+    if [ -f "pnpm-lock.yaml" ]; then
+        pnpm install --frozen-lockfile
+    else
+        pnpm install --no-frozen-lockfile
+    fi
+else
+    npm install
+fi
 
 # Generate Prisma client
 echo ""
 echo "🔄 Generating Prisma client..."
-cd apps/api
-npx prisma generate
-cd ../..
+run_pm_script prisma:generate
 
 # Run tests
 echo ""
 echo "🧪 Running tests..."
-npm run test --if-present || echo -e "${YELLOW}⚠️  No tests configured${NC}"
+if [ "$PACKAGE_MANAGER" = "pnpm" ]; then
+    pnpm test -- --runInBand
+else
+    npm run test -- --runInBand
+fi
 
 # Build
 echo ""
 echo "🔨 Building..."
-npm run build
+run_pm_script build
 
 # Deploy API to Fly.io
 echo ""
 echo "🚀 Deploying API to Fly.io..."
 if command -v flyctl &> /dev/null; then
-    flyctl deploy --app infamous-freight --remote-only
+    if [ -n "$FLY_IMAGE" ]; then
+        flyctl deploy --app infamous-freight --image "$FLY_IMAGE"
+    else
+        flyctl deploy --app infamous-freight --remote-only
+    fi
     echo -e "${GREEN}✅ API deployed to Fly.io${NC}"
 else
     echo -e "${YELLOW}⚠️  Fly CLI (flyctl) not found. Skipping API deploy.${NC}"

--- a/docs/INTEGRATIONS-AND-SECRETS.md
+++ b/docs/INTEGRATIONS-AND-SECRETS.md
@@ -92,7 +92,7 @@ here for ownership awareness.
 
 6. **Rollback to last good release:**
    ```bash
-   fly releases --app infamous-freight   # find the last good version
+   flyctl releases --app infamous-freight   # find the last good version
    IMAGE=<previous-image-tag>
    flyctl deploy --image "$IMAGE" --app infamous-freight
 

--- a/docs/INTEGRATIONS-AND-SECRETS.md
+++ b/docs/INTEGRATIONS-AND-SECRETS.md
@@ -93,7 +93,11 @@ here for ownership awareness.
 6. **Rollback to last good release:**
    ```bash
    fly releases --app infamous-freight   # find the last good version
-   fly deploy --image <previous-image-tag> --app infamous-freight
+   IMAGE=<previous-image-tag>
+   flyctl deploy --image "$IMAGE" --app infamous-freight
+
+   # Example format for a known-good image:
+   # IMAGE=registry.fly.io/infamous-freight:deployment-<release-id>
    ```
 
 ---


### PR DESCRIPTION
### Motivation
- Allow the deploy script to work in workspaces that use `pnpm` as the package manager.  
- Enable deploying a prebuilt Fly image (useful for rollbacks or re-deploying a known-good image).  

### Description
- Add optional second argument `FLY_IMAGE` and use it to call `flyctl deploy --image "$FLY_IMAGE"` when provided.  
- Detect package manager (`pnpm` vs `npm`) and set `PACKAGE_MANAGER`, adding a `run_pm_script` helper to consistently run scripts like `prisma:generate`, `build`, and `test`.  
- Use `pnpm install --frozen-lockfile` when a `pnpm-lock.yaml` is present and fall back to non-frozen install otherwise, while preserving `npm install` for `npm` projects.  
- Adjust test invocation to pass `--runInBand` and update the docs (`docs/INTEGRATIONS-AND-SECRETS.md`) to show `flyctl deploy --image` usage with an `IMAGE` example.  

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec46c13144833080c741eec8847c11)