### PR TITLE
cleanup: remove duplicate inline workflow routes

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -6,7 +6,6 @@ import {
   createDataStore,
   DataStore,
   FreightOperationResource,
-  LoadAssignmentDecision,
 } from './data-store';
 import {
   BillingInterval,
@@ -39,7 +38,6 @@ const FREIGHT_OPERATION_RESOURCES: FreightOperationResource[] = [
   'operationalMetrics',
   'loadBoardPosts',
 ];
-const LOAD_ASSIGNMENT_DECISIONS: LoadAssignmentDecision[] = ['accepted', 'rejected'];
 
 class HttpError extends Error {
   statusCode: number;
@@ -152,20 +150,6 @@ function getFreightOperationResource(req: Request): FreightOperationResource {
   }
 
   return resource as FreightOperationResource;
-}
-
-function getLoadAssignmentDecision(req: Request): LoadAssignmentDecision {
-  const decision = req.params.decision;
-
-  if (!LOAD_ASSIGNMENT_DECISIONS.includes(decision as LoadAssignmentDecision)) {
-    throw new HttpError(
-      400,
-      'invalid_load_assignment_decision',
-      'Load assignment decision must be accepted or rejected.',
-    );
-  }
-
-  return decision as LoadAssignmentDecision;
 }
 
 function getCheckoutPlan(req: Request): BillingPlan {
@@ -437,51 +421,6 @@ function registerRoutes(app: express.Express, dataStore: DataStore) {
   }));
 
   app.use('/api/workflows', requireTenant, requireRole, createFreightWorkflowRouter(dataStore));
-
-  app.post('/api/workflows/quotes/:id/convert-to-load', requireTenant, requireRole, wrapAsync(async (req, res) => {
-    const data = await dataStore.convertQuoteToLoad(getRequiredTenantId(req), req.params.id, req.body);
-    res.status(201).json({ data });
-  }));
-
-  app.post('/api/workflows/load-assignments/:id/:decision', requireTenant, requireRole, wrapAsync(async (req, res) => {
-    const data = await dataStore.respondToLoadAssignment(
-      getRequiredTenantId(req),
-      req.params.id,
-      getLoadAssignmentDecision(req),
-      req.body,
-    );
-    res.status(200).json({ data });
-  }));
-
-  app.post('/api/workflows/dispatches/:id/confirm', requireTenant, requireRole, wrapAsync(async (req, res) => {
-    const data = await dataStore.confirmDispatch(getRequiredTenantId(req), req.params.id, req.body);
-    res.status(200).json({ data });
-  }));
-
-  app.post('/api/workflows/loads/:loadId/tracking-updates', requireTenant, requireRole, wrapAsync(async (req, res) => {
-    const data = await dataStore.recordTrackingUpdate(getRequiredTenantId(req), req.params.loadId, req.body);
-    res.status(201).json({ data });
-  }));
-
-  app.post('/api/workflows/loads/:loadId/verify-delivery', requireTenant, requireRole, wrapAsync(async (req, res) => {
-    const data = await dataStore.verifyDelivery(getRequiredTenantId(req), req.params.loadId, req.body);
-    res.status(201).json({ data });
-  }));
-
-  app.post('/api/workflows/carrier-payments/:id/status', requireTenant, requireRole, wrapAsync(async (req, res) => {
-    const data = await dataStore.updateCarrierPaymentStatus(getRequiredTenantId(req), req.params.id, req.body);
-    res.status(200).json({ data });
-  }));
-
-  app.post('/api/workflows/operational-metrics/rollup', requireTenant, requireRole, wrapAsync(async (req, res) => {
-    const data = await dataStore.rollupOperationalMetrics(getRequiredTenantId(req), req.body);
-    res.status(201).json({ data });
-  }));
-
-  app.post('/api/workflows/load-board-posts/:id/status', requireTenant, requireRole, wrapAsync(async (req, res) => {
-    const data = await dataStore.updateLoadBoardPostStatus(getRequiredTenantId(req), req.params.id, req.body);
-    res.status(200).json({ data });
-  }));
 }
 
 export function createApp() {


### PR DESCRIPTION
## Summary

Removes duplicate inline `/api/workflows/*` route definitions from `apps/api/src/app.ts` after the guarded freight workflow router was merged.

## Scope

- Keeps the guarded `createFreightWorkflowRouter(dataStore)` mount
- Removes duplicate inline workflow handlers from `app.ts`
- Keeps billing routes untouched
- Keeps Stripe webhook route untouched
- Keeps public lead intake routes untouched
- Keeps load, driver, shipment, and freight-operation routes untouched

## Related

- #1648
- #1614
- #1647

## Validation

Run:

```bash
npm --prefix apps/api run test -- freight-workflow-rules.test.ts
npm --prefix apps/api run test -- freight-workflow-routes.test.ts
npm --prefix apps/api run test -- mvp-quote-to-load.test.ts
```