### PR TITLE
feat(web): harden launch validation access

### DIFF
--- a/apps/web/src/components/ui/Sidebar.tsx
+++ b/apps/web/src/components/ui/Sidebar.tsx
@@ -1,12 +1,13 @@
 import { NavLink, useLocation } from 'react-router-dom';
 import { useAppStore } from '@/store/app-store';
+import { canAccessLaunchValidation } from '@/lib/launchValidationAccess';
 import {
   LayoutDashboard, Truck, Radio, Users, FileText, MessageSquare,
   TrendingUp, ShieldCheck, Settings, ChevronLeft, ChevronRight,
   Zap, LogOut, ClipboardCheck
 } from 'lucide-react';
 
-const navItems = [
+const baseNavItems = [
   { path: '/', label: 'Dashboard', icon: LayoutDashboard },
   { path: '/loads', label: 'Loads', icon: Truck },
   { path: '/dispatch', label: 'Dispatch Board', icon: Radio },
@@ -15,13 +16,22 @@ const navItems = [
   { path: '/chat', label: 'Messages', icon: MessageSquare, badge: '3' },
   { path: '/analytics', label: 'Analytics', icon: TrendingUp },
   { path: '/compliance', label: 'Compliance', icon: ShieldCheck },
-  { path: '/launch-validation', label: 'Launch Validation', icon: ClipboardCheck },
-  { path: '/settings', label: 'Settings', icon: Settings },
 ];
 
+const launchValidationNavItem = {
+  path: '/launch-validation',
+  label: 'Launch Validation',
+  icon: ClipboardCheck,
+};
+
+const settingsNavItem = { path: '/settings', label: 'Settings', icon: Settings };
+
 const Sidebar: React.FC = () => {
-  const { sidebarOpen, toggleSidebar, logout } = useAppStore();
+  const { sidebarOpen, toggleSidebar, logout, user } = useAppStore();
   const location = useLocation();
+  const navItems = canAccessLaunchValidation(user?.role)
+    ? [...baseNavItems, launchValidationNavItem, settingsNavItem]
+    : [...baseNavItems, settingsNavItem];
 
   return (
     <aside
@@ -68,14 +78,14 @@ const Sidebar: React.FC = () => {
               {sidebarOpen && (
                 <>
                   <span className="text-sm font-medium flex-1">{item.label}</span>
-                  {item.badge && (
+                  {'badge' in item && item.badge && (
                     <span className="bg-infamous-orange text-white text-[10px] font-bold px-1.5 py-0.5 rounded-full min-w-[18px] text-center">
                       {item.badge}
                     </span>
                   )}
                 </>
               )}
-              {!sidebarOpen && item.badge && (
+              {!sidebarOpen && 'badge' in item && item.badge && (
                 <span className="absolute -top-1 -right-1 w-4 h-4 bg-infamous-orange rounded-full text-[9px] font-bold text-white flex items-center justify-center">
                   {item.badge}
                 </span>

--- a/apps/web/src/components/ui/Sidebar.tsx
+++ b/apps/web/src/components/ui/Sidebar.tsx
@@ -4,10 +4,17 @@ import { canAccessLaunchValidation } from '@/lib/launchValidationAccess';
 import {
   LayoutDashboard, Truck, Radio, Users, FileText, MessageSquare,
   TrendingUp, ShieldCheck, Settings, ChevronLeft, ChevronRight,
-  Zap, LogOut, ClipboardCheck
+  Zap, LogOut, ClipboardCheck, type LucideIcon
 } from 'lucide-react';
 
-const baseNavItems = [
+type NavItem = {
+  path: string;
+  label: string;
+  icon: LucideIcon;
+  badge?: string;
+};
+
+const baseNavItems: NavItem[] = [
   { path: '/', label: 'Dashboard', icon: LayoutDashboard },
   { path: '/loads', label: 'Loads', icon: Truck },
   { path: '/dispatch', label: 'Dispatch Board', icon: Radio },
@@ -18,18 +25,18 @@ const baseNavItems = [
   { path: '/compliance', label: 'Compliance', icon: ShieldCheck },
 ];
 
-const launchValidationNavItem = {
+const launchValidationNavItem: NavItem = {
   path: '/launch-validation',
   label: 'Launch Validation',
   icon: ClipboardCheck,
 };
 
-const settingsNavItem = { path: '/settings', label: 'Settings', icon: Settings };
+const settingsNavItem: NavItem = { path: '/settings', label: 'Settings', icon: Settings };
 
 const Sidebar: React.FC = () => {
   const { sidebarOpen, toggleSidebar, logout, user } = useAppStore();
   const location = useLocation();
-  const navItems = canAccessLaunchValidation(user?.role)
+  const navItems: NavItem[] = canAccessLaunchValidation(user?.role)
     ? [...baseNavItems, launchValidationNavItem, settingsNavItem]
     : [...baseNavItems, settingsNavItem];
 
@@ -78,14 +85,14 @@ const Sidebar: React.FC = () => {
               {sidebarOpen && (
                 <>
                   <span className="text-sm font-medium flex-1">{item.label}</span>
-                  {'badge' in item && item.badge && (
+                  {item.badge && (
                     <span className="bg-infamous-orange text-white text-[10px] font-bold px-1.5 py-0.5 rounded-full min-w-[18px] text-center">
                       {item.badge}
                     </span>
                   )}
                 </>
               )}
-              {!sidebarOpen && 'badge' in item && item.badge && (
+              {!sidebarOpen && item.badge && (
                 <span className="absolute -top-1 -right-1 w-4 h-4 bg-infamous-orange rounded-full text-[9px] font-bold text-white flex items-center justify-center">
                   {item.badge}
                 </span>

--- a/apps/web/src/lib/launchValidationAccess.ts
+++ b/apps/web/src/lib/launchValidationAccess.ts
@@ -1,0 +1,20 @@
+const OWNER_ADMIN_ROLES = new Set(['owner', 'admin']);
+
+export function isLaunchValidationEnabled(): boolean {
+  const flag = import.meta.env.VITE_LAUNCH_VALIDATION_ENABLED;
+
+  if (flag === 'true') {
+    return true;
+  }
+
+  if (flag === 'false') {
+    return false;
+  }
+
+  // Keep local/staging development easy, but keep production closed unless explicitly enabled.
+  return import.meta.env.MODE !== 'production';
+}
+
+export function canAccessLaunchValidation(role?: string | null): boolean {
+  return isLaunchValidationEnabled() && OWNER_ADMIN_ROLES.has((role ?? '').toLowerCase());
+}

--- a/apps/web/src/pages/LaunchValidationPage.tsx
+++ b/apps/web/src/pages/LaunchValidationPage.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import toast from 'react-hot-toast';
 import {
+  AlertTriangle,
   CheckCircle2,
   ClipboardCheck,
   FileCheck2,
@@ -12,6 +13,7 @@ import {
   XCircle,
 } from 'lucide-react';
 import { useAppStore } from '@/store/app-store';
+import { canAccessLaunchValidation, isLaunchValidationEnabled } from '@/lib/launchValidationAccess';
 import {
   confirmDispatch,
   convertQuoteToLoad,
@@ -67,6 +69,8 @@ const LaunchValidationPage: React.FC = () => {
     tenantId: user?.carrierId ?? 'carrier_default',
     role: user?.role ?? 'dispatcher',
   }), [user?.carrierId, user?.role]);
+  const launchValidationEnabled = isLaunchValidationEnabled();
+  const canAccess = canAccessLaunchValidation(user?.role);
 
   const setRunning = (name: string) => {
     setChecks((current) => updateCheck(current, name, { status: 'running', detail: undefined }));
@@ -81,6 +85,11 @@ const LaunchValidationPage: React.FC = () => {
   };
 
   const runValidation = async () => {
+    if (!canAccess) {
+      toast.error('Launch validation is restricted to owner/admin users when enabled.');
+      return;
+    }
+
     setIsRunning(true);
     setChecks(initialChecks);
 
@@ -199,6 +208,27 @@ const LaunchValidationPage: React.FC = () => {
 
   const passedCount = checks.filter((check) => check.status === 'passed').length;
   const failedCount = checks.filter((check) => check.status === 'failed').length;
+
+  if (!canAccess) {
+    return (
+      <div className="flex min-h-[70vh] items-center justify-center">
+        <div className="max-w-xl rounded-2xl border border-infamous-border bg-infamous-card p-8 text-center">
+          <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-red-500/10">
+            <AlertTriangle className="text-red-400" size={24} />
+          </div>
+          <h1 className="text-2xl font-bold text-white">Launch validation restricted</h1>
+          <p className="mt-3 text-sm text-gray-400">
+            This tool creates real workflow records. Access is limited to owner/admin users and requires
+            <span className="font-mono text-gray-200"> VITE_LAUNCH_VALIDATION_ENABLED=true</span> in production.
+          </p>
+          <div className="mt-5 rounded-xl border border-infamous-border bg-black/20 p-4 text-left text-sm text-gray-400">
+            <p>Feature flag: <span className="font-mono text-white">{String(launchValidationEnabled)}</span></p>
+            <p>Current role: <span className="font-mono text-white">{context.role}</span></p>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">

--- a/docs/PHASE_5_LAUNCH_VALIDATION.md
+++ b/docs/PHASE_5_LAUNCH_VALIDATION.md
@@ -1,7 +1,7 @@
 # Infamous Freight — Phase 5 Launch Validation
 
 Date: April 26, 2026
-Status: Phase 5 UI and launch validation path added
+Status: Phase 5 UI and launch validation path added; production access now gated
 
 ## Purpose
 
@@ -42,6 +42,27 @@ The API must have production database access configured through:
 DATABASE_URL=postgresql://...
 ```
 
+## Launch validation access control
+
+The validation page creates real workflow records, so it is restricted.
+
+Access requires:
+
+1. User role is `owner` or `admin`.
+2. In production, the web environment variable below is explicitly enabled:
+
+```env
+VITE_LAUNCH_VALIDATION_ENABLED=true
+```
+
+If the flag is unset in production, the route remains blocked and the sidebar item is hidden. Local and non-production environments remain enabled by default to support staging validation.
+
+Recommended production setting after validation:
+
+```env
+VITE_LAUNCH_VALIDATION_ENABLED=false
+```
+
 ## Production migration readiness
 
 Do not run the launch validation page against production until the production migration plan is confirmed.
@@ -63,20 +84,12 @@ npm --prefix apps/api exec prisma migrate deploy --schema prisma/schema.prisma
 1. Confirm CI is green on `main`.
 2. Confirm production environment variables are present.
 3. Apply database migration to staging first.
-4. Run `/launch-validation` against staging.
+4. Run `/launch-validation` against staging with an owner/admin internal test account.
 5. Apply production migration.
-6. Run `/launch-validation` against production with an internal carrier account.
-7. Review generated validation records in the dashboard/API.
-8. Disable or restrict access to launch validation if the page should not remain available to all dispatcher/admin users.
-
-## Access control note
-
-The page uses the existing app auth/session context. It calls API endpoints with:
-
-- `x-tenant-id`
-- `x-user-role`
-
-For stricter production control, restrict the route to owner/admin users or hide it behind a feature flag before broad rollout.
+6. Temporarily set `VITE_LAUNCH_VALIDATION_ENABLED=true` in production web env.
+7. Run `/launch-validation` against production with an internal owner/admin carrier account.
+8. Review generated validation records in the dashboard/API.
+9. Set `VITE_LAUNCH_VALIDATION_ENABLED=false` again unless active validation access is still needed.
 
 ## Operational note
 


### PR DESCRIPTION
## Summary

Hardens the Phase 5 launch validation console before environment-level launch execution.

## Changes

- Adds reusable launch validation access helper
- Restricts `/launch-validation` to owner/admin users
- Requires `VITE_LAUNCH_VALIDATION_ENABLED=true` in production
- Hides the sidebar item unless access is allowed
- Updates the Phase 5 runbook with feature-flag and role-gating instructions

## Notes

The `.env.example` update was intentionally avoided because the connector blocked edits to that file due to existing secret-token placeholders. The feature flag is documented in the runbook instead.

Closes part of #1606.