### PR TITLE
ci: document MVP quote validation workflow trigger

### DIFF
--- a/.github/workflows/mvp-quote-workflow-validation.yml
+++ b/.github/workflows/mvp-quote-workflow-validation.yml
@@ -1,5 +1,8 @@
 name: MVP Quote Workflow Validation
 
+# Validates the MVP quote-to-load guard and route behavior.
+# Use workflow_dispatch for manual evidence runs tracked by issue #1651.
+
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
## Summary

Adds comments to the MVP quote workflow validation file so the manual evidence run tracked by #1651 is explicit.

## Purpose

This also creates a workflow-file change that should trigger the validation workflow on merge to `main`.

## Related

- #1651
- #1647
- #1592

## Validation

The workflow should run on merge because the workflow file is included in its `push` path filters.