### PR TITLE
feat(billing): add webhook logs and checkout guard

### DIFF
--- a/apps/api/prisma/migrations/20260427010000_add_stripe_webhook_events/migration.sql
+++ b/apps/api/prisma/migrations/20260427010000_add_stripe_webhook_events/migration.sql
@@ -1,0 +1,28 @@
+-- CreateTable
+CREATE TABLE "StripeWebhookEvent" (
+    "id" TEXT NOT NULL,
+    "eventId" TEXT NOT NULL,
+    "eventType" TEXT NOT NULL,
+    "carrierId" TEXT,
+    "status" TEXT NOT NULL,
+    "errorMessage" TEXT,
+    "receivedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "processedAt" TIMESTAMP(3),
+
+    CONSTRAINT "StripeWebhookEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "StripeWebhookEvent_eventId_key" ON "StripeWebhookEvent"("eventId");
+
+-- CreateIndex
+CREATE INDEX "StripeWebhookEvent_eventType_idx" ON "StripeWebhookEvent"("eventType");
+
+-- CreateIndex
+CREATE INDEX "StripeWebhookEvent_status_idx" ON "StripeWebhookEvent"("status");
+
+-- CreateIndex
+CREATE INDEX "StripeWebhookEvent_carrierId_idx" ON "StripeWebhookEvent"("carrierId");
+
+-- CreateIndex
+CREATE INDEX "StripeWebhookEvent_receivedAt_idx" ON "StripeWebhookEvent"("receivedAt");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -317,6 +317,22 @@ model AiUsageEvent {
   @@index([feature])
 }
 
+model StripeWebhookEvent {
+  id           String    @id @default(cuid())
+  eventId      String    @unique
+  eventType    String
+  carrierId    String?
+  status       String
+  errorMessage String?
+  receivedAt   DateTime  @default(now())
+  processedAt  DateTime?
+
+  @@index([eventType])
+  @@index([status])
+  @@index([carrierId])
+  @@index([receivedAt])
+}
+
 model AuditLog {
   id         String   @id @default(cuid())
   entityType String // load, driver, invoice, etc.

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -19,6 +19,7 @@ import {
   verifyStripeWebhookSignature,
 } from './billing';
 import { createAiUsageStore } from './ai-usage';
+import { createStripeWebhookEventStore } from './stripe-webhook-events';
 
 type Role = 'owner' | 'admin' | 'dispatcher';
 
@@ -186,7 +187,13 @@ function getCheckoutInterval(req: Request): BillingInterval {
   return billingInterval;
 }
 
+function getCarrierIdFromBillingSync(billingSync: ReturnType<typeof getBillingSyncFromStripeEvent>): string | null {
+  return billingSync?.carrierId ?? null;
+}
+
 function registerWebhookRoute(app: express.Express, dataStore: DataStore) {
+  const webhookEvents = createStripeWebhookEventStore();
+
   app.post('/api/billing/webhook', express.raw({ type: 'application/json' }), wrapAsync(async (req, res) => {
     const rawBody = Buffer.isBuffer(req.body) ? req.body : Buffer.from(JSON.stringify(req.body ?? {}));
     const signature = req.header('stripe-signature');
@@ -198,9 +205,44 @@ function registerWebhookRoute(app: express.Express, dataStore: DataStore) {
 
     const event = JSON.parse(rawBody.toString('utf8')) as StripeEvent;
     const billingSync = getBillingSyncFromStripeEvent(event);
+    const carrierId = getCarrierIdFromBillingSync(billingSync);
 
-    if (billingSync) {
-      await dataStore.syncCarrierBilling(billingSync);
+    await webhookEvents.upsert({
+      eventId: event.id,
+      eventType: event.type,
+      carrierId,
+      status: 'received',
+    });
+
+    try {
+      if (billingSync) {
+        const synced = await dataStore.syncCarrierBilling(billingSync);
+        await webhookEvents.upsert({
+          eventId: event.id,
+          eventType: event.type,
+          carrierId,
+          status: synced ? 'processed' : 'ignored',
+          processedAt: new Date(),
+        });
+      } else {
+        await webhookEvents.upsert({
+          eventId: event.id,
+          eventType: event.type,
+          carrierId,
+          status: 'ignored',
+          processedAt: new Date(),
+        });
+      }
+    } catch (error) {
+      await webhookEvents.upsert({
+        eventId: event.id,
+        eventType: event.type,
+        carrierId,
+        status: 'failed',
+        errorMessage: error instanceof Error ? error.message : 'Unknown webhook processing error',
+        processedAt: new Date(),
+      });
+      throw error;
     }
 
     res.status(200).json({ received: true });
@@ -223,6 +265,15 @@ function registerRoutes(app: express.Express, dataStore: DataStore) {
   app.post('/api/billing/checkout-session', requireTenant, requireRole, requireBillingRole, wrapAsync(async (req, res) => {
     const carrierId = getRequiredTenantId(req);
     const stripeCustomerId = await dataStore.getCarrierStripeCustomerId(carrierId);
+
+    if (stripeCustomerId) {
+      throw new HttpError(
+        409,
+        'stripe_customer_already_linked',
+        'This carrier already has a Stripe customer. Use the Customer Portal to change billing.',
+      );
+    }
+
     const url = await createStripeCheckoutSession({
       carrierId,
       stripeCustomerId,

--- a/apps/api/src/stripe-webhook-events.ts
+++ b/apps/api/src/stripe-webhook-events.ts
@@ -1,0 +1,70 @@
+import { PrismaClient } from '@prisma/client';
+
+export type StripeWebhookEventStatus = 'received' | 'processed' | 'failed' | 'ignored';
+
+export type StripeWebhookEventInput = {
+  eventId: string;
+  eventType: string;
+  carrierId?: string | null;
+  status: StripeWebhookEventStatus;
+  errorMessage?: string | null;
+  processedAt?: Date | null;
+};
+
+interface StripeWebhookEventStore {
+  upsert(input: StripeWebhookEventInput): Promise<void>;
+}
+
+class MemoryStripeWebhookEventStore implements StripeWebhookEventStore {
+  private events = new Map<string, StripeWebhookEventInput>();
+
+  async upsert(input: StripeWebhookEventInput): Promise<void> {
+    const current = this.events.get(input.eventId);
+    this.events.set(input.eventId, {
+      ...current,
+      ...input,
+    });
+  }
+}
+
+class PrismaStripeWebhookEventStore implements StripeWebhookEventStore {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async upsert(input: StripeWebhookEventInput): Promise<void> {
+    await this.prisma.stripeWebhookEvent.upsert({
+      where: { eventId: input.eventId },
+      create: {
+        eventId: input.eventId,
+        eventType: input.eventType,
+        carrierId: input.carrierId,
+        status: input.status,
+        errorMessage: input.errorMessage,
+        processedAt: input.processedAt,
+      },
+      update: {
+        eventType: input.eventType,
+        carrierId: input.carrierId,
+        status: input.status,
+        errorMessage: input.errorMessage,
+        processedAt: input.processedAt,
+      },
+    });
+  }
+}
+
+let prismaClient: PrismaClient | null = null;
+let memoryStore: MemoryStripeWebhookEventStore | null = null;
+
+export function createStripeWebhookEventStore(): StripeWebhookEventStore {
+  if (process.env.NODE_ENV === 'test') {
+    memoryStore ??= new MemoryStripeWebhookEventStore();
+    return memoryStore;
+  }
+
+  if (!process.env.DATABASE_URL) {
+    throw new Error('DATABASE_URL is required outside of test mode.');
+  }
+
+  prismaClient ??= new PrismaClient();
+  return new PrismaStripeWebhookEventStore(prismaClient);
+}

--- a/apps/api/test/billing.test.ts
+++ b/apps/api/test/billing.test.ts
@@ -74,6 +74,39 @@ describe('Stripe billing endpoints', () => {
     expect(response.body.error).toBe('stripe_secret_key_required');
   });
 
+  it('blocks duplicate checkout when a carrier already has a Stripe customer', async () => {
+    const app = createApp();
+    const payload = JSON.stringify({
+      id: 'evt_checkout_duplicate_guard',
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          customer: 'cus_duplicate_guard',
+          metadata: {
+            carrierId: 'carrier_duplicate_guard',
+            plan: 'starter',
+          },
+        },
+      },
+    });
+
+    await request(app)
+      .post('/api/billing/webhook')
+      .set('stripe-signature', createStripeSignature(payload, 'whsec_test_secret'))
+      .set('Content-Type', 'application/json')
+      .send(payload)
+      .expect(200, { received: true });
+
+    const response = await request(app)
+      .post('/api/billing/checkout-session')
+      .set('x-tenant-id', 'carrier_duplicate_guard')
+      .set('x-user-role', 'owner')
+      .send({ plan: 'professional', billingInterval: 'month' })
+      .expect(409);
+
+    expect(response.body.error).toBe('stripe_customer_already_linked');
+  });
+
   it('requires owner or admin access for customer portal and checkout sessions', async () => {
     const app = createApp();
 

--- a/docs/STRIPE_BILLING_AUTOMATION.md
+++ b/docs/STRIPE_BILLING_AUTOMATION.md
@@ -1,7 +1,7 @@
 # Stripe Billing Automation
 
 Date: April 27, 2026
-Status: Checkout, webhook sync, customer portal, and AI usage ledger foundation added
+Status: Checkout, webhook sync, customer portal, webhook logging, duplicate checkout guard, and AI usage ledger foundation added
 
 ## Purpose
 
@@ -11,7 +11,9 @@ The implementation adds:
 
 - Backend-created Stripe Checkout Sessions
 - Stripe webhook verification
+- Stripe webhook event logging
 - Subscription/customer sync to `Carrier`
+- Duplicate checkout protection
 - Owner/admin customer portal endpoint
 - AI usage ledger API and database table
 - Billing UI in Settings
@@ -26,6 +28,15 @@ POST /api/billing/webhook
 ```
 
 This endpoint expects Stripe's raw request body and validates the `stripe-signature` header with `STRIPE_WEBHOOK_SECRET`.
+
+Verified events are logged to `StripeWebhookEvent` with status:
+
+```text
+received
+processed
+failed
+ignored
+```
 
 ### Checkout Session
 
@@ -63,6 +74,8 @@ Supported billing intervals:
 month
 year
 ```
+
+If a carrier already has a linked Stripe customer, checkout creation returns a conflict. Use the Customer Portal for billing changes after first checkout.
 
 ### Customer portal
 
@@ -138,21 +151,21 @@ API:
 ```env
 STRIPE_SECRET_KEY=sk_live_...
 STRIPE_WEBHOOK_SECRET=whsec_...
-STRIPE_PORTAL_RETURN_URL=https://app.infamousfreight.com/settings
-STRIPE_CHECKOUT_SUCCESS_URL=https://app.infamousfreight.com/settings?checkout=success
-STRIPE_CHECKOUT_CANCEL_URL=https://app.infamousfreight.com/settings?checkout=canceled
+STRIPE_PORTAL_RETURN_URL=https://www.infamousfreight.com/settings
+STRIPE_CHECKOUT_SUCCESS_URL=https://www.infamousfreight.com/settings?checkout=success
+STRIPE_CHECKOUT_CANCEL_URL=https://www.infamousfreight.com/settings?checkout=canceled
 ```
 
 Optional fallback:
 
 ```env
-WEB_APP_URL=https://app.infamousfreight.com
+WEB_APP_URL=https://www.infamousfreight.com
 ```
 
 Web:
 
 ```env
-VITE_API_URL=https://<api-domain>
+VITE_API_URL=/api
 ```
 
 ## Required Stripe webhook events
@@ -203,6 +216,24 @@ unpaid
 incomplete
 inactive
 ```
+
+## Webhook event logs
+
+`StripeWebhookEvent` is used for operational debugging.
+
+Track:
+
+```text
+eventId
+eventType
+carrierId
+status
+errorMessage
+receivedAt
+processedAt
+```
+
+Use this table when Stripe shows an event was delivered but the app billing state did not change.
 
 ## Checkout metadata
 
@@ -262,8 +293,9 @@ After deployment:
    - `stripeCustomerId`
    - correct `subscriptionTier`
    - correct `status`
-8. Open customer portal from Settings as owner/admin.
-9. Record one AI usage event and confirm it appears in Settings → Billing & Plans.
+8. Confirm `StripeWebhookEvent` logged the webhook as `processed`.
+9. Open customer portal from Settings as owner/admin.
+10. Record one AI usage event and confirm it appears in Settings → Billing & Plans.
 
 ## Notes
 


### PR DESCRIPTION
## Summary

Adds repo-side billing hardening for the remaining Stripe recommendations.

## Changes

- Adds `StripeWebhookEvent` Prisma model and migration
- Logs verified Stripe webhooks as received, processed, ignored, or failed
- Blocks duplicate checkout creation when a carrier already has a linked Stripe customer
- Keeps billing changes after first checkout routed through Customer Portal
- Adds API test coverage for the duplicate checkout guard
- Updates billing runbook with webhook log and checkout guard behavior

## Notes

Environment execution still requires Fly.io/API host access and Stripe Dashboard webhook setup. This PR completes the repo-side hardening package.