### PR TITLE
test: prove pending quotes cannot convert to loads

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -20,6 +20,7 @@ import {
 } from './billing';
 import { createAiUsageStore } from './ai-usage';
 import { createStripeWebhookEventStore } from './stripe-webhook-events';
+import { createFreightWorkflowRouter } from './freight-workflow-routes';
 
 type Role = 'owner' | 'admin' | 'dispatcher';
 
@@ -369,6 +370,8 @@ function registerRoutes(app: express.Express, dataStore: DataStore) {
     );
     res.status(200).json({ data });
   }));
+
+  app.use('/api/workflows', requireTenant, requireRole, createFreightWorkflowRouter(dataStore));
 
   app.post('/api/workflows/quotes/:id/convert-to-load', requireTenant, requireRole, wrapAsync(async (req, res) => {
     const data = await dataStore.convertQuoteToLoad(getRequiredTenantId(req), req.params.id, req.body);

--- a/apps/api/src/freight-workflow-routes.ts
+++ b/apps/api/src/freight-workflow-routes.ts
@@ -1,0 +1,138 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import {
+  DataStore,
+  LoadAssignmentDecision,
+} from './data-store';
+import {
+  FreightWorkflowRuleError,
+  assertQuoteCanConvertToLoad,
+} from './freight-workflow-rules';
+
+class FreightWorkflowHttpError extends Error {
+  constructor(
+    public readonly statusCode: number,
+    public readonly code: string,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+type TenantRequest = Request & {
+  tenantId?: string;
+};
+
+function wrapAsync(
+  handler: (req: Request, res: Response, next: NextFunction) => Promise<void>,
+) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    void handler(req, res, next).catch(next);
+  };
+}
+
+function getRequiredTenantId(req: TenantRequest): string {
+  if (!req.tenantId) {
+    throw new FreightWorkflowHttpError(
+      400,
+      'tenant_id_required',
+      'Provide tenantId via x-tenant-id header, query, or body.',
+    );
+  }
+
+  return req.tenantId;
+}
+
+function getLoadAssignmentDecision(req: Request): LoadAssignmentDecision {
+  if (req.params.decision !== 'accepted' && req.params.decision !== 'rejected') {
+    throw new FreightWorkflowHttpError(
+      400,
+      'invalid_load_assignment_decision',
+      'Load assignment decision must be accepted or rejected.',
+    );
+  }
+
+  return req.params.decision;
+}
+
+export function createFreightWorkflowRouter(dataStore: DataStore): Router {
+  const router = Router();
+
+  router.post('/quotes/:id/convert-to-load', wrapAsync(async (req: TenantRequest, res) => {
+    const tenantId = getRequiredTenantId(req);
+    const quoteRequests = await dataStore.listFreightOperations('quoteRequests', tenantId);
+    const quoteRequest = quoteRequests.find((item) => item.id === req.params.id);
+
+    if (!quoteRequest) {
+      throw new FreightWorkflowHttpError(
+        404,
+        'quote_request_not_found',
+        'Quote request was not found for this tenant.',
+      );
+    }
+
+    assertQuoteCanConvertToLoad(quoteRequest);
+
+    const data = await dataStore.convertQuoteToLoad(tenantId, req.params.id, req.body);
+    res.status(201).json({ data });
+  }));
+
+  router.post('/load-assignments/:id/:decision', wrapAsync(async (req: TenantRequest, res) => {
+    const data = await dataStore.respondToLoadAssignment(
+      getRequiredTenantId(req),
+      req.params.id,
+      getLoadAssignmentDecision(req),
+      req.body,
+    );
+    res.status(200).json({ data });
+  }));
+
+  router.post('/dispatches/:id/confirm', wrapAsync(async (req: TenantRequest, res) => {
+    const data = await dataStore.confirmDispatch(getRequiredTenantId(req), req.params.id, req.body);
+    res.status(200).json({ data });
+  }));
+
+  router.post('/loads/:loadId/tracking-updates', wrapAsync(async (req: TenantRequest, res) => {
+    const data = await dataStore.recordTrackingUpdate(getRequiredTenantId(req), req.params.loadId, req.body);
+    res.status(201).json({ data });
+  }));
+
+  router.post('/loads/:loadId/verify-delivery', wrapAsync(async (req: TenantRequest, res) => {
+    const data = await dataStore.verifyDelivery(getRequiredTenantId(req), req.params.loadId, req.body);
+    res.status(201).json({ data });
+  }));
+
+  router.post('/carrier-payments/:id/status', wrapAsync(async (req: TenantRequest, res) => {
+    const data = await dataStore.updateCarrierPaymentStatus(getRequiredTenantId(req), req.params.id, req.body);
+    res.status(200).json({ data });
+  }));
+
+  router.post('/operational-metrics/rollup', wrapAsync(async (req: TenantRequest, res) => {
+    const data = await dataStore.rollupOperationalMetrics(getRequiredTenantId(req), req.body);
+    res.status(201).json({ data });
+  }));
+
+  router.post('/load-board-posts/:id/status', wrapAsync(async (req: TenantRequest, res) => {
+    const data = await dataStore.updateLoadBoardPostStatus(getRequiredTenantId(req), req.params.id, req.body);
+    res.status(200).json({ data });
+  }));
+
+  router.use((err: Error, _req: Request, res: Response, next: NextFunction) => {
+    if (err instanceof FreightWorkflowRuleError) {
+      return res.status(409).json({
+        error: err.code,
+        message: err.message,
+      });
+    }
+
+    if (err instanceof FreightWorkflowHttpError) {
+      return res.status(err.statusCode).json({
+        error: err.code,
+        message: err.message,
+      });
+    }
+
+    next(err);
+  });
+
+  return router;
+}

--- a/apps/api/src/freight-workflow-rules.ts
+++ b/apps/api/src/freight-workflow-rules.ts
@@ -1,0 +1,21 @@
+export type QuoteLike = {
+  status?: unknown;
+};
+
+export class FreightWorkflowRuleError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+export function assertQuoteCanConvertToLoad(quoteRequest: QuoteLike): void {
+  if (quoteRequest.status !== 'approved') {
+    throw new FreightWorkflowRuleError(
+      'quote_request_not_approved',
+      'Quote request must be approved before it can be converted into a load.',
+    );
+  }
+}

--- a/apps/api/test/freight-workflow-routes.test.ts
+++ b/apps/api/test/freight-workflow-routes.test.ts
@@ -1,0 +1,64 @@
+import express from 'express';
+import request from 'supertest';
+import { DataStore } from '../src/data-store';
+import { createFreightWorkflowRouter } from '../src/freight-workflow-routes';
+
+function createTestApp(dataStore: DataStore) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.tenantId = req.header('x-tenant-id') ?? undefined;
+    next();
+  });
+  app.use('/api/workflows', createFreightWorkflowRouter(dataStore));
+  return app;
+}
+
+describe('freight workflow routes', () => {
+  it('returns 409 when a quote is not approved before load conversion', async () => {
+    const dataStore = {
+      listFreightOperations: jest.fn().mockResolvedValue([
+        { id: 'quote-1', tenantId: 'tenant-1', status: 'pending' },
+      ]),
+      convertQuoteToLoad: jest.fn(),
+    } as unknown as DataStore;
+
+    const app = createTestApp(dataStore);
+
+    const response = await request(app)
+      .post('/api/workflows/quotes/quote-1/convert-to-load')
+      .set('x-tenant-id', 'tenant-1')
+      .send({ quoteStatus: 'converted', load: { status: 'booked' } })
+      .expect(409);
+
+    expect(response.body.error).toBe('quote_request_not_approved');
+    expect(dataStore.convertQuoteToLoad).not.toHaveBeenCalled();
+  });
+
+  it('converts an approved quote into a load', async () => {
+    const dataStore = {
+      listFreightOperations: jest.fn().mockResolvedValue([
+        { id: 'quote-1', tenantId: 'tenant-1', status: 'approved' },
+      ]),
+      convertQuoteToLoad: jest.fn().mockResolvedValue({
+        quoteRequest: { id: 'quote-1', status: 'converted' },
+        load: { id: 'load-1', quoteRequestId: 'quote-1' },
+      }),
+    } as unknown as DataStore;
+
+    const app = createTestApp(dataStore);
+
+    const response = await request(app)
+      .post('/api/workflows/quotes/quote-1/convert-to-load')
+      .set('x-tenant-id', 'tenant-1')
+      .send({ quoteStatus: 'converted', load: { status: 'booked' } })
+      .expect(201);
+
+    expect(dataStore.convertQuoteToLoad).toHaveBeenCalledWith(
+      'tenant-1',
+      'quote-1',
+      { quoteStatus: 'converted', load: { status: 'booked' } },
+    );
+    expect(response.body.data.load).toEqual({ id: 'load-1', quoteRequestId: 'quote-1' });
+  });
+});

