### PR TITLE
feat(api): add Phase 4 freight workflow integration

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -6,6 +6,7 @@ import {
   createDataStore,
   DataStore,
   FreightOperationResource,
+  LoadAssignmentDecision,
 } from './data-store';
 
 type Role = 'owner' | 'admin' | 'dispatcher';
@@ -22,6 +23,7 @@ const FREIGHT_OPERATION_RESOURCES: FreightOperationResource[] = [
   'operationalMetrics',
   'loadBoardPosts',
 ];
+const LOAD_ASSIGNMENT_DECISIONS: LoadAssignmentDecision[] = ['accepted', 'rejected'];
 
 class HttpError extends Error {
   statusCode: number;
@@ -125,6 +127,20 @@ function getFreightOperationResource(req: Request): FreightOperationResource {
   return resource as FreightOperationResource;
 }
 
+function getLoadAssignmentDecision(req: Request): LoadAssignmentDecision {
+  const decision = req.params.decision;
+
+  if (!LOAD_ASSIGNMENT_DECISIONS.includes(decision as LoadAssignmentDecision)) {
+    throw new HttpError(
+      400,
+      'invalid_load_assignment_decision',
+      'Load assignment decision must be accepted or rejected.',
+    );
+  }
+
+  return decision as LoadAssignmentDecision;
+}
+
 function registerRoutes(app: express.Express, dataStore: DataStore) {
   app.get('/api/loads', requireTenant, requireRole, wrapAsync(async (req, res) => {
     const data = await dataStore.listLoads(getRequiredTenantId(req));
@@ -176,6 +192,51 @@ function registerRoutes(app: express.Express, dataStore: DataStore) {
       req.params.id,
       req.body,
     );
+    res.status(200).json({ data });
+  }));
+
+  app.post('/api/workflows/quotes/:id/convert-to-load', requireTenant, requireRole, wrapAsync(async (req, res) => {
+    const data = await dataStore.convertQuoteToLoad(getRequiredTenantId(req), req.params.id, req.body);
+    res.status(201).json({ data });
+  }));
+
+  app.post('/api/workflows/load-assignments/:id/:decision', requireTenant, requireRole, wrapAsync(async (req, res) => {
+    const data = await dataStore.respondToLoadAssignment(
+      getRequiredTenantId(req),
+      req.params.id,
+      getLoadAssignmentDecision(req),
+      req.body,
+    );
+    res.status(200).json({ data });
+  }));
+
+  app.post('/api/workflows/dispatches/:id/confirm', requireTenant, requireRole, wrapAsync(async (req, res) => {
+    const data = await dataStore.confirmDispatch(getRequiredTenantId(req), req.params.id, req.body);
+    res.status(200).json({ data });
+  }));
+
+  app.post('/api/workflows/loads/:loadId/tracking-updates', requireTenant, requireRole, wrapAsync(async (req, res) => {
+    const data = await dataStore.recordTrackingUpdate(getRequiredTenantId(req), req.params.loadId, req.body);
+    res.status(201).json({ data });
+  }));
+
+  app.post('/api/workflows/loads/:loadId/verify-delivery', requireTenant, requireRole, wrapAsync(async (req, res) => {
+    const data = await dataStore.verifyDelivery(getRequiredTenantId(req), req.params.loadId, req.body);
+    res.status(201).json({ data });
+  }));
+
+  app.post('/api/workflows/carrier-payments/:id/status', requireTenant, requireRole, wrapAsync(async (req, res) => {
+    const data = await dataStore.updateCarrierPaymentStatus(getRequiredTenantId(req), req.params.id, req.body);
+    res.status(200).json({ data });
+  }));
+
+  app.post('/api/workflows/operational-metrics/rollup', requireTenant, requireRole, wrapAsync(async (req, res) => {
+    const data = await dataStore.rollupOperationalMetrics(getRequiredTenantId(req), req.body);
+    res.status(201).json({ data });
+  }));
+
+  app.post('/api/workflows/load-board-posts/:id/status', requireTenant, requireRole, wrapAsync(async (req, res) => {
+    const data = await dataStore.updateLoadBoardPostStatus(getRequiredTenantId(req), req.params.id, req.body);
     res.status(200).json({ data });
   }));
 }
@@ -248,6 +309,13 @@ export function createApp() {
       return res.status(404).json({
         error: 'load_not_found_for_tenant',
         message: 'Referenced load was not found for this tenant.',
+      });
+    }
+
+    if (err.message === 'quote_request_not_found') {
+      return res.status(404).json({
+        error: 'quote_request_not_found',
+        message: 'Quote request was not found for this tenant.',
       });
     }
 

--- a/apps/api/src/data-store.ts
+++ b/apps/api/src/data-store.ts
@@ -17,6 +17,8 @@ export type FreightOperationResource =
   | 'operationalMetrics'
   | 'loadBoardPosts';
 
+export type LoadAssignmentDecision = 'accepted' | 'rejected';
+export type FreightWorkflowResult = Record<string, unknown>;
 export type LoadRecord = BaseRecord & Record<string, unknown>;
 export type DriverRecord = BaseRecord & Record<string, unknown>;
 export type ShipmentRecord = BaseRecord & Record<string, unknown>;
@@ -151,7 +153,51 @@ export interface DataStore {
     id: string,
     payload: Record<string, unknown>,
   ): Promise<FreightOperationRecord>;
+  convertQuoteToLoad(
+    tenantId: string,
+    quoteRequestId: string,
+    payload: Record<string, unknown>,
+  ): Promise<FreightWorkflowResult>;
+  respondToLoadAssignment(
+    tenantId: string,
+    assignmentId: string,
+    decision: LoadAssignmentDecision,
+    payload?: Record<string, unknown>,
+  ): Promise<FreightOperationRecord>;
+  confirmDispatch(
+    tenantId: string,
+    dispatchId: string,
+    payload?: Record<string, unknown>,
+  ): Promise<FreightOperationRecord>;
+  recordTrackingUpdate(
+    tenantId: string,
+    loadId: string,
+    payload: Record<string, unknown>,
+  ): Promise<FreightOperationRecord>;
+  verifyDelivery(
+    tenantId: string,
+    loadId: string,
+    payload: Record<string, unknown>,
+  ): Promise<FreightWorkflowResult>;
+  updateCarrierPaymentStatus(
+    tenantId: string,
+    paymentId: string,
+    payload: Record<string, unknown>,
+  ): Promise<FreightOperationRecord>;
+  rollupOperationalMetrics(
+    tenantId: string,
+    payload: Record<string, unknown>,
+  ): Promise<FreightOperationRecord>;
+  updateLoadBoardPostStatus(
+    tenantId: string,
+    postId: string,
+    payload: Record<string, unknown>,
+  ): Promise<FreightOperationRecord>;
   healthCheck(): Promise<'connected' | 'disconnected'>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function normalizePayload(
@@ -199,6 +245,13 @@ function buildTenantWhere(config: OperationConfig, tenantId: string): Record<str
   }
 
   return {};
+}
+
+function getNestedPayload(
+  payload: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> {
+  return isRecord(payload[key]) ? payload[key] as Record<string, unknown> : payload;
 }
 
 async function assertLoadBelongsToTenant(
@@ -298,6 +351,127 @@ class MemoryDataStore implements DataStore {
 
     records[index] = { ...records[index], ...payload, id, tenantId };
     return records[index];
+  }
+
+  async convertQuoteToLoad(
+    tenantId: string,
+    quoteRequestId: string,
+    payload: Record<string, unknown>,
+  ): Promise<FreightWorkflowResult> {
+    const quoteRequest = await this.updateFreightOperation(
+      'quoteRequests',
+      tenantId,
+      quoteRequestId,
+      { status: payload.quoteStatus ?? 'converted' },
+    );
+    const loadPayload = getNestedPayload(payload, 'load');
+    const load = await this.createLoad(tenantId, {
+      ...loadPayload,
+      quoteRequestId,
+      brokerName: loadPayload.brokerName ?? quoteRequest.brokerName,
+      originCity: loadPayload.originCity ?? quoteRequest.originCity,
+      destCity: loadPayload.destCity ?? quoteRequest.destCity,
+      status: loadPayload.status ?? 'booked',
+    });
+
+    return { quoteRequest, load };
+  }
+
+  async respondToLoadAssignment(
+    tenantId: string,
+    assignmentId: string,
+    decision: LoadAssignmentDecision,
+    payload: Record<string, unknown> = {},
+  ): Promise<FreightOperationRecord> {
+    const timestampField = decision === 'accepted' ? 'acceptedAt' : 'rejectedAt';
+    return this.updateFreightOperation('loadAssignments', tenantId, assignmentId, {
+      ...payload,
+      status: decision,
+      [timestampField]: payload[timestampField] ?? new Date().toISOString(),
+    });
+  }
+
+  async confirmDispatch(
+    tenantId: string,
+    dispatchId: string,
+    payload: Record<string, unknown> = {},
+  ): Promise<FreightOperationRecord> {
+    return this.updateFreightOperation('loadDispatches', tenantId, dispatchId, {
+      ...payload,
+      status: payload.status ?? 'confirmed',
+      confirmedAt: payload.confirmedAt ?? new Date().toISOString(),
+    });
+  }
+
+  async recordTrackingUpdate(
+    tenantId: string,
+    loadId: string,
+    payload: Record<string, unknown>,
+  ): Promise<FreightOperationRecord> {
+    return this.createFreightOperation('shipmentTracking', tenantId, {
+      ...payload,
+      loadId,
+      status: payload.status ?? 'in_transit',
+    });
+  }
+
+  async verifyDelivery(
+    tenantId: string,
+    loadId: string,
+    payload: Record<string, unknown>,
+  ): Promise<FreightWorkflowResult> {
+    const deliveryConfirmation = await this.createFreightOperation('deliveryConfirmations', tenantId, {
+      ...payload,
+      loadId,
+      verifiedAt: payload.verifiedAt ?? new Date().toISOString(),
+    });
+    const tracking = await this.createFreightOperation('shipmentTracking', tenantId, {
+      loadId,
+      status: 'delivered',
+      deliveredAt: payload.deliveryTime ?? new Date().toISOString(),
+      podReceived: true,
+      podVerified: true,
+    });
+
+    return { deliveryConfirmation, tracking };
+  }
+
+  async updateCarrierPaymentStatus(
+    tenantId: string,
+    paymentId: string,
+    payload: Record<string, unknown>,
+  ): Promise<FreightOperationRecord> {
+    return this.updateFreightOperation('carrierPayments', tenantId, paymentId, {
+      ...payload,
+      status: payload.status ?? 'paid',
+      paymentDate: payload.paymentDate ?? new Date().toISOString(),
+    });
+  }
+
+  async rollupOperationalMetrics(
+    tenantId: string,
+    payload: Record<string, unknown>,
+  ): Promise<FreightOperationRecord> {
+    return this.createFreightOperation('operationalMetrics', tenantId, {
+      date: payload.date ?? new Date().toISOString(),
+      period: payload.period ?? 'daily',
+      loadsBooked: payload.loadsBooked ?? 0,
+      grossMargin: payload.grossMargin ?? 0,
+      onTimePickup: payload.onTimePickup ?? 0,
+      onTimeDelivery: payload.onTimeDelivery ?? 0,
+      daysOutstanding: payload.daysOutstanding ?? 0,
+    });
+  }
+
+  async updateLoadBoardPostStatus(
+    tenantId: string,
+    postId: string,
+    payload: Record<string, unknown>,
+  ): Promise<FreightOperationRecord> {
+    return this.updateFreightOperation('loadBoardPosts', tenantId, postId, {
+      ...payload,
+      status: payload.status ?? 'expired',
+    });
   }
 
   async healthCheck(): Promise<'connected' | 'disconnected'> {
@@ -543,6 +717,136 @@ class PrismaDataStore implements DataStore {
     }) as Record<string, unknown>;
 
     return normalizeOperationRecord(record, tenantId);
+  }
+
+  async convertQuoteToLoad(
+    tenantId: string,
+    quoteRequestId: string,
+    payload: Record<string, unknown>,
+  ): Promise<FreightWorkflowResult> {
+    const quoteRequest = await this.prisma.quoteRequest.findFirst({
+      where: { id: quoteRequestId, carrierId: tenantId },
+    }) as Record<string, unknown> | null;
+
+    if (!quoteRequest) {
+      throw new Error('quote_request_not_found');
+    }
+
+    const loadPayload = getNestedPayload(payload, 'load');
+    const load = await this.createLoad(tenantId, {
+      ...loadPayload,
+      brokerName: loadPayload.brokerName ?? quoteRequest.brokerName,
+      originCity: loadPayload.originCity ?? quoteRequest.originCity,
+      destCity: loadPayload.destCity ?? quoteRequest.destCity,
+      pickupDate: loadPayload.pickupDate ?? quoteRequest.pickupDate,
+      status: loadPayload.status ?? 'booked',
+    });
+    const updatedQuote = await this.prisma.quoteRequest.update({
+      where: { id: quoteRequestId },
+      data: { status: String(payload.quoteStatus ?? 'converted') },
+    }) as Record<string, unknown>;
+
+    return {
+      quoteRequest: normalizeOperationRecord(updatedQuote, tenantId),
+      load,
+    };
+  }
+
+  async respondToLoadAssignment(
+    tenantId: string,
+    assignmentId: string,
+    decision: LoadAssignmentDecision,
+    payload: Record<string, unknown> = {},
+  ): Promise<FreightOperationRecord> {
+    const timestampField = decision === 'accepted' ? 'acceptedAt' : 'rejectedAt';
+    return this.updateFreightOperation('loadAssignments', tenantId, assignmentId, {
+      ...payload,
+      status: decision,
+      [timestampField]: payload[timestampField] ?? new Date().toISOString(),
+    });
+  }
+
+  async confirmDispatch(
+    tenantId: string,
+    dispatchId: string,
+    payload: Record<string, unknown> = {},
+  ): Promise<FreightOperationRecord> {
+    return this.updateFreightOperation('loadDispatches', tenantId, dispatchId, {
+      ...payload,
+      status: payload.status ?? 'confirmed',
+      confirmedAt: payload.confirmedAt ?? new Date().toISOString(),
+    });
+  }
+
+  async recordTrackingUpdate(
+    tenantId: string,
+    loadId: string,
+    payload: Record<string, unknown>,
+  ): Promise<FreightOperationRecord> {
+    return this.createFreightOperation('shipmentTracking', tenantId, {
+      ...payload,
+      loadId,
+      status: payload.status ?? 'in_transit',
+    });
+  }
+
+  async verifyDelivery(
+    tenantId: string,
+    loadId: string,
+    payload: Record<string, unknown>,
+  ): Promise<FreightWorkflowResult> {
+    const deliveryConfirmation = await this.createFreightOperation('deliveryConfirmations', tenantId, {
+      ...payload,
+      loadId,
+      verifiedAt: payload.verifiedAt ?? new Date().toISOString(),
+    });
+    const tracking = await this.createFreightOperation('shipmentTracking', tenantId, {
+      loadId,
+      status: 'delivered',
+      deliveredAt: payload.deliveryTime ?? new Date().toISOString(),
+      podReceived: true,
+      podVerified: true,
+    });
+
+    return { deliveryConfirmation, tracking };
+  }
+
+  async updateCarrierPaymentStatus(
+    tenantId: string,
+    paymentId: string,
+    payload: Record<string, unknown>,
+  ): Promise<FreightOperationRecord> {
+    return this.updateFreightOperation('carrierPayments', tenantId, paymentId, {
+      ...payload,
+      status: payload.status ?? 'paid',
+      paymentDate: payload.paymentDate ?? new Date().toISOString(),
+    });
+  }
+
+  async rollupOperationalMetrics(
+    tenantId: string,
+    payload: Record<string, unknown>,
+  ): Promise<FreightOperationRecord> {
+    return this.createFreightOperation('operationalMetrics', tenantId, {
+      date: payload.date ?? new Date().toISOString(),
+      period: payload.period ?? 'daily',
+      loadsBooked: payload.loadsBooked ?? 0,
+      grossMargin: payload.grossMargin ?? 0,
+      onTimePickup: payload.onTimePickup ?? 0,
+      onTimeDelivery: payload.onTimeDelivery ?? 0,
+      daysOutstanding: payload.daysOutstanding ?? 0,
+    });
+  }
+
+  async updateLoadBoardPostStatus(
+    tenantId: string,
+    postId: string,
+    payload: Record<string, unknown>,
+  ): Promise<FreightOperationRecord> {
+    return this.updateFreightOperation('loadBoardPosts', tenantId, postId, {
+      ...payload,
+      status: payload.status ?? 'expired',
+    });
   }
 
   async healthCheck(): Promise<'connected' | 'disconnected'> {

--- a/apps/api/test/freight-workflows.test.ts
+++ b/apps/api/test/freight-workflows.test.ts
@@ -1,0 +1,188 @@
+import request from 'supertest';
+import { createApp } from '../src/app';
+
+const headers = {
+  'x-tenant-id': 'carrier_phase4',
+  'x-user-role': 'dispatcher',
+};
+
+const loadPayload = {
+  brokerName: 'Phase 4 Broker',
+  originCity: 'Dallas',
+  originState: 'TX',
+  originLat: 32.7767,
+  originLng: -96.797,
+  destCity: 'Chicago',
+  destState: 'IL',
+  destLat: 41.8781,
+  destLng: -87.6298,
+  distance: 925,
+  rate: 2600,
+  ratePerMile: 2.81,
+  equipmentType: 'dry_van',
+  weight: 42000,
+  pickupDate: '2026-05-01T10:00:00.000Z',
+};
+
+describe('freight workflow API', () => {
+  beforeEach(() => {
+    process.env.NODE_ENV = 'test';
+  });
+
+  it('converts a quote request into a load', async () => {
+    const app = createApp();
+
+    const quote = await request(app)
+      .post('/api/freight-operations/quoteRequests')
+      .set(headers)
+      .send({
+        brokerName: 'Acme Broker',
+        originCity: 'Dallas',
+        destCity: 'Chicago',
+        freightType: 'dry_van',
+        weight: 42000,
+        pickupDate: '2026-05-01T10:00:00.000Z',
+        shipperRate: 2600,
+        carrierCost: 2100,
+        profitMargin: 500,
+        status: 'pending',
+      })
+      .expect(201);
+
+    const response = await request(app)
+      .post(`/api/workflows/quotes/${quote.body.data.id}/convert-to-load`)
+      .set(headers)
+      .send({ load: loadPayload })
+      .expect(201);
+
+    expect(response.body.data.quoteRequest).toMatchObject({
+      id: quote.body.data.id,
+      status: 'converted',
+    });
+    expect(response.body.data.load).toMatchObject({
+      tenantId: 'carrier_phase4',
+      brokerName: 'Phase 4 Broker',
+      status: 'booked',
+    });
+  });
+
+  it('handles assignment, dispatch, tracking, delivery, payment, metrics, and load board lifecycle', async () => {
+    const app = createApp();
+
+    const load = await request(app)
+      .post('/api/loads')
+      .set(headers)
+      .send(loadPayload)
+      .expect(201);
+    const loadId = load.body.data.id;
+
+    const assignment = await request(app)
+      .post('/api/freight-operations/loadAssignments')
+      .set(headers)
+      .send({ loadId, rateConfirmed: 2500, status: 'pending' })
+      .expect(201);
+
+    const assignmentResponse = await request(app)
+      .post(`/api/workflows/load-assignments/${assignment.body.data.id}/accepted`)
+      .set(headers)
+      .send({})
+      .expect(200);
+
+    expect(assignmentResponse.body.data.status).toBe('accepted');
+    expect(assignmentResponse.body.data.acceptedAt).toBeDefined();
+
+    const dispatch = await request(app)
+      .post('/api/freight-operations/loadDispatches')
+      .set(headers)
+      .send({ loadId, status: 'pending', pickupContactName: 'Dock One' })
+      .expect(201);
+
+    const dispatchResponse = await request(app)
+      .post(`/api/workflows/dispatches/${dispatch.body.data.id}/confirm`)
+      .set(headers)
+      .send({})
+      .expect(200);
+
+    expect(dispatchResponse.body.data.status).toBe('confirmed');
+    expect(dispatchResponse.body.data.confirmedAt).toBeDefined();
+
+    const trackingResponse = await request(app)
+      .post(`/api/workflows/loads/${loadId}/tracking-updates`)
+      .set(headers)
+      .send({ latitude: 33.1, longitude: -96.9, status: 'in_transit' })
+      .expect(201);
+
+    expect(trackingResponse.body.data).toMatchObject({ loadId, status: 'in_transit' });
+
+    const deliveryResponse = await request(app)
+      .post(`/api/workflows/loads/${loadId}/verify-delivery`)
+      .set(headers)
+      .send({ podSignature: 'Jane Receiver', deliveryTime: '2026-05-03T10:00:00.000Z' })
+      .expect(201);
+
+    expect(deliveryResponse.body.data.deliveryConfirmation).toMatchObject({
+      loadId,
+      podSignature: 'Jane Receiver',
+    });
+    expect(deliveryResponse.body.data.tracking).toMatchObject({
+      loadId,
+      status: 'delivered',
+      podReceived: true,
+      podVerified: true,
+    });
+
+    const payment = await request(app)
+      .post('/api/freight-operations/carrierPayments')
+      .set(headers)
+      .send({ loadId, amount: 2200, status: 'pending' })
+      .expect(201);
+
+    const paymentResponse = await request(app)
+      .post(`/api/workflows/carrier-payments/${payment.body.data.id}/status`)
+      .set(headers)
+      .send({ status: 'paid' })
+      .expect(200);
+
+    expect(paymentResponse.body.data.status).toBe('paid');
+    expect(paymentResponse.body.data.paymentDate).toBeDefined();
+
+    const metricsResponse = await request(app)
+      .post('/api/workflows/operational-metrics/rollup')
+      .set(headers)
+      .send({ period: 'daily', loadsBooked: 1, grossMargin: 400 })
+      .expect(201);
+
+    expect(metricsResponse.body.data).toMatchObject({
+      tenantId: 'carrier_phase4',
+      period: 'daily',
+      loadsBooked: 1,
+      grossMargin: 400,
+    });
+
+    const post = await request(app)
+      .post('/api/freight-operations/loadBoardPosts')
+      .set(headers)
+      .send({ loadId, board: 'DAT', boardPostId: 'dat_123', status: 'posted' })
+      .expect(201);
+
+    const postResponse = await request(app)
+      .post(`/api/workflows/load-board-posts/${post.body.data.id}/status`)
+      .set(headers)
+      .send({ status: 'expired' })
+      .expect(200);
+
+    expect(postResponse.body.data.status).toBe('expired');
+  });
+
+  it('rejects invalid assignment decisions', async () => {
+    const app = createApp();
+
+    const response = await request(app)
+      .post('/api/workflows/load-assignments/assignment_123/maybe')
+      .set(headers)
+      .send({})
+      .expect(400);
+
+    expect(response.body.error).toBe('invalid_load_assignment_decision');
+  });
+});


### PR DESCRIPTION
## Summary

Implements Phase 4 workflow integration on top of the Phase 3 freight operations service layer.

## Added workflow endpoints

- `POST /api/workflows/quotes/:id/convert-to-load`
- `POST /api/workflows/load-assignments/:id/:decision`
- `POST /api/workflows/dispatches/:id/confirm`
- `POST /api/workflows/loads/:loadId/tracking-updates`
- `POST /api/workflows/loads/:loadId/verify-delivery`
- `POST /api/workflows/carrier-payments/:id/status`
- `POST /api/workflows/operational-metrics/rollup`
- `POST /api/workflows/load-board-posts/:id/status`

## Covered workflows

- Quote to load conversion
- Load assignment acceptance/rejection
- Dispatch confirmation
- Shipment tracking updates
- POD/delivery verification
- Carrier payment lifecycle
- KPI metric rollups
- Load board post status lifecycle

## Tests

Adds integration tests for the workflow lifecycle and invalid assignment decisions.