### PR TITLE
feat(billing): add checkout sessions and AI usage ledger

### DIFF
--- a/apps/api/prisma/migrations/20260427000000_add_ai_usage_events/migration.sql
+++ b/apps/api/prisma/migrations/20260427000000_add_ai_usage_events/migration.sql
@@ -1,0 +1,29 @@
+-- CreateTable
+CREATE TABLE "AiUsageEvent" (
+    "id" TEXT NOT NULL,
+    "carrierId" TEXT NOT NULL,
+    "feature" TEXT NOT NULL,
+    "actionCount" INTEGER NOT NULL DEFAULT 1,
+    "documentScans" INTEGER NOT NULL DEFAULT 0,
+    "voiceMinutes" INTEGER NOT NULL DEFAULT 0,
+    "inputTokens" INTEGER NOT NULL DEFAULT 0,
+    "outputTokens" INTEGER NOT NULL DEFAULT 0,
+    "estimatedCost" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "idempotencyKey" TEXT,
+    "metadata" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AiUsageEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AiUsageEvent_carrierId_idempotencyKey_key" ON "AiUsageEvent"("carrierId", "idempotencyKey");
+
+-- CreateIndex
+CREATE INDEX "AiUsageEvent_carrierId_createdAt_idx" ON "AiUsageEvent"("carrierId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "AiUsageEvent_feature_idx" ON "AiUsageEvent"("feature");
+
+-- AddForeignKey
+ALTER TABLE "AiUsageEvent" ADD CONSTRAINT "AiUsageEvent_carrierId_fkey" FOREIGN KEY ("carrierId") REFERENCES "Carrier"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -30,6 +30,7 @@ model Carrier {
   loadAssignments LoadAssignment[]
   loadDispatches  LoadDispatch[]
   carrierPayments CarrierPayment[]
+  aiUsageEvents   AiUsageEvent[]
   rateAgreement   RateAgreement?
 }
 
@@ -293,6 +294,27 @@ model LoadBoardPost {
 
   @@index([board])
   @@index([status])
+}
+
+model AiUsageEvent {
+  id             String   @id @default(cuid())
+  carrierId      String
+  feature        String
+  actionCount    Int      @default(1)
+  documentScans  Int      @default(0)
+  voiceMinutes   Int      @default(0)
+  inputTokens    Int      @default(0)
+  outputTokens   Int      @default(0)
+  estimatedCost  Float    @default(0)
+  idempotencyKey String?
+  metadata       String?
+  createdAt      DateTime @default(now())
+
+  carrier Carrier @relation(fields: [carrierId], references: [id])
+
+  @@unique([carrierId, idempotencyKey])
+  @@index([carrierId, createdAt])
+  @@index([feature])
 }
 
 model AuditLog {

--- a/apps/api/src/ai-usage.ts
+++ b/apps/api/src/ai-usage.ts
@@ -1,0 +1,189 @@
+import { randomUUID } from 'crypto';
+import { PrismaClient } from '@prisma/client';
+
+export type AiUsageInput = {
+  carrierId: string;
+  feature: string;
+  actionCount?: number;
+  documentScans?: number;
+  voiceMinutes?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  estimatedCost?: number;
+  idempotencyKey?: string;
+  metadata?: Record<string, unknown> | string;
+};
+
+export type AiUsageRecord = {
+  id: string;
+  carrierId: string;
+  feature: string;
+  actionCount: number;
+  documentScans: number;
+  voiceMinutes: number;
+  inputTokens: number;
+  outputTokens: number;
+  estimatedCost: number;
+  idempotencyKey?: string | null;
+  metadata?: string | null;
+  createdAt: Date | string;
+};
+
+export type AiUsageSummary = {
+  carrierId: string;
+  actionCount: number;
+  documentScans: number;
+  voiceMinutes: number;
+  inputTokens: number;
+  outputTokens: number;
+  estimatedCost: number;
+};
+
+interface AiUsageStore {
+  record(input: AiUsageInput): Promise<AiUsageRecord>;
+  summarize(carrierId: string): Promise<AiUsageSummary>;
+}
+
+function toNumber(value: unknown, fallback = 0): number {
+  const number = Number(value ?? fallback);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function stringifyMetadata(metadata: AiUsageInput['metadata']): string | undefined {
+  if (!metadata) {
+    return undefined;
+  }
+
+  return typeof metadata === 'string' ? metadata : JSON.stringify(metadata);
+}
+
+class MemoryAiUsageStore implements AiUsageStore {
+  private records: AiUsageRecord[] = [];
+
+  async record(input: AiUsageInput): Promise<AiUsageRecord> {
+    if (input.idempotencyKey) {
+      const existing = this.records.find(
+        (record) => record.carrierId === input.carrierId && record.idempotencyKey === input.idempotencyKey,
+      );
+
+      if (existing) {
+        return existing;
+      }
+    }
+
+    const record: AiUsageRecord = {
+      id: randomUUID(),
+      carrierId: input.carrierId,
+      feature: input.feature,
+      actionCount: toNumber(input.actionCount, 1),
+      documentScans: toNumber(input.documentScans),
+      voiceMinutes: toNumber(input.voiceMinutes),
+      inputTokens: toNumber(input.inputTokens),
+      outputTokens: toNumber(input.outputTokens),
+      estimatedCost: toNumber(input.estimatedCost),
+      idempotencyKey: input.idempotencyKey,
+      metadata: stringifyMetadata(input.metadata),
+      createdAt: new Date().toISOString(),
+    };
+
+    this.records.push(record);
+    return record;
+  }
+
+  async summarize(carrierId: string): Promise<AiUsageSummary> {
+    return this.records
+      .filter((record) => record.carrierId === carrierId)
+      .reduce<AiUsageSummary>((summary, record) => ({
+        carrierId,
+        actionCount: summary.actionCount + record.actionCount,
+        documentScans: summary.documentScans + record.documentScans,
+        voiceMinutes: summary.voiceMinutes + record.voiceMinutes,
+        inputTokens: summary.inputTokens + record.inputTokens,
+        outputTokens: summary.outputTokens + record.outputTokens,
+        estimatedCost: summary.estimatedCost + record.estimatedCost,
+      }), {
+        carrierId,
+        actionCount: 0,
+        documentScans: 0,
+        voiceMinutes: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        estimatedCost: 0,
+      });
+  }
+}
+
+class PrismaAiUsageStore implements AiUsageStore {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async record(input: AiUsageInput): Promise<AiUsageRecord> {
+    const data = {
+      carrierId: input.carrierId,
+      feature: input.feature,
+      actionCount: toNumber(input.actionCount, 1),
+      documentScans: toNumber(input.documentScans),
+      voiceMinutes: toNumber(input.voiceMinutes),
+      inputTokens: toNumber(input.inputTokens),
+      outputTokens: toNumber(input.outputTokens),
+      estimatedCost: toNumber(input.estimatedCost),
+      idempotencyKey: input.idempotencyKey,
+      metadata: stringifyMetadata(input.metadata),
+    };
+
+    if (input.idempotencyKey) {
+      return this.prisma.aiUsageEvent.upsert({
+        where: {
+          carrierId_idempotencyKey: {
+            carrierId: input.carrierId,
+            idempotencyKey: input.idempotencyKey,
+          },
+        },
+        create: data,
+        update: {},
+      });
+    }
+
+    return this.prisma.aiUsageEvent.create({ data });
+  }
+
+  async summarize(carrierId: string): Promise<AiUsageSummary> {
+    const aggregate = await this.prisma.aiUsageEvent.aggregate({
+      where: { carrierId },
+      _sum: {
+        actionCount: true,
+        documentScans: true,
+        voiceMinutes: true,
+        inputTokens: true,
+        outputTokens: true,
+        estimatedCost: true,
+      },
+    });
+
+    return {
+      carrierId,
+      actionCount: aggregate._sum.actionCount ?? 0,
+      documentScans: aggregate._sum.documentScans ?? 0,
+      voiceMinutes: aggregate._sum.voiceMinutes ?? 0,
+      inputTokens: aggregate._sum.inputTokens ?? 0,
+      outputTokens: aggregate._sum.outputTokens ?? 0,
+      estimatedCost: aggregate._sum.estimatedCost ?? 0,
+    };
+  }
+}
+
+let prismaClient: PrismaClient | null = null;
+let memoryStore: MemoryAiUsageStore | null = null;
+
+export function createAiUsageStore(): AiUsageStore {
+  if (process.env.NODE_ENV === 'test') {
+    memoryStore ??= new MemoryAiUsageStore();
+    return memoryStore;
+  }
+
+  if (!process.env.DATABASE_URL) {
+    throw new Error('DATABASE_URL is required outside of test mode.');
+  }
+
+  prismaClient ??= new PrismaClient();
+  return new PrismaAiUsageStore(prismaClient);
+}

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -9,17 +9,23 @@ import {
   LoadAssignmentDecision,
 } from './data-store';
 import {
+  BillingInterval,
+  BillingPlan,
   createStripeBillingPortalSession,
+  createStripeCheckoutSession,
   getBillingSyncFromStripeEvent,
   getStripeWebhookSecret,
   StripeEvent,
   verifyStripeWebhookSignature,
 } from './billing';
+import { createAiUsageStore } from './ai-usage';
 
 type Role = 'owner' | 'admin' | 'dispatcher';
 
 const ALLOWED_ROLES: Role[] = ['owner', 'admin', 'dispatcher'];
 const BILLING_ROLES: Role[] = ['owner', 'admin'];
+const BILLING_PLANS: BillingPlan[] = ['starter', 'professional', 'enterprise'];
+const BILLING_INTERVALS: BillingInterval[] = ['month', 'year'];
 const FREIGHT_OPERATION_RESOURCES: FreightOperationResource[] = [
   'quoteRequests',
   'loadAssignments',
@@ -160,6 +166,26 @@ function getLoadAssignmentDecision(req: Request): LoadAssignmentDecision {
   return decision as LoadAssignmentDecision;
 }
 
+function getCheckoutPlan(req: Request): BillingPlan {
+  const plan = req.body?.plan;
+
+  if (!BILLING_PLANS.includes(plan)) {
+    throw new HttpError(400, 'invalid_billing_plan', 'Billing plan must be starter, professional, or enterprise.');
+  }
+
+  return plan;
+}
+
+function getCheckoutInterval(req: Request): BillingInterval {
+  const billingInterval = req.body?.billingInterval ?? 'month';
+
+  if (!BILLING_INTERVALS.includes(billingInterval)) {
+    throw new HttpError(400, 'invalid_billing_interval', 'Billing interval must be month or year.');
+  }
+
+  return billingInterval;
+}
+
 function registerWebhookRoute(app: express.Express, dataStore: DataStore) {
   app.post('/api/billing/webhook', express.raw({ type: 'application/json' }), wrapAsync(async (req, res) => {
     const rawBody = Buffer.isBuffer(req.body) ? req.body : Buffer.from(JSON.stringify(req.body ?? {}));
@@ -182,6 +208,31 @@ function registerWebhookRoute(app: express.Express, dataStore: DataStore) {
 }
 
 function registerRoutes(app: express.Express, dataStore: DataStore) {
+  const aiUsageStore = createAiUsageStore();
+
+  app.get('/api/billing/status', requireTenant, requireRole, wrapAsync(async (req, res) => {
+    const stripeCustomerId = await dataStore.getCarrierStripeCustomerId(getRequiredTenantId(req));
+    res.status(200).json({
+      data: {
+        stripeCustomerId,
+        hasStripeCustomer: Boolean(stripeCustomerId),
+      },
+    });
+  }));
+
+  app.post('/api/billing/checkout-session', requireTenant, requireRole, requireBillingRole, wrapAsync(async (req, res) => {
+    const carrierId = getRequiredTenantId(req);
+    const stripeCustomerId = await dataStore.getCarrierStripeCustomerId(carrierId);
+    const url = await createStripeCheckoutSession({
+      carrierId,
+      stripeCustomerId,
+      plan: getCheckoutPlan(req),
+      billingInterval: getCheckoutInterval(req),
+    });
+
+    res.status(200).json({ data: { url } });
+  }));
+
   app.post('/api/billing/customer-portal', requireTenant, requireRole, requireBillingRole, wrapAsync(async (req, res) => {
     const stripeCustomerId = await dataStore.getCarrierStripeCustomerId(getRequiredTenantId(req));
 
@@ -195,6 +246,24 @@ function registerRoutes(app: express.Express, dataStore: DataStore) {
 
     const url = await createStripeBillingPortalSession(stripeCustomerId);
     res.status(200).json({ data: { url } });
+  }));
+
+  app.post('/api/ai-usage/events', requireTenant, requireRole, wrapAsync(async (req, res) => {
+    if (!req.body?.feature || typeof req.body.feature !== 'string') {
+      throw new HttpError(400, 'ai_usage_feature_required', 'AI usage events require a feature string.');
+    }
+
+    const data = await aiUsageStore.record({
+      ...req.body,
+      carrierId: getRequiredTenantId(req),
+    });
+
+    res.status(201).json({ data });
+  }));
+
+  app.get('/api/ai-usage/summary', requireTenant, requireRole, wrapAsync(async (req, res) => {
+    const data = await aiUsageStore.summarize(getRequiredTenantId(req));
+    res.status(200).json({ data });
   }));
 
   app.get('/api/loads', requireTenant, requireRole, wrapAsync(async (req, res) => {
@@ -379,7 +448,7 @@ export function createApp() {
     if (err.message === 'stripe_secret_key_required') {
       return res.status(500).json({
         error: 'stripe_secret_key_required',
-        message: 'STRIPE_SECRET_KEY is required for billing portal sessions.',
+        message: 'STRIPE_SECRET_KEY is required for billing actions.',
       });
     }
 

--- a/apps/api/src/billing.ts
+++ b/apps/api/src/billing.ts
@@ -11,6 +11,13 @@ export type BillingSyncPayload = {
   status?: BillingStatus;
 };
 
+export type CheckoutSessionInput = {
+  carrierId: string;
+  plan: BillingPlan;
+  billingInterval: BillingInterval;
+  stripeCustomerId?: string | null;
+};
+
 export type StripeEvent = {
   id: string;
   type: string;
@@ -19,14 +26,29 @@ export type StripeEvent = {
   };
 };
 
-const PLAN_BY_PRICE_ID: Record<string, BillingPlan> = {
-  price_1TBnZ2KCNuZqDozYEcW5j4xM: 'starter',
-  price_1TBnZ3KCNuZqDozYvHBLW9L3: 'starter',
-  price_1TBnZ3KCNuZqDozY2FISQT98: 'professional',
-  price_1TBnZ4KCNuZqDozYO9YCSWIr: 'professional',
-  price_1TBnZ3KCNuZqDozYUG5nsCHt: 'enterprise',
-  price_1TBnZ4KCNuZqDozYy4qS3Kvy: 'enterprise',
+const PRICE_BY_PLAN_INTERVAL: Record<BillingPlan, Record<BillingInterval, string>> = {
+  starter: {
+    month: 'price_1TBnZ2KCNuZqDozYEcW5j4xM',
+    year: 'price_1TBnZ3KCNuZqDozYvHBLW9L3',
+  },
+  professional: {
+    month: 'price_1TBnZ3KCNuZqDozY2FISQT98',
+    year: 'price_1TBnZ4KCNuZqDozYO9YCSWIr',
+  },
+  enterprise: {
+    month: 'price_1TBnZ3KCNuZqDozYUG5nsCHt',
+    year: 'price_1TBnZ4KCNuZqDozYy4qS3Kvy',
+  },
 };
+
+const PLAN_BY_PRICE_ID: Record<string, BillingPlan> = Object.entries(PRICE_BY_PLAN_INTERVAL).reduce(
+  (acc, [plan, intervals]) => ({
+    ...acc,
+    [intervals.month]: plan as BillingPlan,
+    [intervals.year]: plan as BillingPlan,
+  }),
+  {} as Record<string, BillingPlan>,
+);
 
 export function getStripeSecretKey(): string | null {
   return process.env.STRIPE_SECRET_KEY?.trim() || null;
@@ -40,6 +62,16 @@ export function getBillingPortalReturnUrl(): string {
   return process.env.STRIPE_PORTAL_RETURN_URL?.trim()
     || process.env.WEB_APP_URL?.trim()
     || 'http://localhost:5173/settings';
+}
+
+function getCheckoutSuccessUrl(): string {
+  return process.env.STRIPE_CHECKOUT_SUCCESS_URL?.trim()
+    || `${process.env.WEB_APP_URL?.trim() || 'http://localhost:5173'}/settings?checkout=success`;
+}
+
+function getCheckoutCancelUrl(): string {
+  return process.env.STRIPE_CHECKOUT_CANCEL_URL?.trim()
+    || `${process.env.WEB_APP_URL?.trim() || 'http://localhost:5173'}/settings?checkout=canceled`;
 }
 
 export function verifyStripeWebhookSignature(
@@ -189,19 +221,14 @@ export function getBillingSyncFromStripeEvent(event: StripeEvent): BillingSyncPa
   }
 }
 
-export async function createStripeBillingPortalSession(customerId: string): Promise<string> {
+async function postStripeForm<T>(path: string, body: URLSearchParams): Promise<T> {
   const secretKey = getStripeSecretKey();
 
   if (!secretKey) {
     throw new Error('stripe_secret_key_required');
   }
 
-  const body = new URLSearchParams({
-    customer: customerId,
-    return_url: getBillingPortalReturnUrl(),
-  });
-
-  const response = await fetch('https://api.stripe.com/v1/billing_portal/sessions', {
+  const response = await fetch(`https://api.stripe.com/v1${path}`, {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${secretKey}`,
@@ -210,11 +237,60 @@ export async function createStripeBillingPortalSession(customerId: string): Prom
     body,
   });
 
-  const json = await response.json() as { url?: string; error?: { message?: string } };
+  const json = await response.json() as T & { error?: { message?: string } };
 
-  if (!response.ok || !json.url) {
-    throw new Error(json.error?.message ?? 'stripe_portal_session_failed');
+  if (!response.ok) {
+    throw new Error(json.error?.message ?? 'stripe_request_failed');
   }
 
-  return json.url;
+  return json;
+}
+
+export async function createStripeCheckoutSession(input: CheckoutSessionInput): Promise<string> {
+  const price = PRICE_BY_PLAN_INTERVAL[input.plan]?.[input.billingInterval];
+
+  if (!price) {
+    throw new Error('invalid_checkout_plan');
+  }
+
+  const body = new URLSearchParams({
+    mode: 'subscription',
+    success_url: getCheckoutSuccessUrl(),
+    cancel_url: getCheckoutCancelUrl(),
+    'line_items[0][price]': price,
+    'line_items[0][quantity]': '1',
+    'metadata[carrierId]': input.carrierId,
+    'metadata[plan]': input.plan,
+    'metadata[billingInterval]': input.billingInterval,
+    'subscription_data[metadata][carrierId]': input.carrierId,
+    'subscription_data[metadata][plan]': input.plan,
+    'subscription_data[metadata][billingInterval]': input.billingInterval,
+  });
+
+  if (input.stripeCustomerId) {
+    body.set('customer', input.stripeCustomerId);
+  } else {
+    body.set('client_reference_id', input.carrierId);
+  }
+
+  const session = await postStripeForm<{ url?: string }>('/checkout/sessions', body);
+
+  if (!session.url) {
+    throw new Error('stripe_checkout_session_failed');
+  }
+
+  return session.url;
+}
+
+export async function createStripeBillingPortalSession(customerId: string): Promise<string> {
+  const session = await postStripeForm<{ url?: string }>('/billing_portal/sessions', new URLSearchParams({
+    customer: customerId,
+    return_url: getBillingPortalReturnUrl(),
+  }));
+
+  if (!session.url) {
+    throw new Error('stripe_portal_session_failed');
+  }
+
+  return session.url;
 }

--- a/apps/api/test/billing.test.ts
+++ b/apps/api/test/billing.test.ts
@@ -53,6 +53,17 @@ describe('Stripe billing endpoints', () => {
       .send(payload)
       .expect(200, { received: true });
 
+    const statusResponse = await request(app)
+      .get('/api/billing/status')
+      .set('x-tenant-id', 'carrier_billing_123')
+      .set('x-user-role', 'owner')
+      .expect(200);
+
+    expect(statusResponse.body.data).toMatchObject({
+      stripeCustomerId: 'cus_test_123',
+      hasStripeCustomer: true,
+    });
+
     const response = await request(app)
       .post('/api/billing/customer-portal')
       .set('x-tenant-id', 'carrier_billing_123')
@@ -63,17 +74,48 @@ describe('Stripe billing endpoints', () => {
     expect(response.body.error).toBe('stripe_secret_key_required');
   });
 
-  it('requires owner or admin access for customer portal sessions', async () => {
+  it('requires owner or admin access for customer portal and checkout sessions', async () => {
     const app = createApp();
 
-    const response = await request(app)
+    const portalResponse = await request(app)
       .post('/api/billing/customer-portal')
       .set('x-tenant-id', 'carrier_billing_123')
       .set('x-user-role', 'dispatcher')
       .send({})
       .expect(403);
 
-    expect(response.body.error).toBe('billing_forbidden');
+    expect(portalResponse.body.error).toBe('billing_forbidden');
+
+    const checkoutResponse = await request(app)
+      .post('/api/billing/checkout-session')
+      .set('x-tenant-id', 'carrier_billing_123')
+      .set('x-user-role', 'dispatcher')
+      .send({ plan: 'professional', billingInterval: 'month' })
+      .expect(403);
+
+    expect(checkoutResponse.body.error).toBe('billing_forbidden');
+  });
+
+  it('validates checkout plan and interval before creating Stripe sessions', async () => {
+    const app = createApp();
+
+    const invalidPlanResponse = await request(app)
+      .post('/api/billing/checkout-session')
+      .set('x-tenant-id', 'carrier_billing_123')
+      .set('x-user-role', 'owner')
+      .send({ plan: 'free', billingInterval: 'month' })
+      .expect(400);
+
+    expect(invalidPlanResponse.body.error).toBe('invalid_billing_plan');
+
+    const invalidIntervalResponse = await request(app)
+      .post('/api/billing/checkout-session')
+      .set('x-tenant-id', 'carrier_billing_123')
+      .set('x-user-role', 'owner')
+      .send({ plan: 'professional', billingInterval: 'weekly' })
+      .expect(400);
+
+    expect(invalidIntervalResponse.body.error).toBe('invalid_billing_interval');
   });
 
   it('returns 404 when no Stripe customer is linked to a carrier', async () => {
@@ -87,5 +129,67 @@ describe('Stripe billing endpoints', () => {
       .expect(404);
 
     expect(response.body.error).toBe('stripe_customer_not_found');
+  });
+
+  it('records and summarizes AI usage events with idempotency protection', async () => {
+    const app = createApp();
+
+    await request(app)
+      .post('/api/ai-usage/events')
+      .set('x-tenant-id', 'carrier_ai_123')
+      .set('x-user-role', 'dispatcher')
+      .send({
+        feature: 'dispatch-assistant',
+        actionCount: 2,
+        documentScans: 1,
+        inputTokens: 100,
+        outputTokens: 40,
+        estimatedCost: 0.25,
+        idempotencyKey: 'evt_ai_1',
+      })
+      .expect(201);
+
+    await request(app)
+      .post('/api/ai-usage/events')
+      .set('x-tenant-id', 'carrier_ai_123')
+      .set('x-user-role', 'dispatcher')
+      .send({
+        feature: 'dispatch-assistant',
+        actionCount: 2,
+        documentScans: 1,
+        inputTokens: 100,
+        outputTokens: 40,
+        estimatedCost: 0.25,
+        idempotencyKey: 'evt_ai_1',
+      })
+      .expect(201);
+
+    const summary = await request(app)
+      .get('/api/ai-usage/summary')
+      .set('x-tenant-id', 'carrier_ai_123')
+      .set('x-user-role', 'owner')
+      .expect(200);
+
+    expect(summary.body.data).toMatchObject({
+      carrierId: 'carrier_ai_123',
+      actionCount: 2,
+      documentScans: 1,
+      inputTokens: 100,
+      outputTokens: 40,
+      estimatedCost: 0.25,
+    });
+  });
+
+  it('requires a feature for AI usage events', async () => {
+    const app = createApp();
+
+    const response = await request(app)
+      .post('/api/ai-usage/events')
+      .set('x-tenant-id', 'carrier_ai_123')
+      .set('x-user-role', 'dispatcher')
+      .send({ actionCount: 1 })
+      .expect(400);
+
+    expect(response.body.error).toBe('ai_usage_feature_required');
   });
 });

--- a/apps/web/src/components/billing/BillingSettingsPanel.tsx
+++ b/apps/web/src/components/billing/BillingSettingsPanel.tsx
@@ -1,0 +1,247 @@
+import { useEffect, useMemo, useState } from 'react';
+import toast from 'react-hot-toast';
+import { CreditCard, ExternalLink, Loader2, ShieldCheck, Sparkles } from 'lucide-react';
+import { useAppStore } from '@/store/app-store';
+import {
+  BillingInterval,
+  BillingPlan,
+  createCheckoutSession,
+  createCustomerPortalSession,
+  getAiUsageSummary,
+  getBillingErrorMessage,
+  getBillingStatus,
+  AiUsageSummary,
+  BillingStatus,
+} from '@/lib/billingApi';
+
+const plans: Array<{
+  plan: BillingPlan;
+  name: string;
+  description: string;
+  monthly: string;
+  annual: string;
+  recommended?: boolean;
+}> = [
+  {
+    plan: 'starter',
+    name: 'Starter',
+    description: 'Small freight operations getting dispatch visibility online.',
+    monthly: '$99/mo',
+    annual: '$1,089/yr',
+  },
+  {
+    plan: 'professional',
+    name: 'Professional',
+    description: 'Recommended for growing carriers that need automation and reporting.',
+    monthly: '$499/mo',
+    annual: '$5,389/yr',
+    recommended: true,
+  },
+  {
+    plan: 'enterprise',
+    name: 'Enterprise',
+    description: 'Large operations needing dedicated support, scale, and integrations.',
+    monthly: '$2,000/mo',
+    annual: '$21,600/yr',
+  },
+];
+
+const BillingSettingsPanel: React.FC = () => {
+  const { user } = useAppStore();
+  const [billingStatus, setBillingStatus] = useState<BillingStatus | null>(null);
+  const [usageSummary, setUsageSummary] = useState<AiUsageSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busyAction, setBusyAction] = useState<string | null>(null);
+
+  const context = useMemo(() => ({
+    tenantId: user?.carrierId ?? 'carrier_default',
+    role: user?.role ?? 'dispatcher',
+  }), [user?.carrierId, user?.role]);
+
+  const canManageBilling = ['owner', 'admin'].includes(context.role);
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function loadBilling() {
+      try {
+        const [status, usage] = await Promise.all([
+          getBillingStatus(context),
+          getAiUsageSummary(context),
+        ]);
+
+        if (mounted) {
+          setBillingStatus(status);
+          setUsageSummary(usage);
+        }
+      } catch (error) {
+        toast.error(getBillingErrorMessage(error));
+      } finally {
+        if (mounted) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void loadBilling();
+
+    return () => {
+      mounted = false;
+    };
+  }, [context]);
+
+  const startCheckout = async (plan: BillingPlan, billingInterval: BillingInterval) => {
+    if (!canManageBilling) {
+      toast.error('Billing changes require owner or admin access.');
+      return;
+    }
+
+    const actionKey = `${plan}-${billingInterval}`;
+    setBusyAction(actionKey);
+
+    try {
+      const url = await createCheckoutSession(context, plan, billingInterval);
+      window.location.assign(url);
+    } catch (error) {
+      toast.error(getBillingErrorMessage(error));
+    } finally {
+      setBusyAction(null);
+    }
+  };
+
+  const openPortal = async () => {
+    if (!canManageBilling) {
+      toast.error('Billing portal access requires owner or admin access.');
+      return;
+    }
+
+    setBusyAction('portal');
+
+    try {
+      const url = await createCustomerPortalSession(context);
+      window.location.assign(url);
+    } catch (error) {
+      toast.error(getBillingErrorMessage(error));
+    } finally {
+      setBusyAction(null);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="card flex min-h-[220px] items-center justify-center">
+        <Loader2 className="animate-spin text-infamous-orange" size={24} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="card">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 className="text-lg font-semibold">Billing Control Center</h2>
+            <p className="mt-1 text-sm text-gray-400">
+              Manage subscription checkout, Stripe customer portal access, and AI usage visibility.
+            </p>
+          </div>
+          <button
+            onClick={openPortal}
+            disabled={!canManageBilling || !billingStatus?.hasStripeCustomer || busyAction === 'portal'}
+            className="btn-secondary inline-flex items-center gap-2 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {busyAction === 'portal' ? <Loader2 size={16} className="animate-spin" /> : <ExternalLink size={16} />}
+            Open Customer Portal
+          </button>
+        </div>
+
+        <div className="mt-5 grid gap-4 md:grid-cols-3">
+          <div className="rounded-xl border border-infamous-border bg-infamous-dark p-4">
+            <CreditCard className="mb-3 text-infamous-orange" size={20} />
+            <p className="text-xs uppercase tracking-wide text-gray-500">Stripe customer</p>
+            <p className="mt-2 truncate font-mono text-sm text-white">
+              {billingStatus?.stripeCustomerId ?? 'Not linked yet'}
+            </p>
+          </div>
+          <div className="rounded-xl border border-infamous-border bg-infamous-dark p-4">
+            <ShieldCheck className="mb-3 text-infamous-orange" size={20} />
+            <p className="text-xs uppercase tracking-wide text-gray-500">Billing role</p>
+            <p className="mt-2 text-sm font-semibold text-white">
+              {canManageBilling ? 'Owner/admin access' : 'Read only'}
+            </p>
+          </div>
+          <div className="rounded-xl border border-infamous-border bg-infamous-dark p-4">
+            <Sparkles className="mb-3 text-infamous-orange" size={20} />
+            <p className="text-xs uppercase tracking-wide text-gray-500">AI actions</p>
+            <p className="mt-2 text-sm font-semibold text-white">
+              {usageSummary?.actionCount ?? 0} logged
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-3">
+        {plans.map((plan) => (
+          <div
+            key={plan.plan}
+            className={`card border ${plan.recommended ? 'border-infamous-orange/50' : 'border-infamous-border'}`}
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <h3 className="text-lg font-semibold">{plan.name}</h3>
+                <p className="mt-2 min-h-[48px] text-sm text-gray-400">{plan.description}</p>
+              </div>
+              {plan.recommended && (
+                <span className="rounded-full bg-infamous-orange/10 px-2.5 py-1 text-xs font-semibold text-infamous-orange">
+                  Recommended
+                </span>
+              )}
+            </div>
+
+            <div className="mt-5 space-y-3">
+              <button
+                onClick={() => startCheckout(plan.plan, 'month')}
+                disabled={!canManageBilling || busyAction === `${plan.plan}-month`}
+                className="btn-primary flex w-full items-center justify-center gap-2 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {busyAction === `${plan.plan}-month` && <Loader2 size={16} className="animate-spin" />}
+                Start {plan.monthly}
+              </button>
+              <button
+                onClick={() => startCheckout(plan.plan, 'year')}
+                disabled={!canManageBilling || busyAction === `${plan.plan}-year`}
+                className="btn-secondary flex w-full items-center justify-center gap-2 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {busyAction === `${plan.plan}-year` && <Loader2 size={16} className="animate-spin" />}
+                Start {plan.annual}
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="card">
+        <h2 className="text-lg font-semibold">AI Usage Ledger</h2>
+        <div className="mt-4 grid gap-4 md:grid-cols-3 xl:grid-cols-6">
+          <Metric label="Actions" value={usageSummary?.actionCount ?? 0} />
+          <Metric label="Doc scans" value={usageSummary?.documentScans ?? 0} />
+          <Metric label="Voice minutes" value={usageSummary?.voiceMinutes ?? 0} />
+          <Metric label="Input tokens" value={usageSummary?.inputTokens ?? 0} />
+          <Metric label="Output tokens" value={usageSummary?.outputTokens ?? 0} />
+          <Metric label="Est. cost" value={`$${(usageSummary?.estimatedCost ?? 0).toFixed(2)}`} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+function Metric({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="rounded-xl border border-infamous-border bg-infamous-dark p-4">
+      <p className="text-xs uppercase tracking-wide text-gray-500">{label}</p>
+      <p className="mt-2 text-lg font-bold text-white">{value}</p>
+    </div>
+  );
+}
+
+export default BillingSettingsPanel;

--- a/apps/web/src/lib/billingApi.ts
+++ b/apps/web/src/lib/billingApi.ts
@@ -1,0 +1,94 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_URL || '',
+});
+
+export type BillingPlan = 'starter' | 'professional' | 'enterprise';
+export type BillingInterval = 'month' | 'year';
+
+export type BillingStatus = {
+  stripeCustomerId: string | null;
+  hasStripeCustomer: boolean;
+};
+
+export type AiUsageSummary = {
+  carrierId: string;
+  actionCount: number;
+  documentScans: number;
+  voiceMinutes: number;
+  inputTokens: number;
+  outputTokens: number;
+  estimatedCost: number;
+};
+
+type ApiEnvelope<T> = {
+  data: T;
+};
+
+type RequestContext = {
+  tenantId: string;
+  role: string;
+};
+
+function getHeaders(context: RequestContext) {
+  return {
+    'x-tenant-id': context.tenantId,
+    'x-user-role': context.role || 'dispatcher',
+  };
+}
+
+export async function getBillingStatus(context: RequestContext): Promise<BillingStatus> {
+  const response = await api.get<ApiEnvelope<BillingStatus>>('/api/billing/status', {
+    headers: getHeaders(context),
+  });
+
+  return response.data.data;
+}
+
+export async function createCheckoutSession(
+  context: RequestContext,
+  plan: BillingPlan,
+  billingInterval: BillingInterval,
+): Promise<string> {
+  const response = await api.post<ApiEnvelope<{ url: string }>>(
+    '/api/billing/checkout-session',
+    { plan, billingInterval },
+    { headers: getHeaders(context) },
+  );
+
+  return response.data.data.url;
+}
+
+export async function createCustomerPortalSession(context: RequestContext): Promise<string> {
+  const response = await api.post<ApiEnvelope<{ url: string }>>(
+    '/api/billing/customer-portal',
+    {},
+    { headers: getHeaders(context) },
+  );
+
+  return response.data.data.url;
+}
+
+export async function getAiUsageSummary(context: RequestContext): Promise<AiUsageSummary> {
+  const response = await api.get<ApiEnvelope<AiUsageSummary>>('/api/ai-usage/summary', {
+    headers: getHeaders(context),
+  });
+
+  return response.data.data;
+}
+
+export function getBillingErrorMessage(error: unknown): string {
+  if (axios.isAxiosError(error)) {
+    const message = error.response?.data?.message;
+    if (typeof message === 'string') {
+      return message;
+    }
+
+    if (error.message) {
+      return error.message;
+    }
+  }
+
+  return error instanceof Error ? error.message : 'Unexpected billing error';
+}

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { User, CreditCard, Radio, Bell, Shield, Users, FileText, Zap } from 'lucide-react';
+import BillingSettingsPanel from '@/components/billing/BillingSettingsPanel';
 
 const SettingsPage: React.FC = () => {
   const [activeSection, setActiveSection] = useState('profile');
@@ -77,37 +78,7 @@ const SettingsPage: React.FC = () => {
             </div>
           )}
 
-          {activeSection === 'billing' && (
-            <div className="space-y-4">
-              <div className="card">
-                <h2 className="text-lg font-semibold mb-4">Current Plan</h2>
-                <div className="bg-gradient-to-r from-infamous-orange/20 to-infamous-orange/5 border border-infamous-orange/30 rounded-xl p-5">
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <p className="text-lg font-bold">Growth Plan</p>
-                      <p className="text-sm text-gray-400">$99/month · Renews May 1, 2025</p>
-                    </div>
-                    <p className="text-2xl font-bold text-infamous-orange">$99<span className="text-sm text-gray-400">/mo</span></p>
-                  </div>
-                  <div className="mt-4 flex gap-3">
-                    <button className="btn-primary text-sm">Upgrade Plan</button>
-                    <button className="btn-secondary text-sm">View Invoices</button>
-                  </div>
-                </div>
-              </div>
-              <div className="card">
-                <h2 className="text-lg font-semibold mb-4">Payment Method</h2>
-                <div className="flex items-center gap-3 p-3 bg-infamous-dark rounded-xl">
-                  <div className="w-10 h-7 bg-gradient-to-r from-blue-600 to-blue-800 rounded" />
-                  <div className="flex-1">
-                    <p className="text-sm font-medium">Visa ending in 4242</p>
-                    <p className="text-xs text-gray-500">Expires 12/26</p>
-                  </div>
-                  <button className="text-sm text-infamous-orange hover:underline">Update</button>
-                </div>
-              </div>
-            </div>
-          )}
+          {activeSection === 'billing' && <BillingSettingsPanel />}
 
           {activeSection === 'eld' && (
             <div className="card space-y-4">

--- a/docs/STRIPE_BILLING_AUTOMATION.md
+++ b/docs/STRIPE_BILLING_AUTOMATION.md
@@ -1,18 +1,21 @@
 # Stripe Billing Automation
 
 Date: April 27, 2026
-Status: App-side Stripe webhook and customer portal foundation added
+Status: Checkout, webhook sync, customer portal, and AI usage ledger foundation added
 
 ## Purpose
 
-This runbook documents the Stripe billing automation required after the Stripe catalog cleanup.
+This runbook documents Stripe billing automation for Infamous Freight after catalog cleanup.
 
 The implementation adds:
 
+- Backend-created Stripe Checkout Sessions
 - Stripe webhook verification
 - Subscription/customer sync to `Carrier`
 - Owner/admin customer portal endpoint
-- Billing event tests
+- AI usage ledger API and database table
+- Billing UI in Settings
+- Billing and usage tests
 
 ## API endpoints
 
@@ -23,6 +26,43 @@ POST /api/billing/webhook
 ```
 
 This endpoint expects Stripe's raw request body and validates the `stripe-signature` header with `STRIPE_WEBHOOK_SECRET`.
+
+### Checkout Session
+
+```http
+POST /api/billing/checkout-session
+```
+
+Required headers:
+
+```text
+x-tenant-id: <carrier id>
+x-user-role: owner | admin
+```
+
+Request:
+
+```json
+{
+  "plan": "professional",
+  "billingInterval": "month"
+}
+```
+
+Supported plans:
+
+```text
+starter
+professional
+enterprise
+```
+
+Supported billing intervals:
+
+```text
+month
+year
+```
 
 ### Customer portal
 
@@ -47,6 +87,50 @@ Response:
 }
 ```
 
+### Billing status
+
+```http
+GET /api/billing/status
+```
+
+Returns whether the carrier has a linked Stripe customer.
+
+### AI usage event
+
+```http
+POST /api/ai-usage/events
+```
+
+Required headers:
+
+```text
+x-tenant-id: <carrier id>
+x-user-role: owner | admin | dispatcher
+```
+
+Request:
+
+```json
+{
+  "feature": "dispatch-assistant",
+  "actionCount": 1,
+  "documentScans": 0,
+  "voiceMinutes": 0,
+  "inputTokens": 100,
+  "outputTokens": 40,
+  "estimatedCost": 0.25,
+  "idempotencyKey": "unique-event-id"
+}
+```
+
+### AI usage summary
+
+```http
+GET /api/ai-usage/summary
+```
+
+Returns aggregate usage totals for the current carrier.
+
 ## Required environment variables
 
 API:
@@ -55,12 +139,20 @@ API:
 STRIPE_SECRET_KEY=sk_live_...
 STRIPE_WEBHOOK_SECRET=whsec_...
 STRIPE_PORTAL_RETURN_URL=https://app.infamousfreight.com/settings
+STRIPE_CHECKOUT_SUCCESS_URL=https://app.infamousfreight.com/settings?checkout=success
+STRIPE_CHECKOUT_CANCEL_URL=https://app.infamousfreight.com/settings?checkout=canceled
 ```
 
 Optional fallback:
 
 ```env
 WEB_APP_URL=https://app.infamousfreight.com
+```
+
+Web:
+
+```env
+VITE_API_URL=https://<api-domain>
 ```
 
 ## Required Stripe webhook events
@@ -112,9 +204,9 @@ incomplete
 inactive
 ```
 
-## Metadata requirement for backend-created Checkout Sessions
+## Checkout metadata
 
-When the app moves away from static Payment Links to backend-created Checkout Sessions, include metadata:
+Backend-created Checkout Sessions include metadata:
 
 ```ts
 metadata: {
@@ -124,7 +216,7 @@ metadata: {
 }
 ```
 
-Without `carrierId` metadata, webhook sync can still update by known `stripeCustomerId` for invoice/subscription events, but first-time checkout mapping is weaker.
+Subscription metadata also receives the same values so future subscription events can preserve plan mapping.
 
 ## Customer portal setup
 
@@ -142,6 +234,20 @@ Configure:
 - Cancellation behavior
 - Return URL
 
+## AI usage ledger
+
+The `AiUsageEvent` table is a ledger, not a metered billing implementation. Use it to build confidence in usage tracking before enabling Stripe metered billing.
+
+Recommended launch limits:
+
+```text
+Starter: 500 AI actions / month
+Professional: 5,000 AI actions / month
+Enterprise: 25,000 AI actions / month
+```
+
+Keep AI add-ons as one-time packs until the ledger has proven accuracy in production.
+
 ## Launch validation
 
 After deployment:
@@ -150,13 +256,15 @@ After deployment:
 2. Configure Stripe live webhook endpoint.
 3. Trigger a test event from Stripe Dashboard.
 4. Confirm `/api/billing/webhook` returns `200`.
-5. Complete a test checkout using an internal carrier.
-6. Confirm the carrier row has:
+5. Start checkout from Settings → Billing & Plans using an internal carrier.
+6. Complete checkout.
+7. Confirm the carrier row has:
    - `stripeCustomerId`
    - correct `subscriptionTier`
    - correct `status`
-7. Open customer portal from the app as owner/admin.
+8. Open customer portal from Settings as owner/admin.
+9. Record one AI usage event and confirm it appears in Settings → Billing & Plans.
 
 ## Notes
 
-This foundation intentionally avoids usage-based metering until the backend has reliable AI usage tracking. Continue using one-time AI add-on packs for launch.
+This foundation intentionally avoids Stripe metered billing until the backend has reliable AI usage tracking. Continue using one-time AI add-on packs for launch.


### PR DESCRIPTION
## Summary

Completes the next Infamous Freight billing hardening package.

## Added

- Backend-created Stripe Checkout Sessions
- Settings billing UI connected to API
- Billing status endpoint
- AI usage ledger model + migration
- AI usage record and summary endpoints
- Billing API client for the web app
- Expanded billing automation runbook
- Tests for:
  - checkout plan/interval validation
  - billing access gates
  - billing status after webhook sync
  - AI usage idempotency and summary

## Notes

This keeps Stripe metered billing disabled for launch. AI usage is logged internally first so usage accuracy can be proven before billing customers by meter.

## Required env after deployment

```env
STRIPE_SECRET_KEY=sk_live_...
STRIPE_WEBHOOK_SECRET=whsec_...
STRIPE_PORTAL_RETURN_URL=https://app.infamousfreight.com/settings
STRIPE_CHECKOUT_SUCCESS_URL=https://app.infamousfreight.com/settings?checkout=success
STRIPE_CHECKOUT_CANCEL_URL=https://app.infamousfreight.com/settings?checkout=canceled
```