--- a/apps/api/test/freight-workflow-rules.test.ts
+++ b/apps/api/test/freight-workflow-rules.test.ts
@@ -1,0 +1,24 @@
+import {
+  FreightWorkflowRuleError,
+  assertQuoteCanConvertToLoad,
+} from '../src/freight-workflow-rules';
+
+describe('freight workflow rules', () => {
+  it('allows approved quotes to convert into loads', () => {
+    expect(() => assertQuoteCanConvertToLoad({ status: 'approved' })).not.toThrow();
+  });
+
+  it.each(['pending', 'reviewing', 'quoted', 'rejected', 'converted', undefined])(
+    'blocks %s quotes from converting into loads',
+    (status) => {
+      expect(() => assertQuoteCanConvertToLoad({ status })).toThrow(FreightWorkflowRuleError);
+
+      try {
+        assertQuoteCanConvertToLoad({ status });
+      } catch (error) {
+        expect(error).toBeInstanceOf(FreightWorkflowRuleError);
+        expect((error as FreightWorkflowRuleError).code).toBe('quote_request_not_approved');
+      }
+    },
+  );
+});

--- a/apps/api/test/mvp-quote-to-load.test.ts
+++ b/apps/api/test/mvp-quote-to-load.test.ts
@@ -84,4 +84,64 @@ describe('MVP quote-to-load workflow', () => {
       status: 'booked',
     });
   });
