### PR TITLE
docs: link GitHub-native MVP plan from operations index

### DIFF
--- a/docs/production-operations/README.md
+++ b/docs/production-operations/README.md
@@ -2,4 +2,31 @@
 
 This package is GitHub-native and excludes Wix.
 
-It contains operations, compliance, dispatch, carrier, sales, and repository execution documentation for Infamous Freight.
+It contains operations, compliance, dispatch, carrier, sales, launch readiness, and repository execution documentation for Infamous Freight.
+
+## Core Documents
+
+- [Operating Model](OPERATING_MODEL.md)
+- [Launch Checklist](LAUNCH_CHECKLIST.md)
+- [Compliance Checklist](COMPLIANCE_CHECKLIST.md)
+- [Carrier Vetting SOP](CARRIER_VETTING_SOP.md)
+- [Dispatch Workflow](DISPATCH_WORKFLOW.md)
+- [Daily Operations SOP](DAILY_OPERATIONS_SOP.md)
+- [Shipper Sales Script](SHIPPER_SALES_SCRIPT.md)
+- [GitHub Execution Backlog](GITHUB_EXECUTION_BACKLOG.md)
+- [GitHub-Native MVP Build Plan](GITHUB_NATIVE_MVP_BUILD_PLAN.md)
+- [Production Readiness Evidence](PRODUCTION_READINESS_EVIDENCE.md)
+
+## Build Priority
+
+Build the MVP operating loop first:
+
+```text
+Quote Request -> Quote Review -> Load Creation -> Carrier Assignment -> Dispatch -> Tracking -> POD Upload -> Invoice
+```
+
+Do not prioritize advanced automation until the core freight lifecycle works end to end.
+
+## Launch Rule
+
+Production readiness remains blocked until the evidence log is completed and the related launch-readiness issues are verified.


### PR DESCRIPTION
## Summary

Updates the production operations index to link the GitHub-native MVP build plan and production readiness evidence log.

## Scope

- Adds core document links
- Adds MVP operating loop priority
- Reinforces launch readiness evidence rule

## Exclusions

- No Base44 references
- No Wix references

## Validation

Documentation-only change. No build impact expected.