### PR TITLE
feat(web): add Phase 5 launch validation UI

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -14,6 +14,7 @@ import MetricsDashboard from '@/pages/MetricsDashboard';
 import CaseStudies from '@/pages/CaseStudies';
 import ProductHunt from '@/pages/ProductHunt';
 import GDPR from '@/pages/GDPR';
+import LaunchValidationPage from '@/pages/LaunchValidationPage';
 import { PayPerLoadPricing } from '@/components/PayPerLoadPricing';
 import { ReferralProgram } from '@/components/ReferralProgram';
 import LoginPage from '@/pages/LoginPage';
@@ -37,6 +38,7 @@ function App() {
           <Route path="/case-studies" element={<CaseStudies />} />
           <Route path="/product-hunt" element={<ProductHunt />} />
           <Route path="/gdpr" element={<GDPR />} />
+          <Route path="/launch-validation" element={<LaunchValidationPage />} />
         </Route>
 
         {/* Public routes (no layout) */}

--- a/apps/web/src/components/ui/Sidebar.tsx
+++ b/apps/web/src/components/ui/Sidebar.tsx
@@ -3,7 +3,7 @@ import { useAppStore } from '@/store/app-store';
 import {
   LayoutDashboard, Truck, Radio, Users, FileText, MessageSquare,
   TrendingUp, ShieldCheck, Settings, ChevronLeft, ChevronRight,
-  Zap, LogOut
+  Zap, LogOut, ClipboardCheck
 } from 'lucide-react';
 
 const navItems = [
@@ -15,6 +15,7 @@ const navItems = [
   { path: '/chat', label: 'Messages', icon: MessageSquare, badge: '3' },
   { path: '/analytics', label: 'Analytics', icon: TrendingUp },
   { path: '/compliance', label: 'Compliance', icon: ShieldCheck },
+  { path: '/launch-validation', label: 'Launch Validation', icon: ClipboardCheck },
   { path: '/settings', label: 'Settings', icon: Settings },
 ];
 
@@ -50,7 +51,7 @@ const Sidebar: React.FC = () => {
       </div>
 
       {/* Navigation */}
-      <nav className="flex-1 py-4 space-y-1 px-2">
+      <nav className="flex-1 py-4 space-y-1 px-2 overflow-y-auto">
         {navItems.map((item) => {
           const isActive = location.pathname === item.path;
           return (

--- a/apps/web/src/lib/freightWorkflowApi.ts
+++ b/apps/web/src/lib/freightWorkflowApi.ts
@@ -1,0 +1,202 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_URL || '',
+});
+
+export type FreightOperationResource =
+  | 'quoteRequests'
+  | 'loadAssignments'
+  | 'loadDispatches'
+  | 'shipmentTracking'
+  | 'deliveryConfirmations'
+  | 'carrierPayments'
+  | 'rateAgreements'
+  | 'operationalMetrics'
+  | 'loadBoardPosts';
+
+export type LaunchValidationResult = {
+  name: string;
+  status: 'pending' | 'running' | 'passed' | 'failed';
+  detail?: string;
+};
+
+type ApiEnvelope<T> = {
+  data: T;
+  count?: number;
+};
+
+type RequestContext = {
+  tenantId: string;
+  role: string;
+};
+
+function getHeaders(context: RequestContext) {
+  return {
+    'x-tenant-id': context.tenantId,
+    'x-user-role': context.role || 'dispatcher',
+  };
+}
+
+export async function listFreightOperations<T>(
+  resource: FreightOperationResource,
+  context: RequestContext,
+): Promise<T[]> {
+  const response = await api.get<ApiEnvelope<T[]>>(`/api/freight-operations/${resource}`, {
+    headers: getHeaders(context),
+  });
+
+  return response.data.data;
+}
+
+export async function createFreightOperation<T>(
+  resource: FreightOperationResource,
+  context: RequestContext,
+  payload: Record<string, unknown>,
+): Promise<T> {
+  const response = await api.post<ApiEnvelope<T>>(`/api/freight-operations/${resource}`, payload, {
+    headers: getHeaders(context),
+  });
+
+  return response.data.data;
+}
+
+export async function updateFreightOperation<T>(
+  resource: FreightOperationResource,
+  context: RequestContext,
+  id: string,
+  payload: Record<string, unknown>,
+): Promise<T> {
+  const response = await api.patch<ApiEnvelope<T>>(`/api/freight-operations/${resource}/${id}`, payload, {
+    headers: getHeaders(context),
+  });
+
+  return response.data.data;
+}
+
+export async function convertQuoteToLoad<T>(
+  context: RequestContext,
+  quoteRequestId: string,
+  payload: Record<string, unknown>,
+): Promise<T> {
+  const response = await api.post<ApiEnvelope<T>>(
+    `/api/workflows/quotes/${quoteRequestId}/convert-to-load`,
+    payload,
+    { headers: getHeaders(context) },
+  );
+
+  return response.data.data;
+}
+
+export async function respondToLoadAssignment<T>(
+  context: RequestContext,
+  assignmentId: string,
+  decision: 'accepted' | 'rejected',
+  payload: Record<string, unknown> = {},
+): Promise<T> {
+  const response = await api.post<ApiEnvelope<T>>(
+    `/api/workflows/load-assignments/${assignmentId}/${decision}`,
+    payload,
+    { headers: getHeaders(context) },
+  );
+
+  return response.data.data;
+}
+
+export async function confirmDispatch<T>(
+  context: RequestContext,
+  dispatchId: string,
+  payload: Record<string, unknown> = {},
+): Promise<T> {
+  const response = await api.post<ApiEnvelope<T>>(
+    `/api/workflows/dispatches/${dispatchId}/confirm`,
+    payload,
+    { headers: getHeaders(context) },
+  );
+
+  return response.data.data;
+}
+
+export async function recordTrackingUpdate<T>(
+  context: RequestContext,
+  loadId: string,
+  payload: Record<string, unknown>,
+): Promise<T> {
+  const response = await api.post<ApiEnvelope<T>>(
+    `/api/workflows/loads/${loadId}/tracking-updates`,
+    payload,
+    { headers: getHeaders(context) },
+  );
+
+  return response.data.data;
+}
+
+export async function verifyDelivery<T>(
+  context: RequestContext,
+  loadId: string,
+  payload: Record<string, unknown>,
+): Promise<T> {
+  const response = await api.post<ApiEnvelope<T>>(
+    `/api/workflows/loads/${loadId}/verify-delivery`,
+    payload,
+    { headers: getHeaders(context) },
+  );
+
+  return response.data.data;
+}
+
+export async function updateCarrierPaymentStatus<T>(
+  context: RequestContext,
+  paymentId: string,
+  payload: Record<string, unknown>,
+): Promise<T> {
+  const response = await api.post<ApiEnvelope<T>>(
+    `/api/workflows/carrier-payments/${paymentId}/status`,
+    payload,
+    { headers: getHeaders(context) },
+  );
+
+  return response.data.data;
+}
+
+export async function rollupOperationalMetrics<T>(
+  context: RequestContext,
+  payload: Record<string, unknown>,
+): Promise<T> {
+  const response = await api.post<ApiEnvelope<T>>(
+    '/api/workflows/operational-metrics/rollup',
+    payload,
+    { headers: getHeaders(context) },
+  );
+
+  return response.data.data;
+}
+
+export async function updateLoadBoardPostStatus<T>(
+  context: RequestContext,
+  postId: string,
+  payload: Record<string, unknown>,
+): Promise<T> {
+  const response = await api.post<ApiEnvelope<T>>(
+    `/api/workflows/load-board-posts/${postId}/status`,
+    payload,
+    { headers: getHeaders(context) },
+  );
+
+  return response.data.data;
+}
+
+export function getApiErrorMessage(error: unknown): string {
+  if (axios.isAxiosError(error)) {
+    const message = error.response?.data?.message;
+    if (typeof message === 'string') {
+      return message;
+    }
+
+    if (error.message) {
+      return error.message;
+    }
+  }
+
+  return error instanceof Error ? error.message : 'Unexpected API error';
+}

--- a/apps/web/src/pages/LaunchValidationPage.tsx
+++ b/apps/web/src/pages/LaunchValidationPage.tsx
@@ -1,0 +1,302 @@
+import { useMemo, useState } from 'react';
+import toast from 'react-hot-toast';
+import {
+  CheckCircle2,
+  ClipboardCheck,
+  FileCheck2,
+  Loader2,
+  PlayCircle,
+  Radio,
+  ShieldCheck,
+  Truck,
+  XCircle,
+} from 'lucide-react';
+import { useAppStore } from '@/store/app-store';
+import {
+  confirmDispatch,
+  convertQuoteToLoad,
+  createFreightOperation,
+  getApiErrorMessage,
+  LaunchValidationResult,
+  recordTrackingUpdate,
+  respondToLoadAssignment,
+  rollupOperationalMetrics,
+  updateCarrierPaymentStatus,
+  updateLoadBoardPostStatus,
+  verifyDelivery,
+} from '@/lib/freightWorkflowApi';
+
+type WorkflowRecord = Record<string, unknown> & { id: string };
+
+type QuoteToLoadResult = {
+  quoteRequest: WorkflowRecord;
+  load: WorkflowRecord;
+};
+
+type DeliveryVerificationResult = {
+  deliveryConfirmation: WorkflowRecord;
+  tracking: WorkflowRecord;
+};
+
+const initialChecks: LaunchValidationResult[] = [
+  { name: 'Quote to load conversion', status: 'pending' },
+  { name: 'Assignment acceptance', status: 'pending' },
+  { name: 'Dispatch confirmation', status: 'pending' },
+  { name: 'Tracking update', status: 'pending' },
+  { name: 'POD verification', status: 'pending' },
+  { name: 'Carrier payment status', status: 'pending' },
+  { name: 'Operational KPI rollup', status: 'pending' },
+  { name: 'Load board lifecycle', status: 'pending' },
+];
+
+function updateCheck(
+  checks: LaunchValidationResult[],
+  name: string,
+  patch: Partial<LaunchValidationResult>,
+): LaunchValidationResult[] {
+  return checks.map((check) => (check.name === name ? { ...check, ...patch } : check));
+}
+
+const LaunchValidationPage: React.FC = () => {
+  const { user } = useAppStore();
+  const [checks, setChecks] = useState<LaunchValidationResult[]>(initialChecks);
+  const [isRunning, setIsRunning] = useState(false);
+  const [lastLoadId, setLastLoadId] = useState<string | null>(null);
+
+  const context = useMemo(() => ({
+    tenantId: user?.carrierId ?? 'carrier_default',
+    role: user?.role ?? 'dispatcher',
+  }), [user?.carrierId, user?.role]);
+
+  const setRunning = (name: string) => {
+    setChecks((current) => updateCheck(current, name, { status: 'running', detail: undefined }));
+  };
+
+  const setPassed = (name: string, detail: string) => {
+    setChecks((current) => updateCheck(current, name, { status: 'passed', detail }));
+  };
+
+  const setFailed = (name: string, detail: string) => {
+    setChecks((current) => updateCheck(current, name, { status: 'failed', detail }));
+  };
+
+  const runValidation = async () => {
+    setIsRunning(true);
+    setChecks(initialChecks);
+
+    try {
+      setRunning('Quote to load conversion');
+      const quote = await createFreightOperation<WorkflowRecord>('quoteRequests', context, {
+        brokerName: 'Launch Validation Broker',
+        originCity: 'Dallas',
+        destCity: 'Chicago',
+        freightType: 'dry_van',
+        weight: 42000,
+        pickupDate: new Date().toISOString(),
+        shipperRate: 2600,
+        carrierCost: 2100,
+        profitMargin: 500,
+        status: 'pending',
+      });
+      const quoteConversion = await convertQuoteToLoad<QuoteToLoadResult>(context, quote.id, {
+        load: {
+          brokerName: 'Launch Validation Broker',
+          originCity: 'Dallas',
+          originState: 'TX',
+          originLat: 32.7767,
+          originLng: -96.797,
+          destCity: 'Chicago',
+          destState: 'IL',
+          destLat: 41.8781,
+          destLng: -87.6298,
+          distance: 925,
+          rate: 2600,
+          ratePerMile: 2.81,
+          equipmentType: 'dry_van',
+          weight: 42000,
+          pickupDate: new Date().toISOString(),
+        },
+      });
+      const loadId = quoteConversion.load.id;
+      setLastLoadId(loadId);
+      setPassed('Quote to load conversion', `Created load ${loadId}`);
+
+      setRunning('Assignment acceptance');
+      const assignment = await createFreightOperation<WorkflowRecord>('loadAssignments', context, {
+        loadId,
+        rateConfirmed: 2500,
+        status: 'pending',
+      });
+      await respondToLoadAssignment<WorkflowRecord>(context, assignment.id, 'accepted');
+      setPassed('Assignment acceptance', `Accepted assignment ${assignment.id}`);
+
+      setRunning('Dispatch confirmation');
+      const dispatch = await createFreightOperation<WorkflowRecord>('loadDispatches', context, {
+        loadId,
+        status: 'pending',
+        pickupContactName: 'Launch Dock',
+      });
+      await confirmDispatch<WorkflowRecord>(context, dispatch.id);
+      setPassed('Dispatch confirmation', `Confirmed dispatch ${dispatch.id}`);
+
+      setRunning('Tracking update');
+      await recordTrackingUpdate<WorkflowRecord>(context, loadId, {
+        latitude: 33.1,
+        longitude: -96.9,
+        status: 'in_transit',
+      });
+      setPassed('Tracking update', 'Recorded in-transit location update');
+
+      setRunning('POD verification');
+      const delivery = await verifyDelivery<DeliveryVerificationResult>(context, loadId, {
+        podSignature: 'Launch Receiver',
+        deliveryTime: new Date().toISOString(),
+      });
+      setPassed('POD verification', `Verified POD ${delivery.deliveryConfirmation.id}`);
+
+      setRunning('Carrier payment status');
+      const payment = await createFreightOperation<WorkflowRecord>('carrierPayments', context, {
+        loadId,
+        amount: 2200,
+        status: 'pending',
+      });
+      await updateCarrierPaymentStatus<WorkflowRecord>(context, payment.id, { status: 'paid' });
+      setPassed('Carrier payment status', `Marked payment ${payment.id} paid`);
+
+      setRunning('Operational KPI rollup');
+      const metrics = await rollupOperationalMetrics<WorkflowRecord>(context, {
+        period: 'daily',
+        loadsBooked: 1,
+        grossMargin: 400,
+        onTimePickup: 1,
+        onTimeDelivery: 1,
+        daysOutstanding: 0,
+      });
+      setPassed('Operational KPI rollup', `Created metric ${metrics.id}`);
+
+      setRunning('Load board lifecycle');
+      const post = await createFreightOperation<WorkflowRecord>('loadBoardPosts', context, {
+        loadId,
+        board: 'DAT',
+        boardPostId: `launch_${Date.now()}`,
+        status: 'posted',
+      });
+      await updateLoadBoardPostStatus<WorkflowRecord>(context, post.id, { status: 'expired' });
+      setPassed('Load board lifecycle', `Expired load-board post ${post.id}`);
+
+      toast.success('Launch validation passed');
+    } catch (error) {
+      const message = getApiErrorMessage(error);
+      const runningCheck = checks.find((check) => check.status === 'running');
+      if (runningCheck) {
+        setFailed(runningCheck.name, message);
+      }
+      toast.error(message);
+    } finally {
+      setIsRunning(false);
+    }
+  };
+
+  const passedCount = checks.filter((check) => check.status === 'passed').length;
+  const failedCount = checks.filter((check) => check.status === 'failed').length;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <p className="text-sm uppercase tracking-[0.25em] text-infamous-orange">Phase 5</p>
+          <h1 className="mt-2 text-3xl font-bold text-white">Launch Validation</h1>
+          <p className="mt-2 max-w-3xl text-sm text-gray-400">
+            Validate the core freight workflows against the live API using the current carrier context.
+            Run this before production migration, launch demos, or customer onboarding.
+          </p>
+        </div>
+        <button
+          onClick={runValidation}
+          disabled={isRunning}
+          className="inline-flex items-center justify-center gap-2 rounded-xl bg-infamous-orange px-5 py-3 text-sm font-semibold text-white transition hover:bg-infamous-orange-light disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {isRunning ? <Loader2 size={18} className="animate-spin" /> : <PlayCircle size={18} />}
+          {isRunning ? 'Running validation' : 'Run validation'}
+        </button>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-4">
+        <div className="rounded-2xl border border-infamous-border bg-infamous-card p-4">
+          <p className="text-xs uppercase tracking-wide text-gray-500">Carrier context</p>
+          <p className="mt-2 truncate text-lg font-semibold text-white">{context.tenantId}</p>
+        </div>
+        <div className="rounded-2xl border border-infamous-border bg-infamous-card p-4">
+          <p className="text-xs uppercase tracking-wide text-gray-500">Role</p>
+          <p className="mt-2 text-lg font-semibold text-white">{context.role}</p>
+        </div>
+        <div className="rounded-2xl border border-infamous-border bg-infamous-card p-4">
+          <p className="text-xs uppercase tracking-wide text-gray-500">Passed</p>
+          <p className="mt-2 text-lg font-semibold text-green-400">{passedCount}/{checks.length}</p>
+        </div>
+        <div className="rounded-2xl border border-infamous-border bg-infamous-card p-4">
+          <p className="text-xs uppercase tracking-wide text-gray-500">Failed</p>
+          <p className="mt-2 text-lg font-semibold text-red-400">{failedCount}</p>
+        </div>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        {checks.map((check) => (
+          <div key={check.name} className="rounded-2xl border border-infamous-border bg-infamous-card p-5">
+            <div className="flex items-start gap-4">
+              <div className="mt-1">
+                {check.status === 'passed' && <CheckCircle2 className="text-green-400" size={22} />}
+                {check.status === 'failed' && <XCircle className="text-red-400" size={22} />}
+                {check.status === 'running' && <Loader2 className="animate-spin text-infamous-orange" size={22} />}
+                {check.status === 'pending' && <ClipboardCheck className="text-gray-500" size={22} />}
+              </div>
+              <div className="min-w-0 flex-1">
+                <h2 className="font-semibold text-white">{check.name}</h2>
+                <p className="mt-1 text-sm text-gray-400">{check.detail ?? 'Not run yet'}</p>
+              </div>
+              <span className="rounded-full border border-infamous-border px-2.5 py-1 text-xs uppercase text-gray-400">
+                {check.status}
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="rounded-2xl border border-infamous-border bg-infamous-card p-5">
+        <div className="flex items-center gap-3">
+          <ShieldCheck className="text-infamous-orange" size={24} />
+          <h2 className="text-xl font-semibold text-white">Launch gates</h2>
+        </div>
+        <div className="mt-5 grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          <div className="rounded-xl border border-infamous-border bg-black/20 p-4">
+            <Truck className="mb-3 text-infamous-orange" size={20} />
+            <h3 className="font-semibold text-white">Dispatcher workflow</h3>
+            <p className="mt-2 text-sm text-gray-400">Quote, load, assignment, dispatch, and tracking lifecycle.</p>
+          </div>
+          <div className="rounded-xl border border-infamous-border bg-black/20 p-4">
+            <FileCheck2 className="mb-3 text-infamous-orange" size={20} />
+            <h3 className="font-semibold text-white">POD workflow</h3>
+            <p className="mt-2 text-sm text-gray-400">Delivery confirmation, POD verification, and delivered tracking state.</p>
+          </div>
+          <div className="rounded-xl border border-infamous-border bg-black/20 p-4">
+            <ClipboardCheck className="mb-3 text-infamous-orange" size={20} />
+            <h3 className="font-semibold text-white">Payment workflow</h3>
+            <p className="mt-2 text-sm text-gray-400">Carrier payment creation and status lifecycle.</p>
+          </div>
+          <div className="rounded-xl border border-infamous-border bg-black/20 p-4">
+            <Radio className="mb-3 text-infamous-orange" size={20} />
+            <h3 className="font-semibold text-white">Reporting workflow</h3>
+            <p className="mt-2 text-sm text-gray-400">Operational metric rollup and load-board lifecycle checks.</p>
+          </div>
+        </div>
+        {lastLoadId && (
+          <p className="mt-5 rounded-xl border border-infamous-border bg-black/20 px-4 py-3 text-sm text-gray-400">
+            Last validation load: <span className="font-mono text-white">{lastLoadId}</span>
+          </p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default LaunchValidationPage;

--- a/docs/PHASE_5_LAUNCH_VALIDATION.md
+++ b/docs/PHASE_5_LAUNCH_VALIDATION.md
@@ -1,0 +1,83 @@
+# Infamous Freight — Phase 5 Launch Validation
+
+Date: April 26, 2026
+Status: Phase 5 UI and launch validation path added
+
+## Purpose
+
+Phase 5 gives the operations team a browser-based validation console for the freight workflow API added in Phases 3 and 4.
+
+The validation page is available at:
+
+```text
+/launch-validation
+```
+
+## What the page validates
+
+The page runs end-to-end workflow checks against the configured API using the signed-in user's carrier context.
+
+It validates:
+
+1. Quote to load conversion
+2. Load assignment acceptance
+3. Dispatch confirmation
+4. Shipment tracking update
+5. POD / delivery verification
+6. Carrier payment status update
+7. Operational metric rollup
+8. Load board post lifecycle
+
+## Required environment
+
+The web app must have a valid API URL configured:
+
+```env
+VITE_API_URL=https://api.infamousfreight.com
+```
+
+The API must have production database access configured through:
+
+```env
+DATABASE_URL=postgresql://...
+```
+
+## Production migration readiness
+
+Do not run the launch validation page against production until the production migration plan is confirmed.
+
+For an existing production database that already has the original baseline tables, mark the baseline migration as applied first:
+
+```bash
+npm --prefix apps/api exec prisma migrate resolve --applied 20260425000000_baseline_schema --schema prisma/schema.prisma
+```
+
+Then deploy pending migrations:
+
+```bash
+npm --prefix apps/api exec prisma migrate deploy --schema prisma/schema.prisma
+```
+
+## Recommended launch sequence
+
+1. Confirm CI is green on `main`.
+2. Confirm production environment variables are present.
+3. Apply database migration to staging first.
+4. Run `/launch-validation` against staging.
+5. Apply production migration.
+6. Run `/launch-validation` against production with an internal carrier account.
+7. Review generated validation records in the dashboard/API.
+8. Disable or restrict access to launch validation if the page should not remain available to all dispatcher/admin users.
+
+## Access control note
+
+The page uses the existing app auth/session context. It calls API endpoints with:
+
+- `x-tenant-id`
+- `x-user-role`
+
+For stricter production control, restrict the route to owner/admin users or hide it behind a feature flag before broad rollout.
+
+## Operational note
+
+The validation page creates real workflow records in the selected environment. Use it with an internal test carrier account, not a live customer tenant.


### PR DESCRIPTION
## Summary

Adds Phase 5 launch validation UI and runbook for validating the freight workflow lifecycle from the web app.

## Added

- Freight workflow API client
- `/launch-validation` route
- Sidebar navigation item
- Launch validation page that checks:
  - quote to load conversion
  - assignment acceptance
  - dispatch confirmation
  - tracking update
  - POD verification
  - carrier payment status
  - operational KPI rollup
  - load board lifecycle
- Phase 5 launch validation runbook

## Notes

The validation page creates real workflow records in the selected environment. Use it with an internal test carrier account.