+
+  it('does not convert a pending quote request into a load', async () => {
+    const app = createApp();
+
+    const quoteResponse = await request(app)
+      .post('/api/freight-operations/quoteRequests')
+      .set(headers)
+      .send({
+        brokerName: 'Infamous Freight Pending Shipper',
+        originCity: 'Houston',
+        destCity: 'Memphis',
+        freightType: 'Reefer',
+        weight: 36000,
+        pickupDate: '2026-05-05T10:00:00.000Z',
+        shipperRate: 1900,
+        carrierCost: 1600,
+        profitMargin: 300,
+        status: 'pending',
+      })
+      .expect(201);
+
+    const quoteId = quoteResponse.body.data.id;
+
+    await request(app)
+      .post(`/api/workflows/quotes/${quoteId}/convert-to-load`)
+      .set(headers)
+      .send({
+        quoteStatus: 'converted',
+        load: {
+          brokerName: 'Infamous Freight Pending Shipper',
+          originCity: 'Houston',
+          originState: 'TX',
+          originLat: 29.7604,
+          originLng: -95.3698,
+          destCity: 'Memphis',
+          destState: 'TN',
+          destLat: 35.1495,
+          destLng: -90.049,
+          distance: 567,
+          rate: 1900,
+          ratePerMile: 3.35,
+          equipmentType: 'Reefer',
+          weight: 36000,
+          pickupDate: '2026-05-05T10:00:00.000Z',
+          status: 'booked',
+        },
+      })
+      .expect(409);
+
+    const loadsResponse = await request(app)
+      .get('/api/loads')
+      .set(headers)
+      .expect(200);
+
+    expect(loadsResponse.body.data).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ quoteRequestId: quoteId }),
+      ]),
+    );
+  });
 });

--- a/apps/api/test/mvp-quote-to-load.test.ts
+++ b/apps/api/test/mvp-quote-to-load.test.ts
@@ -107,7 +107,7 @@ describe('MVP quote-to-load workflow', () => {
 
     const quoteId = quoteResponse.body.data.id;
 
-    await request(app)
+    const conversionResponse = await request(app)
       .post(`/api/workflows/quotes/${quoteId}/convert-to-load`)
       .set(headers)
       .send({
@@ -133,6 +133,8 @@ describe('MVP quote-to-load workflow', () => {
       })
       .expect(409);
 
+    expect(conversionResponse.body.error).toBe('quote_request_not_approved');
+
     const loadsResponse = await request(app)
       .get('/api/loads')
       .set(headers)
@@ -142,6 +144,19 @@ describe('MVP quote-to-load workflow', () => {
       expect.arrayContaining([
         expect.objectContaining({ quoteRequestId: quoteId }),
       ]),
+    );
+
+    const quoteRequestsResponse = await request(app)
+      .get('/api/freight-operations/quoteRequests')
+      .set(headers)
+      .expect(200);
+
+    const updatedQuote = quoteRequestsResponse.body.data.find(
+      (quote: { id: string; status: string }) => quote.id === quoteId,
+    );
+
+    expect(updatedQuote).toEqual(
+      expect.objectContaining({ id: quoteId, status: 'pending' }),
     );
   });
 });


### PR DESCRIPTION
## Summary

Adds the approved-quote conversion guard and tests proving pending quote requests must not convert into loads.

## Scope

- Adds `apps/api/src/freight-workflow-rules.ts`
- Adds `apps/api/src/freight-workflow-routes.ts`
- Mounts the guarded workflow router at `/api/workflows`
- Adds `apps/api/test/freight-workflow-rules.test.ts`
- Adds `apps/api/test/freight-workflow-routes.test.ts`
- Extends `apps/api/test/mvp-quote-to-load.test.ts`
- Keeps the approved quote happy-path test
- Adds a pending quote rejection test
- Expects HTTP 409 for pending quote conversion
- Asserts response error is `quote_request_not_approved`
- Confirms no load is created for the pending quote
- Confirms the pending quote remains `pending`

## Current State

The guarded workflow router is now mounted in `apps/api/src/app.ts` before the older inline workflow routes, so `/api/workflows/*` requests are handled by the guarded router first.

Remaining before closing #1592:

1. Run the workflow tests locally or in CI.
2. Update the production readiness evidence log with test output.
3. Confirm whether the duplicate inline workflow routes should be removed in a cleanup PR.

## CI Note

The exposed Vercel status is failing because the account hit the free deployment limit, not because a test failure was reported.

## Related

- #1592
- #1646

## Validation

```bash
npm --prefix apps/api run test -- freight-workflow-rules.test.ts
npm --prefix apps/api run test -- freight-workflow-routes.test.ts
npm --prefix apps/api run test -- mvp-quote-to-load.test.ts
```