### PR TITLE
ci: add MVP quote workflow validation

### DIFF
--- a/.github/workflows/mvp-quote-workflow-validation.yml
+++ b/.github/workflows/mvp-quote-workflow-validation.yml
@@ -1,0 +1,60 @@
+name: MVP Quote Workflow Validation
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'apps/api/src/freight-workflow-rules.ts'
+      - 'apps/api/src/freight-workflow-routes.ts'
+      - 'apps/api/src/app.ts'
+      - 'apps/api/test/freight-workflow-rules.test.ts'
+      - 'apps/api/test/freight-workflow-routes.test.ts'
+      - 'apps/api/test/mvp-quote-to-load.test.ts'
+      - 'apps/api/package.json'
+      - 'apps/api/package-lock.json'
+      - '.github/workflows/mvp-quote-workflow-validation.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'apps/api/src/freight-workflow-rules.ts'
+      - 'apps/api/src/freight-workflow-routes.ts'
+      - 'apps/api/src/app.ts'
+      - 'apps/api/test/freight-workflow-rules.test.ts'
+      - 'apps/api/test/freight-workflow-routes.test.ts'
+      - 'apps/api/test/mvp-quote-to-load.test.ts'
+      - 'apps/api/package.json'
+      - 'apps/api/package-lock.json'
+      - '.github/workflows/mvp-quote-workflow-validation.yml'
+
+jobs:
+  validate-mvp-quote-workflow:
+    name: Validate MVP quote workflow
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: apps/api/package-lock.json
+
+      - name: Install API dependencies
+        run: npm ci
+        working-directory: apps/api
+
+      - name: Run freight workflow rule tests
+        run: npm run test -- freight-workflow-rules.test.ts
+        working-directory: apps/api
+
+      - name: Run guarded workflow route tests
+        run: npm run test -- freight-workflow-routes.test.ts
+        working-directory: apps/api
+
+      - name: Run quote-to-load workflow tests
+        run: npm run test -- mvp-quote-to-load.test.ts
+        working-directory: apps/api


### PR DESCRIPTION
## Summary

Adds a targeted GitHub Actions workflow for validating the MVP quote-to-load workflow.

## What it runs

- `freight-workflow-rules.test.ts`
- `freight-workflow-routes.test.ts`
- `mvp-quote-to-load.test.ts`

## Why

This gives the repo a repeatable validation path that does not depend on local-only test output or Vercel deployment status.

## Related

- #1647
- #1592
- #1614

## Validation

Workflow is triggered by:

- Manual `workflow_dispatch`
- Pull requests touching MVP quote workflow files
- Pushes to `main` touching MVP quote workflow files