### PR TITLE
feat(api): add Phase 3 freight operations service layer

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -2,11 +2,26 @@ import cors from 'cors';
 import helmet from 'helmet';
 import express, { NextFunction, Request, Response } from 'express';
 import * as Sentry from '@sentry/node';
-import { createDataStore, DataStore } from './data-store';
+import {
+  createDataStore,
+  DataStore,
+  FreightOperationResource,
+} from './data-store';
 
 type Role = 'owner' | 'admin' | 'dispatcher';
 
 const ALLOWED_ROLES: Role[] = ['owner', 'admin', 'dispatcher'];
+const FREIGHT_OPERATION_RESOURCES: FreightOperationResource[] = [
+  'quoteRequests',
+  'loadAssignments',
+  'loadDispatches',
+  'shipmentTracking',
+  'deliveryConfirmations',
+  'carrierPayments',
+  'rateAgreements',
+  'operationalMetrics',
+  'loadBoardPosts',
+];
 
 class HttpError extends Error {
   statusCode: number;
@@ -96,6 +111,20 @@ function getRequiredTenantId(req: Request): string {
   return req.tenantId;
 }
 
+function getFreightOperationResource(req: Request): FreightOperationResource {
+  const resource = req.params.resource;
+
+  if (!FREIGHT_OPERATION_RESOURCES.includes(resource as FreightOperationResource)) {
+    throw new HttpError(
+      404,
+      'freight_operation_resource_not_found',
+      `Unsupported freight operation resource: ${resource}`,
+    );
+  }
+
+  return resource as FreightOperationResource;
+}
+
 function registerRoutes(app: express.Express, dataStore: DataStore) {
   app.get('/api/loads', requireTenant, requireRole, wrapAsync(async (req, res) => {
     const data = await dataStore.listLoads(getRequiredTenantId(req));
@@ -125,6 +154,29 @@ function registerRoutes(app: express.Express, dataStore: DataStore) {
   app.post('/api/shipments', requireTenant, requireRole, wrapAsync(async (req, res) => {
     const data = await dataStore.createShipment(getRequiredTenantId(req), req.body);
     res.status(201).json({ data });
+  }));
+
+  app.get('/api/freight-operations/:resource', requireTenant, requireRole, wrapAsync(async (req, res) => {
+    const resource = getFreightOperationResource(req);
+    const data = await dataStore.listFreightOperations(resource, getRequiredTenantId(req));
+    res.status(200).json({ data, count: data.length });
+  }));
+
+  app.post('/api/freight-operations/:resource', requireTenant, requireRole, wrapAsync(async (req, res) => {
+    const resource = getFreightOperationResource(req);
+    const data = await dataStore.createFreightOperation(resource, getRequiredTenantId(req), req.body);
+    res.status(201).json({ data });
+  }));
+
+  app.patch('/api/freight-operations/:resource/:id', requireTenant, requireRole, wrapAsync(async (req, res) => {
+    const resource = getFreightOperationResource(req);
+    const data = await dataStore.updateFreightOperation(
+      resource,
+      getRequiredTenantId(req),
+      req.params.id,
+      req.body,
+    );
+    res.status(200).json({ data });
   }));
 }
 
@@ -182,6 +234,20 @@ export function createApp() {
       return res.status(err.statusCode).json({
         error: err.code,
         message: err.message,
+      });
+    }
+
+    if (err.message === 'freight_operation_not_found') {
+      return res.status(404).json({
+        error: 'freight_operation_not_found',
+        message: 'Freight operation record was not found for this tenant.',
+      });
+    }
+
+    if (err.message === 'load_not_found_for_tenant') {
+      return res.status(404).json({
+        error: 'load_not_found_for_tenant',
+        message: 'Referenced load was not found for this tenant.',
       });
     }
 

--- a/apps/api/src/data-store.ts
+++ b/apps/api/src/data-store.ts
@@ -6,9 +6,21 @@ type BaseRecord = {
   tenantId: string;
 };
 
+export type FreightOperationResource =
+  | 'quoteRequests'
+  | 'loadAssignments'
+  | 'loadDispatches'
+  | 'shipmentTracking'
+  | 'deliveryConfirmations'
+  | 'carrierPayments'
+  | 'rateAgreements'
+  | 'operationalMetrics'
+  | 'loadBoardPosts';
+
 export type LoadRecord = BaseRecord & Record<string, unknown>;
 export type DriverRecord = BaseRecord & Record<string, unknown>;
 export type ShipmentRecord = BaseRecord & Record<string, unknown>;
+export type FreightOperationRecord = BaseRecord & Record<string, unknown>;
 
 type PrismaLoadRecord = {
   id: string;
@@ -54,6 +66,69 @@ type PrismaDriverRecord = {
   createdAt: Date;
 };
 
+type OperationConfig = {
+  delegate: string;
+  tenantField?: string;
+  tenantRelation?: string;
+  numberFields?: string[];
+  booleanFields?: string[];
+  dateFields?: string[];
+};
+
+const OPERATION_CONFIG: Record<FreightOperationResource, OperationConfig> = {
+  quoteRequests: {
+    delegate: 'quoteRequest',
+    tenantField: 'carrierId',
+    numberFields: ['weight', 'shipperRate', 'carrierCost', 'profitMargin'],
+    dateFields: ['pickupDate', 'deliveryDeadline', 'expiresAt'],
+  },
+  loadAssignments: {
+    delegate: 'loadAssignment',
+    tenantField: 'carrierId',
+    numberFields: ['rateConfirmed'],
+    dateFields: ['acceptedAt', 'rejectedAt'],
+  },
+  loadDispatches: {
+    delegate: 'loadDispatch',
+    tenantField: 'carrierId',
+    dateFields: ['pickupAppointment', 'deliveryAppointment', 'dispatchedAt', 'confirmedAt'],
+  },
+  shipmentTracking: {
+    delegate: 'shipmentTracking',
+    tenantRelation: 'load',
+    numberFields: ['latitude', 'longitude'],
+    booleanFields: ['podReceived', 'podVerified'],
+    dateFields: ['pickupConfirmedAt', 'deliveryETA', 'deliveredAt'],
+  },
+  deliveryConfirmations: {
+    delegate: 'deliveryConfirmation',
+    tenantRelation: 'load',
+    dateFields: ['podDate', 'deliveryTime', 'verifiedAt'],
+  },
+  carrierPayments: {
+    delegate: 'carrierPayment',
+    tenantField: 'carrierId',
+    numberFields: ['amount'],
+    dateFields: ['paymentDate'],
+  },
+  rateAgreements: {
+    delegate: 'rateAgreement',
+    tenantField: 'carrierId',
+    numberFields: ['baseRate', 'fuelSurcharge'],
+    dateFields: ['effectiveDate', 'expiryDate'],
+  },
+  operationalMetrics: {
+    delegate: 'operationalMetric',
+    numberFields: ['loadsBooked', 'grossMargin', 'onTimePickup', 'onTimeDelivery', 'daysOutstanding'],
+    dateFields: ['date'],
+  },
+  loadBoardPosts: {
+    delegate: 'loadBoardPost',
+    tenantRelation: 'load',
+    dateFields: ['postedAt', 'expiresAt'],
+  },
+};
+
 export interface DataStore {
   listLoads(tenantId: string): Promise<LoadRecord[]>;
   createLoad(tenantId: string, payload: Record<string, unknown>): Promise<LoadRecord>;
@@ -61,13 +136,105 @@ export interface DataStore {
   createDriver(tenantId: string, payload: Record<string, unknown>): Promise<DriverRecord>;
   listShipments(tenantId: string): Promise<ShipmentRecord[]>;
   createShipment(tenantId: string, payload: Record<string, unknown>): Promise<ShipmentRecord>;
+  listFreightOperations(
+    resource: FreightOperationResource,
+    tenantId: string,
+  ): Promise<FreightOperationRecord[]>;
+  createFreightOperation(
+    resource: FreightOperationResource,
+    tenantId: string,
+    payload: Record<string, unknown>,
+  ): Promise<FreightOperationRecord>;
+  updateFreightOperation(
+    resource: FreightOperationResource,
+    tenantId: string,
+    id: string,
+    payload: Record<string, unknown>,
+  ): Promise<FreightOperationRecord>;
   healthCheck(): Promise<'connected' | 'disconnected'>;
+}
+
+function normalizePayload(
+  payload: Record<string, unknown>,
+  config: OperationConfig,
+): Record<string, unknown> {
+  const data = { ...payload };
+
+  for (const field of config.numberFields ?? []) {
+    if (data[field] !== undefined && data[field] !== null) {
+      data[field] = Number(data[field]);
+    }
+  }
+
+  for (const field of config.booleanFields ?? []) {
+    if (data[field] !== undefined && data[field] !== null) {
+      data[field] = Boolean(data[field]);
+    }
+  }
+
+  for (const field of config.dateFields ?? []) {
+    if (data[field] !== undefined && data[field] !== null) {
+      data[field] = new Date(String(data[field]));
+    }
+  }
+
+  delete data.tenantId;
+  return data;
+}
+
+function normalizeOperationRecord(
+  record: Record<string, unknown>,
+  tenantId: string,
+): FreightOperationRecord {
+  return { ...record, id: String(record.id), tenantId };
+}
+
+function buildTenantWhere(config: OperationConfig, tenantId: string): Record<string, unknown> {
+  if (config.tenantField) {
+    return { [config.tenantField]: tenantId };
+  }
+
+  if (config.tenantRelation) {
+    return { [config.tenantRelation]: { carrierId: tenantId } };
+  }
+
+  return {};
+}
+
+async function assertLoadBelongsToTenant(
+  prisma: PrismaClient,
+  tenantId: string,
+  loadId: unknown,
+): Promise<void> {
+  if (typeof loadId !== 'string' || !loadId.trim()) {
+    return;
+  }
+
+  const load = await prisma.load.findFirst({
+    where: { id: loadId, carrierId: tenantId },
+    select: { id: true },
+  });
+
+  if (!load) {
+    throw new Error('load_not_found_for_tenant');
+  }
 }
 
 class MemoryDataStore implements DataStore {
   private loads: LoadRecord[] = [];
   private drivers: DriverRecord[] = [];
   private shipments: ShipmentRecord[] = [];
+  private freightOperations: Record<FreightOperationResource, FreightOperationRecord[]> = {
+    quoteRequests: [],
+    loadAssignments: [],
+    loadDispatches: [],
+    shipmentTracking: [],
+    deliveryConfirmations: [],
+    carrierPayments: [],
+    rateAgreements: [],
+    operationalMetrics: [],
+    loadBoardPosts: [],
+  };
 
   async listLoads(tenantId: string): Promise<LoadRecord[]> {
     return this.loads.filter((item) => item.tenantId === tenantId);
@@ -97,6 +264,40 @@ class MemoryDataStore implements DataStore {
     const record = { id: randomUUID(), tenantId, ...payload };
     this.shipments.push(record);
     return record;
+  }
+
+  async listFreightOperations(
+    resource: FreightOperationResource,
+    tenantId: string,
+  ): Promise<FreightOperationRecord[]> {
+    return this.freightOperations[resource].filter((item) => item.tenantId === tenantId);
+  }
+
+  async createFreightOperation(
+    resource: FreightOperationResource,
+    tenantId: string,
+    payload: Record<string, unknown>,
+  ): Promise<FreightOperationRecord> {
+    const record = { id: randomUUID(), tenantId, ...payload };
+    this.freightOperations[resource].push(record);
+    return record;
+  }
+
+  async updateFreightOperation(
+    resource: FreightOperationResource,
+    tenantId: string,
+    id: string,
+    payload: Record<string, unknown>,
+  ): Promise<FreightOperationRecord> {
+    const records = this.freightOperations[resource];
+    const index = records.findIndex((item) => item.id === id && item.tenantId === tenantId);
+
+    if (index === -1) {
+      throw new Error('freight_operation_not_found');
+    }
+
+    records[index] = { ...records[index], ...payload, id, tenantId };
+    return records[index];
   }
 
   async healthCheck(): Promise<'connected' | 'disconnected'> {
@@ -271,6 +472,77 @@ class PrismaDataStore implements DataStore {
       deliveryDate: load.deliveryDate ?? null,
       rate: load.rate,
     };
+  }
+
+  async listFreightOperations(
+    resource: FreightOperationResource,
+    tenantId: string,
+  ): Promise<FreightOperationRecord[]> {
+    const config = OPERATION_CONFIG[resource];
+    const delegate = (this.prisma as unknown as Record<string, any>)[config.delegate];
+    const records = await delegate.findMany({
+      where: buildTenantWhere(config, tenantId),
+      orderBy: { createdAt: 'desc' },
+    }) as Array<Record<string, unknown>>;
+
+    return records.map((record) => normalizeOperationRecord(record, tenantId));
+  }
+
+  async createFreightOperation(
+    resource: FreightOperationResource,
+    tenantId: string,
+    payload: Record<string, unknown>,
+  ): Promise<FreightOperationRecord> {
+    const config = OPERATION_CONFIG[resource];
+    const data = normalizePayload(payload, config);
+
+    if (config.tenantField) {
+      data[config.tenantField] = tenantId;
+    }
+
+    if (config.tenantRelation === 'load') {
+      await assertLoadBelongsToTenant(this.prisma, tenantId, data.loadId);
+    }
+
+    const delegate = (this.prisma as unknown as Record<string, any>)[config.delegate];
+    const record = await delegate.create({ data }) as Record<string, unknown>;
+    return normalizeOperationRecord(record, tenantId);
+  }
+
+  async updateFreightOperation(
+    resource: FreightOperationResource,
+    tenantId: string,
+    id: string,
+    payload: Record<string, unknown>,
+  ): Promise<FreightOperationRecord> {
+    const config = OPERATION_CONFIG[resource];
+    const delegate = (this.prisma as unknown as Record<string, any>)[config.delegate];
+    const existing = await delegate.findFirst({
+      where: { id, ...buildTenantWhere(config, tenantId) },
+      select: { id: true },
+    });
+
+    if (!existing) {
+      throw new Error('freight_operation_not_found');
+    }
+
+    const data = normalizePayload(payload, config);
+    delete data.id;
+
+    if (config.tenantField) {
+      delete data[config.tenantField];
+    }
+
+    if (config.tenantRelation === 'load' && data.loadId !== undefined) {
+      await assertLoadBelongsToTenant(this.prisma, tenantId, data.loadId);
+    }
+
+    const record = await delegate.update({
+      where: { id },
+      data,
+    }) as Record<string, unknown>;
+
+    return normalizeOperationRecord(record, tenantId);
   }
 
   async healthCheck(): Promise<'connected' | 'disconnected'> {

--- a/apps/api/test/freight-operations.test.ts
+++ b/apps/api/test/freight-operations.test.ts
@@ -1,0 +1,111 @@
+import request from 'supertest';
+import { createApp } from '../src/app';
+
+const headers = {
+  'x-tenant-id': 'carrier_123',
+  'x-user-role': 'dispatcher',
+};
+
+describe('freight operations API', () => {
+  beforeEach(() => {
+    process.env.NODE_ENV = 'test';
+  });
+
+  it('creates, lists, and updates quote requests for a tenant', async () => {
+    const app = createApp();
+
+    const createResponse = await request(app)
+      .post('/api/freight-operations/quoteRequests')
+      .set(headers)
+      .send({
+        brokerName: 'Acme Broker',
+        originCity: 'Dallas',
+        destCity: 'Chicago',
+        freightType: 'dry_van',
+        weight: 42000,
+        pickupDate: '2026-05-01T10:00:00.000Z',
+        deliveryDeadline: '2026-05-03T10:00:00.000Z',
+        shipperRate: 2600,
+        carrierCost: 2100,
+        profitMargin: 500,
+        status: 'pending',
+      })
+      .expect(201);
+
+    expect(createResponse.body.data).toMatchObject({
+      tenantId: 'carrier_123',
+      brokerName: 'Acme Broker',
+      status: 'pending',
+    });
+
+    const listResponse = await request(app)
+      .get('/api/freight-operations/quoteRequests')
+      .set(headers)
+      .expect(200);
+
+    expect(listResponse.body.count).toBe(1);
+    expect(listResponse.body.data[0].id).toBe(createResponse.body.data.id);
+
+    const updateResponse = await request(app)
+      .patch(`/api/freight-operations/quoteRequests/${createResponse.body.data.id}`)
+      .set(headers)
+      .send({ status: 'accepted' })
+      .expect(200);
+
+    expect(updateResponse.body.data).toMatchObject({
+      id: createResponse.body.data.id,
+      tenantId: 'carrier_123',
+      status: 'accepted',
+    });
+  });
+
+  it('keeps freight operation records isolated by tenant', async () => {
+    const app = createApp();
+
+    await request(app)
+      .post('/api/freight-operations/carrierPayments')
+      .set(headers)
+      .send({
+        loadId: 'load_123',
+        amount: 1200,
+        paymentMethod: 'ach',
+        status: 'pending',
+      })
+      .expect(201);
+
+    const otherTenantResponse = await request(app)
+      .get('/api/freight-operations/carrierPayments')
+      .set({ ...headers, 'x-tenant-id': 'carrier_999' })
+      .expect(200);
+
+    expect(otherTenantResponse.body.count).toBe(0);
+    expect(otherTenantResponse.body.data).toEqual([]);
+  });
+
+  it('rejects unsupported freight operation resources', async () => {
+    const app = createApp();
+
+    const response = await request(app)
+      .get('/api/freight-operations/notAResource')
+      .set(headers)
+      .expect(404);
+
+    expect(response.body).toMatchObject({
+      error: 'freight_operation_resource_not_found',
+    });
+  });
+
+  it('requires tenant and role headers', async () => {
+    const app = createApp();
+
+    await request(app)
+      .get('/api/freight-operations/quoteRequests')
+      .set({ 'x-user-role': 'dispatcher' })
+      .expect(400);
+
+    await request(app)
+      .get('/api/freight-operations/quoteRequests')
+      .set({ 'x-tenant-id': 'carrier_123' })
+      .expect(403);
+  });
+});


### PR DESCRIPTION
## Summary

Implements Phase 3 API service layer for the freight operations models added in Phase 1.

## Added

- DataStore service methods for:
  - quote requests
  - load assignments
  - load dispatches
  - shipment tracking
  - delivery confirmations
  - carrier payments
  - rate agreements
  - operational metrics
  - load board posts
- Tenant-protected Express endpoints:
  - `GET /api/freight-operations/:resource`
  - `POST /api/freight-operations/:resource`
  - `PATCH /api/freight-operations/:resource/:id`
- Test coverage for:
  - create/list/update
  - tenant isolation
  - unsupported resource handling
  - required tenant/role headers

## Validation expected

- API build
- API tests
- Existing CI/CD checks