### PR TITLE
docs: add production readiness evidence log

### DIFF
--- a/docs/production-operations/PRODUCTION_READINESS_EVIDENCE.md
+++ b/docs/production-operations/PRODUCTION_READINESS_EVIDENCE.md
@@ -1,0 +1,90 @@
+# Production Readiness Evidence
+
+Use this file to record evidence before closing launch-readiness issues.
+
+## Launch Gate
+
+Main tracking issue: #1589
+
+## Compliance Evidence
+
+Related issue: #1583
+
+- Legal entity status:
+- EIN status:
+- FMCSA broker authority status:
+- BOC-3 status:
+- BMC-84 or BMC-85 status:
+- Evidence location:
+- Verified by:
+- Verified date:
+
+## Carrier Packet Evidence
+
+Related issue: #1584
+
+- Storage location:
+- Broker-carrier agreement source:
+- W-9 process:
+- Insurance process:
+- Approval owner:
+- Carrier statuses:
+- Test carrier record:
+- Verified by:
+- Verified date:
+
+## Quote Intake Evidence
+
+Related issue: #1585
+
+- Quote route or endpoint:
+- Lead destination:
+- Internal notification path:
+- Follow-up owner:
+- Test quote ID:
+- Test result:
+- Verified by:
+- Verified date:
+
+## Carrier Onboarding Evidence
+
+Related issue: #1586
+
+- Application route or endpoint:
+- Document upload path:
+- Carrier record destination:
+- Approval workflow:
+- Test application ID:
+- Test result:
+- Verified by:
+- Verified date:
+
+## Tracking Evidence
+
+Related issue: #1587
+
+- Shipment statuses:
+- Status update owner:
+- Customer visibility rules:
+- Delay messaging process:
+- Test load ID:
+- Test result:
+- Verified by:
+- Verified date:
+
+## Document Retention Evidence
+
+Related issue: #1588
+
+- Storage system:
+- Folder structure:
+- Naming convention:
+- Retention period:
+- Access owner:
+- Backup process:
+- Verified by:
+- Verified date:
+
+## Closure Rule
+
+Do not close #1589 until #1583 through #1588 have documented evidence and are closed.


### PR DESCRIPTION
## Summary

Adds a production readiness evidence log for Infamous Freight.

## Purpose

This file gives the team one place to record evidence before closing launch-readiness issues.

## Covers

- Compliance evidence
- Carrier packet evidence
- Quote intake evidence
- Carrier onboarding evidence
- Tracking evidence
- Document retention evidence

## Related

- #1583
- #1584
- #1585
- #1586
- #1587
- #1588
- #1589

## Validation

Documentation-only change. No build impact expected.