### PR TITLE
feat(api): add Stripe billing automation foundation

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -160,7 +160,7 @@ function getLoadAssignmentDecision(req: Request): LoadAssignmentDecision {
   return decision as LoadAssignmentDecision;
 }
 
-function registerRoutes(app: express.Express, dataStore: DataStore) {
+function registerWebhookRoute(app: express.Express, dataStore: DataStore) {
   app.post('/api/billing/webhook', express.raw({ type: 'application/json' }), wrapAsync(async (req, res) => {
     const rawBody = Buffer.isBuffer(req.body) ? req.body : Buffer.from(JSON.stringify(req.body ?? {}));
     const signature = req.header('stripe-signature');
@@ -179,7 +179,9 @@ function registerRoutes(app: express.Express, dataStore: DataStore) {
 
     res.status(200).json({ received: true });
   }));
+}
 
+function registerRoutes(app: express.Express, dataStore: DataStore) {
   app.post('/api/billing/customer-portal', requireTenant, requireRole, requireBillingRole, wrapAsync(async (req, res) => {
     const stripeCustomerId = await dataStore.getCarrierStripeCustomerId(getRequiredTenantId(req));
 
@@ -320,7 +322,7 @@ export function createApp() {
     }),
   );
 
-  registerRoutes(app, dataStore);
+  registerWebhookRoute(app, dataStore);
   app.use(express.json());
 
   app.get('/health', wrapAsync(async (_req, res) => {
@@ -342,6 +344,8 @@ export function createApp() {
       services: { database },
     });
   }));
+
+  registerRoutes(app, dataStore);
 
   app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
     if (err instanceof HttpError) {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -8,10 +8,18 @@ import {
   FreightOperationResource,
   LoadAssignmentDecision,
 } from './data-store';
+import {
+  createStripeBillingPortalSession,
+  getBillingSyncFromStripeEvent,
+  getStripeWebhookSecret,
+  StripeEvent,
+  verifyStripeWebhookSignature,
+} from './billing';
 
 type Role = 'owner' | 'admin' | 'dispatcher';
 
 const ALLOWED_ROLES: Role[] = ['owner', 'admin', 'dispatcher'];
+const BILLING_ROLES: Role[] = ['owner', 'admin'];
 const FREIGHT_OPERATION_RESOURCES: FreightOperationResource[] = [
   'quoteRequests',
   'loadAssignments',
@@ -69,6 +77,17 @@ function requireRole(req: Request, res: Response, next: NextFunction) {
   }
 
   req.userRole = role as Role;
+  next();
+}
+
+function requireBillingRole(req: Request, res: Response, next: NextFunction) {
+  if (!req.userRole || !BILLING_ROLES.includes(req.userRole)) {
+    return res.status(403).json({
+      error: 'billing_forbidden',
+      message: 'Billing actions require owner or admin access.',
+    });
+  }
+
   next();
 }
 
@@ -142,6 +161,40 @@ function getLoadAssignmentDecision(req: Request): LoadAssignmentDecision {
 }
 
 function registerRoutes(app: express.Express, dataStore: DataStore) {
+  app.post('/api/billing/webhook', express.raw({ type: 'application/json' }), wrapAsync(async (req, res) => {
+    const rawBody = Buffer.isBuffer(req.body) ? req.body : Buffer.from(JSON.stringify(req.body ?? {}));
+    const signature = req.header('stripe-signature');
+
+    if (!verifyStripeWebhookSignature(rawBody, signature, getStripeWebhookSecret())) {
+      res.status(400).json({ error: 'invalid_stripe_signature' });
+      return;
+    }
+
+    const event = JSON.parse(rawBody.toString('utf8')) as StripeEvent;
+    const billingSync = getBillingSyncFromStripeEvent(event);
+
+    if (billingSync) {
+      await dataStore.syncCarrierBilling(billingSync);
+    }
+
+    res.status(200).json({ received: true });
+  }));
+
+  app.post('/api/billing/customer-portal', requireTenant, requireRole, requireBillingRole, wrapAsync(async (req, res) => {
+    const stripeCustomerId = await dataStore.getCarrierStripeCustomerId(getRequiredTenantId(req));
+
+    if (!stripeCustomerId) {
+      throw new HttpError(
+        404,
+        'stripe_customer_not_found',
+        'No Stripe customer is linked to this carrier yet.',
+      );
+    }
+
+    const url = await createStripeBillingPortalSession(stripeCustomerId);
+    res.status(200).json({ data: { url } });
+  }));
+
   app.get('/api/loads', requireTenant, requireRole, wrapAsync(async (req, res) => {
     const data = await dataStore.listLoads(getRequiredTenantId(req));
     res.status(200).json({ data, count: data.length });
@@ -266,6 +319,8 @@ export function createApp() {
       credentials: true,
     }),
   );
+
+  registerRoutes(app, dataStore);
   app.use(express.json());
 
   app.get('/health', wrapAsync(async (_req, res) => {
@@ -287,8 +342,6 @@ export function createApp() {
       services: { database },
     });
   }));
-
-  registerRoutes(app, dataStore);
 
   app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
     if (err instanceof HttpError) {
@@ -316,6 +369,13 @@ export function createApp() {
       return res.status(404).json({
         error: 'quote_request_not_found',
         message: 'Quote request was not found for this tenant.',
+      });
+    }
+
+    if (err.message === 'stripe_secret_key_required') {
+      return res.status(500).json({
+        error: 'stripe_secret_key_required',
+        message: 'STRIPE_SECRET_KEY is required for billing portal sessions.',
       });
     }
 

--- a/apps/api/src/billing.ts
+++ b/apps/api/src/billing.ts
@@ -1,0 +1,220 @@
+import crypto from 'crypto';
+
+export type BillingPlan = 'starter' | 'professional' | 'enterprise';
+export type BillingInterval = 'month' | 'year';
+export type BillingStatus = 'active' | 'trial' | 'past_due' | 'canceled' | 'unpaid' | 'incomplete' | 'inactive';
+
+export type BillingSyncPayload = {
+  carrierId?: string;
+  stripeCustomerId?: string;
+  subscriptionTier?: BillingPlan;
+  status?: BillingStatus;
+};
+
+export type StripeEvent = {
+  id: string;
+  type: string;
+  data: {
+    object: Record<string, unknown>;
+  };
+};
+
+const PLAN_BY_PRICE_ID: Record<string, BillingPlan> = {
+  price_1TBnZ2KCNuZqDozYEcW5j4xM: 'starter',
+  price_1TBnZ3KCNuZqDozYvHBLW9L3: 'starter',
+  price_1TBnZ3KCNuZqDozY2FISQT98: 'professional',
+  price_1TBnZ4KCNuZqDozYO9YCSWIr: 'professional',
+  price_1TBnZ3KCNuZqDozYUG5nsCHt: 'enterprise',
+  price_1TBnZ4KCNuZqDozYy4qS3Kvy: 'enterprise',
+};
+
+export function getStripeSecretKey(): string | null {
+  return process.env.STRIPE_SECRET_KEY?.trim() || null;
+}
+
+export function getStripeWebhookSecret(): string | null {
+  return process.env.STRIPE_WEBHOOK_SECRET?.trim() || null;
+}
+
+export function getBillingPortalReturnUrl(): string {
+  return process.env.STRIPE_PORTAL_RETURN_URL?.trim()
+    || process.env.WEB_APP_URL?.trim()
+    || 'http://localhost:5173/settings';
+}
+
+export function verifyStripeWebhookSignature(
+  rawBody: Buffer,
+  signatureHeader: string | undefined,
+  webhookSecret: string | null = getStripeWebhookSecret(),
+): boolean {
+  if (!webhookSecret || !signatureHeader) {
+    return false;
+  }
+
+  const parts = signatureHeader.split(',').reduce<Record<string, string[]>>((acc, part) => {
+    const [key, value] = part.split('=');
+    if (!key || !value) {
+      return acc;
+    }
+    acc[key] = [...(acc[key] ?? []), value];
+    return acc;
+  }, {});
+
+  const timestamp = parts.t?.[0];
+  const signatures = parts.v1 ?? [];
+
+  if (!timestamp || signatures.length === 0) {
+    return false;
+  }
+
+  const signedPayload = `${timestamp}.${rawBody.toString('utf8')}`;
+  const expected = crypto
+    .createHmac('sha256', webhookSecret)
+    .update(signedPayload, 'utf8')
+    .digest('hex');
+
+  return signatures.some((signature) => {
+    const expectedBuffer = Buffer.from(expected, 'hex');
+    const signatureBuffer = Buffer.from(signature, 'hex');
+
+    return expectedBuffer.length === signatureBuffer.length
+      && crypto.timingSafeEqual(expectedBuffer, signatureBuffer);
+  });
+}
+
+function getString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined;
+}
+
+function getRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function getMetadata(object: Record<string, unknown>): Record<string, unknown> {
+  return getRecord(object.metadata) ?? {};
+}
+
+function getCustomerId(object: Record<string, unknown>): string | undefined {
+  const customer = object.customer;
+  if (typeof customer === 'string') {
+    return customer;
+  }
+
+  return getString(getRecord(customer)?.id);
+}
+
+function mapStripeStatus(status: string | undefined): BillingStatus {
+  switch (status) {
+    case 'active':
+      return 'active';
+    case 'trialing':
+      return 'trial';
+    case 'past_due':
+      return 'past_due';
+    case 'canceled':
+      return 'canceled';
+    case 'unpaid':
+      return 'unpaid';
+    case 'incomplete':
+    case 'incomplete_expired':
+      return 'incomplete';
+    default:
+      return 'inactive';
+  }
+}
+
+function getPlanFromSubscription(object: Record<string, unknown>): BillingPlan | undefined {
+  const metadataPlan = getString(getMetadata(object).plan) as BillingPlan | undefined;
+  if (metadataPlan === 'starter' || metadataPlan === 'professional' || metadataPlan === 'enterprise') {
+    return metadataPlan;
+  }
+
+  const items = getRecord(object.items);
+  const data = Array.isArray(items?.data) ? items.data : [];
+  const firstItem = getRecord(data[0]);
+  const price = getRecord(firstItem?.price);
+  const priceId = getString(price?.id);
+
+  return priceId ? PLAN_BY_PRICE_ID[priceId] : undefined;
+}
+
+export function getBillingSyncFromStripeEvent(event: StripeEvent): BillingSyncPayload | null {
+  const object = event.data.object;
+  const metadata = getMetadata(object);
+  const carrierId = getString(metadata.carrierId);
+  const stripeCustomerId = getCustomerId(object);
+
+  switch (event.type) {
+    case 'checkout.session.completed': {
+      const plan = getString(metadata.plan) as BillingPlan | undefined;
+      return {
+        carrierId,
+        stripeCustomerId,
+        subscriptionTier: plan === 'starter' || plan === 'professional' || plan === 'enterprise' ? plan : undefined,
+        status: 'active',
+      };
+    }
+    case 'customer.subscription.created':
+    case 'customer.subscription.updated': {
+      return {
+        carrierId,
+        stripeCustomerId,
+        subscriptionTier: getPlanFromSubscription(object),
+        status: mapStripeStatus(getString(object.status)),
+      };
+    }
+    case 'customer.subscription.deleted': {
+      return {
+        carrierId,
+        stripeCustomerId,
+        status: 'canceled',
+      };
+    }
+    case 'invoice.payment_succeeded': {
+      return {
+        stripeCustomerId,
+        status: 'active',
+      };
+    }
+    case 'invoice.payment_failed': {
+      return {
+        stripeCustomerId,
+        status: 'past_due',
+      };
+    }
+    default:
+      return null;
+  }
+}
+
+export async function createStripeBillingPortalSession(customerId: string): Promise<string> {
+  const secretKey = getStripeSecretKey();
+
+  if (!secretKey) {
+    throw new Error('stripe_secret_key_required');
+  }
+
+  const body = new URLSearchParams({
+    customer: customerId,
+    return_url: getBillingPortalReturnUrl(),
+  });
+
+  const response = await fetch('https://api.stripe.com/v1/billing_portal/sessions', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${secretKey}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body,
+  });
+
+  const json = await response.json() as { url?: string; error?: { message?: string } };
+
+  if (!response.ok || !json.url) {
+    throw new Error(json.error?.message ?? 'stripe_portal_session_failed');
+  }
+
+  return json.url;
+}

--- a/apps/api/src/data-store.ts
+++ b/apps/api/src/data-store.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'crypto';
 import { PrismaClient } from '@prisma/client';
+import { BillingSyncPayload } from './billing';
 
 type BaseRecord = {
   id: string;
@@ -193,6 +194,8 @@ export interface DataStore {
     postId: string,
     payload: Record<string, unknown>,
   ): Promise<FreightOperationRecord>;
+  syncCarrierBilling(payload: BillingSyncPayload): Promise<boolean>;
+  getCarrierStripeCustomerId(tenantId: string): Promise<string | null>;
   healthCheck(): Promise<'connected' | 'disconnected'>;
 }
 
@@ -277,6 +280,11 @@ class MemoryDataStore implements DataStore {
   private loads: LoadRecord[] = [];
   private drivers: DriverRecord[] = [];
   private shipments: ShipmentRecord[] = [];
+  private carrierBilling = new Map<string, {
+    stripeCustomerId: string | null;
+    subscriptionTier: string;
+    status: string;
+  }>();
   private freightOperations: Record<FreightOperationResource, FreightOperationRecord[]> = {
     quoteRequests: [],
     loadAssignments: [],
@@ -472,6 +480,31 @@ class MemoryDataStore implements DataStore {
       ...payload,
       status: payload.status ?? 'expired',
     });
+  }
+
+  async syncCarrierBilling(payload: BillingSyncPayload): Promise<boolean> {
+    const carrierId = payload.carrierId;
+    if (!carrierId) {
+      return false;
+    }
+
+    const current = this.carrierBilling.get(carrierId) ?? {
+      stripeCustomerId: null,
+      subscriptionTier: 'starter',
+      status: 'trial',
+    };
+
+    this.carrierBilling.set(carrierId, {
+      stripeCustomerId: payload.stripeCustomerId ?? current.stripeCustomerId,
+      subscriptionTier: payload.subscriptionTier ?? current.subscriptionTier,
+      status: payload.status ?? current.status,
+    });
+
+    return true;
+  }
+
+  async getCarrierStripeCustomerId(tenantId: string): Promise<string | null> {
+    return this.carrierBilling.get(tenantId)?.stripeCustomerId ?? null;
   }
 
   async healthCheck(): Promise<'connected' | 'disconnected'> {
@@ -847,6 +880,40 @@ class PrismaDataStore implements DataStore {
       ...payload,
       status: payload.status ?? 'expired',
     });
+  }
+
+  async syncCarrierBilling(payload: BillingSyncPayload): Promise<boolean> {
+    if (!payload.carrierId && !payload.stripeCustomerId) {
+      return false;
+    }
+
+    const existing = payload.carrierId
+      ? await this.prisma.carrier.findUnique({ where: { id: payload.carrierId } })
+      : await this.prisma.carrier.findFirst({ where: { stripeCustomerId: payload.stripeCustomerId } });
+
+    if (!existing) {
+      return false;
+    }
+
+    await this.prisma.carrier.update({
+      where: { id: existing.id },
+      data: {
+        stripeCustomerId: payload.stripeCustomerId ?? existing.stripeCustomerId,
+        subscriptionTier: payload.subscriptionTier ?? existing.subscriptionTier,
+        status: payload.status ?? existing.status,
+      },
+    });
+
+    return true;
+  }
+
+  async getCarrierStripeCustomerId(tenantId: string): Promise<string | null> {
+    const carrier = await this.prisma.carrier.findUnique({
+      where: { id: tenantId },
+      select: { stripeCustomerId: true },
+    });
+
+    return carrier?.stripeCustomerId ?? null;
   }
 
   async healthCheck(): Promise<'connected' | 'disconnected'> {

--- a/apps/api/test/billing.test.ts
+++ b/apps/api/test/billing.test.ts
@@ -1,0 +1,91 @@
+import crypto from 'crypto';
+import request from 'supertest';
+import { createApp } from '../src/app';
+
+function createStripeSignature(payload: string, secret: string): string {
+  const timestamp = Math.floor(Date.now() / 1000);
+  const digest = crypto
+    .createHmac('sha256', secret)
+    .update(`${timestamp}.${payload}`, 'utf8')
+    .digest('hex');
+
+  return `t=${timestamp},v1=${digest}`;
+}
+
+describe('Stripe billing endpoints', () => {
+  beforeEach(() => {
+    process.env.NODE_ENV = 'test';
+    process.env.STRIPE_WEBHOOK_SECRET = 'whsec_test_secret';
+    delete process.env.STRIPE_SECRET_KEY;
+  });
+
+  it('rejects webhook requests with invalid Stripe signatures', async () => {
+    const app = createApp();
+
+    await request(app)
+      .post('/api/billing/webhook')
+      .set('stripe-signature', 't=123,v1=bad')
+      .set('Content-Type', 'application/json')
+      .send(JSON.stringify({ id: 'evt_bad', type: 'invoice.payment_failed', data: { object: {} } }))
+      .expect(400);
+  });
+
+  it('accepts signed checkout webhook events and syncs billing in memory store', async () => {
+    const app = createApp();
+    const payload = JSON.stringify({
+      id: 'evt_checkout_completed',
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          customer: 'cus_test_123',
+          metadata: {
+            carrierId: 'carrier_billing_123',
+            plan: 'professional',
+          },
+        },
+      },
+    });
+
+    await request(app)
+      .post('/api/billing/webhook')
+      .set('stripe-signature', createStripeSignature(payload, 'whsec_test_secret'))
+      .set('Content-Type', 'application/json')
+      .send(payload)
+      .expect(200, { received: true });
+
+    const response = await request(app)
+      .post('/api/billing/customer-portal')
+      .set('x-tenant-id', 'carrier_billing_123')
+      .set('x-user-role', 'owner')
+      .send({})
+      .expect(500);
+
+    expect(response.body.error).toBe('stripe_secret_key_required');
+  });
+
+  it('requires owner or admin access for customer portal sessions', async () => {
+    const app = createApp();
+
+    const response = await request(app)
+      .post('/api/billing/customer-portal')
+      .set('x-tenant-id', 'carrier_billing_123')
+      .set('x-user-role', 'dispatcher')
+      .send({})
+      .expect(403);
+
+    expect(response.body.error).toBe('billing_forbidden');
+  });
+
+  it('returns 404 when no Stripe customer is linked to a carrier', async () => {
+    const app = createApp();
+
+    const response = await request(app)
+      .post('/api/billing/customer-portal')
+      .set('x-tenant-id', 'carrier_without_customer')
+      .set('x-user-role', 'admin')
+      .send({})
+      .expect(404);
+
+    expect(response.body.error).toBe('stripe_customer_not_found');
+  });
+});

--- a/docs/STRIPE_BILLING_AUTOMATION.md
+++ b/docs/STRIPE_BILLING_AUTOMATION.md
@@ -1,0 +1,162 @@
+# Stripe Billing Automation
+
+Date: April 27, 2026
+Status: App-side Stripe webhook and customer portal foundation added
+
+## Purpose
+
+This runbook documents the Stripe billing automation required after the Stripe catalog cleanup.
+
+The implementation adds:
+
+- Stripe webhook verification
+- Subscription/customer sync to `Carrier`
+- Owner/admin customer portal endpoint
+- Billing event tests
+
+## API endpoints
+
+### Stripe webhook
+
+```http
+POST /api/billing/webhook
+```
+
+This endpoint expects Stripe's raw request body and validates the `stripe-signature` header with `STRIPE_WEBHOOK_SECRET`.
+
+### Customer portal
+
+```http
+POST /api/billing/customer-portal
+```
+
+Required headers:
+
+```text
+x-tenant-id: <carrier id>
+x-user-role: owner | admin
+```
+
+Response:
+
+```json
+{
+  "data": {
+    "url": "https://billing.stripe.com/..."
+  }
+}
+```
+
+## Required environment variables
+
+API:
+
+```env
+STRIPE_SECRET_KEY=sk_live_...
+STRIPE_WEBHOOK_SECRET=whsec_...
+STRIPE_PORTAL_RETURN_URL=https://app.infamousfreight.com/settings
+```
+
+Optional fallback:
+
+```env
+WEB_APP_URL=https://app.infamousfreight.com
+```
+
+## Required Stripe webhook events
+
+Configure a live webhook endpoint in Stripe Dashboard:
+
+```text
+https://<api-domain>/api/billing/webhook
+```
+
+Subscribe to:
+
+```text
+checkout.session.completed
+customer.subscription.created
+customer.subscription.updated
+customer.subscription.deleted
+invoice.payment_succeeded
+invoice.payment_failed
+```
+
+## Billing sync behavior
+
+The webhook syncs these `Carrier` fields:
+
+```text
+stripeCustomerId
+subscriptionTier
+status
+```
+
+Supported subscription tiers:
+
+```text
+starter
+professional
+enterprise
+```
+
+Supported billing statuses:
+
+```text
+active
+trial
+past_due
+canceled
+unpaid
+incomplete
+inactive
+```
+
+## Metadata requirement for backend-created Checkout Sessions
+
+When the app moves away from static Payment Links to backend-created Checkout Sessions, include metadata:
+
+```ts
+metadata: {
+  carrierId,
+  plan,
+  billingInterval,
+}
+```
+
+Without `carrierId` metadata, webhook sync can still update by known `stripeCustomerId` for invoice/subscription events, but first-time checkout mapping is weaker.
+
+## Customer portal setup
+
+In Stripe Dashboard:
+
+```text
+Settings → Billing → Customer portal
+```
+
+Configure:
+
+- Allowed subscription changes
+- Payment method updates
+- Invoice history
+- Cancellation behavior
+- Return URL
+
+## Launch validation
+
+After deployment:
+
+1. Add API env vars.
+2. Configure Stripe live webhook endpoint.
+3. Trigger a test event from Stripe Dashboard.
+4. Confirm `/api/billing/webhook` returns `200`.
+5. Complete a test checkout using an internal carrier.
+6. Confirm the carrier row has:
+   - `stripeCustomerId`
+   - correct `subscriptionTier`
+   - correct `status`
+7. Open customer portal from the app as owner/admin.
+
+## Notes
+
+This foundation intentionally avoids usage-based metering until the backend has reliable AI usage tracking. Continue using one-time AI add-on packs for launch.


### PR DESCRIPTION
## Summary

Adds app-side Stripe billing automation foundation after Stripe catalog cleanup.

## Added

- Stripe webhook verification using raw body + `stripe-signature`
- Billing sync from Stripe events into `Carrier` fields:
  - `stripeCustomerId`
  - `subscriptionTier`
  - `status`
- Owner/admin customer portal endpoint
- Billing tests for:
  - invalid webhook signature rejection
  - signed checkout webhook acceptance
  - owner/admin portal access enforcement
  - missing Stripe customer handling
- Billing automation runbook

## Webhook events supported

- `checkout.session.completed`
- `customer.subscription.created`
- `customer.subscription.updated`
- `customer.subscription.deleted`
- `invoice.payment_succeeded`
- `invoice.payment_failed`

## Env required after deployment

```env
STRIPE_SECRET_KEY=sk_live_...
STRIPE_WEBHOOK_SECRET=whsec_...
STRIPE_PORTAL_RETURN_URL=https://app.infamousfreight.com/settings
```

## Notes

This intentionally avoids adding the Stripe SDK dependency to keep the existing lockfile stable. Stripe API calls use native Node fetch and HMAC verification.