### PR TITLE
test: add MVP quote-to-load workflow coverage

### DIFF
--- a/apps/api/test/mvp-quote-to-load.test.ts
+++ b/apps/api/test/mvp-quote-to-load.test.ts
@@ -1,0 +1,87 @@
+import request from 'supertest';
+import { createApp } from '../src/app';
+
+describe('MVP quote-to-load workflow', () => {
+  const tenantId = 'carrier-test-quote-to-load';
+  const headers = {
+    'x-tenant-id': tenantId,
+    'x-user-role': 'dispatcher',
+  };
+
+  beforeAll(() => {
+    process.env.NODE_ENV = 'test';
+  });
+
+  it('creates an approved quote request and converts it into a load', async () => {
+    const app = createApp();
+
+    const quoteResponse = await request(app)
+      .post('/api/freight-operations/quoteRequests')
+      .set(headers)
+      .send({
+        brokerName: 'Infamous Freight Test Shipper',
+        originCity: 'Dallas',
+        destCity: 'Atlanta',
+        freightType: 'Dry Van',
+        weight: 42000,
+        pickupDate: '2026-05-01T10:00:00.000Z',
+        deliveryDeadline: '2026-05-03T17:00:00.000Z',
+        shipperRate: 2800,
+        carrierCost: 2250,
+        profitMargin: 550,
+        status: 'approved',
+      })
+      .expect(201);
+
+    expect(quoteResponse.body.data).toMatchObject({
+      tenantId,
+      brokerName: 'Infamous Freight Test Shipper',
+      originCity: 'Dallas',
+      destCity: 'Atlanta',
+      status: 'approved',
+    });
+
+    const quoteId = quoteResponse.body.data.id;
+
+    const conversionResponse = await request(app)
+      .post(`/api/workflows/quotes/${quoteId}/convert-to-load`)
+      .set(headers)
+      .send({
+        quoteStatus: 'converted',
+        load: {
+          brokerName: 'Infamous Freight Test Shipper',
+          originCity: 'Dallas',
+          originState: 'TX',
+          originLat: 32.7767,
+          originLng: -96.797,
+          destCity: 'Atlanta',
+          destState: 'GA',
+          destLat: 33.749,
+          destLng: -84.388,
+          distance: 781,
+          rate: 2800,
+          ratePerMile: 3.59,
+          equipmentType: 'Dry Van',
+          weight: 42000,
+          pickupDate: '2026-05-01T10:00:00.000Z',
+          status: 'booked',
+        },
+      })
+      .expect(201);
+
+    expect(conversionResponse.body.data.quoteRequest).toMatchObject({
+      id: quoteId,
+      tenantId,
+      status: 'converted',
+    });
+
+    expect(conversionResponse.body.data.load).toMatchObject({
+      tenantId,
+      quoteRequestId: quoteId,
+      brokerName: 'Infamous Freight Test Shipper',
+      originCity: 'Dallas',
+      destCity: 'Atlanta',
+      status: 'booked',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds API coverage for the first MVP workflow: creating an approved quote request and converting it into a load.

## Scope

- Uses the existing Express API app
- Uses the in-memory datastore through `NODE_ENV=test`
- Exercises `/api/freight-operations/quoteRequests`
- Exercises `/api/workflows/quotes/:id/convert-to-load`

## Related

- #1592
- docs/production-operations/GITHUB_NATIVE_MVP_BUILD_PLAN.md
- docs/production-operations/MVP_TECHNICAL_IMPLEMENTATION_SPEC.md
- docs/production-operations/MVP_EXISTING_ARCHITECTURE_ALIGNMENT.md

## Validation

Run:

```bash
npm --prefix apps/api run test -- mvp-quote-to-load.test.ts
```

This PR does not mark #1592 complete until CI/test output is verified and evidence is recorded.