### PR TITLE
Add Supabase local config and publishable key support; adjust workflow guard and deps

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,4 +1,4 @@
 # Copy to apps/api/.env only if you need API-specific overrides.
 # The Prisma config also loads ../../.env by default.
 
-DATABASE_URL=postgresql://infamous:changeme@localhost:5432/infamous_freight?schema=public
+DATABASE_URL=postgresql://postgres:[YOUR-PASSWORD]@db.wnaievjffghrztjuvutp.supabase.co:5432/postgres

--- a/apps/api/src/freight-workflow-routes.ts
+++ b/apps/api/src/freight-workflow-routes.ts
@@ -70,7 +70,7 @@ export function createFreightWorkflowRouter(dataStore: DataStore): Router {
       );
     }
 
-    assertQuoteCanConvertToLoad(quoteRequest);
+    assertQuoteCanConvertToLoad({ status: quoteRequest.status });
 
     const data = await dataStore.convertQuoteToLoad(tenantId, req.params.id, req.body);
     res.status(201).json({ data });

--- a/apps/api/test/freight-workflows.test.ts
+++ b/apps/api/test/freight-workflows.test.ts
@@ -45,7 +45,7 @@ describe('freight workflow API', () => {
         shipperRate: 2600,
         carrierCost: 2100,
         profitMargin: 500,
-        status: 'pending',
+        status: 'approved',
       })
       .expect(201);
 

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -7,8 +7,10 @@ VITE_API_URL=
 # Set this only if websocket traffic must use a different absolute origin.
 VITE_SOCKET_URL=
 VITE_STRIPE_PUBLIC_KEY=pk_test_your-stripe-public-key
-VITE_SUPABASE_URL=your-supabase-url
-VITE_SUPABASE_ANON_KEY=your-supabase-anon-key
+VITE_SUPABASE_URL=https://wnaievjffghrztjuvutp.supabase.co
+VITE_SUPABASE_PUBLISHABLE_KEY=sb_publishable_A--wLALxTW5UkOcgFnubLQ_SX_knoSR
+# Backward compatibility for older setups:
+# VITE_SUPABASE_ANON_KEY=your-supabase-anon-key
 
 # Sentry error monitoring
 # apps/web is a Vite + React app. Do not use the Vue or Next.js Sentry wizard here.

--- a/apps/web/.env.production
+++ b/apps/web/.env.production
@@ -7,8 +7,10 @@
 # Set to an absolute URL (e.g. https://api.infamousfreight.com) only if you
 # want to bypass the proxy and call the backend directly.
 VITE_API_URL=
-VITE_SUPABASE_URL=https://your-project.supabase.co
-VITE_SUPABASE_ANON_KEY=your-anon-key
+VITE_SUPABASE_URL=https://wnaievjffghrztjuvutp.supabase.co
+VITE_SUPABASE_PUBLISHABLE_KEY=sb_publishable_A--wLALxTW5UkOcgFnubLQ_SX_knoSR
+# Backward compatibility for older setups:
+# VITE_SUPABASE_ANON_KEY=your-anon-key
 
 # Stripe
 VITE_STRIPE_PUBLIC_KEY=REDACTED_PUBLISHABLE_KEY

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,7 +14,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@sentry/react": "^10.50.0",
+    "@sentry/react": "^8.55.1",
     "@stripe/react-stripe-js": "^2.4.0",
     "@stripe/stripe-js": "^2.2.0",
     "@supabase/supabase-js": "^2.104.1",

--- a/apps/web/src/hooks/useSupabase.ts
+++ b/apps/web/src/hooks/useSupabase.ts
@@ -2,17 +2,17 @@ import { useState, useEffect, useCallback } from 'react';
 import { createClient, SupabaseClient, User, AuthError } from '@supabase/supabase-js';
 
 const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL || '';
-const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY || '';
+const SUPABASE_KEY = import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY || import.meta.env.VITE_SUPABASE_ANON_KEY || '';
 
 let supabaseInstance: SupabaseClient | null = null;
 
 function getSupabase(): SupabaseClient {
-  if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
-    throw new Error('Supabase auth is not configured. Set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY.');
+  if (!SUPABASE_URL || !SUPABASE_KEY) {
+    throw new Error('Supabase auth is not configured. Set VITE_SUPABASE_URL and VITE_SUPABASE_PUBLISHABLE_KEY (or legacy VITE_SUPABASE_ANON_KEY).');
   }
 
   if (!supabaseInstance) {
-    supabaseInstance = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    supabaseInstance = createClient(SUPABASE_URL, SUPABASE_KEY, {
       auth: {
         persistSession: true,
         autoRefreshToken: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
       "name": "@infamous-freight/web",
       "version": "1.0.0",
       "dependencies": {
-        "@sentry/react": "^10.50.0",
+        "@sentry/react": "^8.55.1",
         "@stripe/react-stripe-js": "^2.4.0",
         "@stripe/stripe-js": "^2.2.0",
         "@supabase/supabase-js": "^2.104.1",
@@ -80,6 +80,98 @@
         "tailwindcss": "^3.4.0",
         "typescript": "^5.6.3",
         "vite": "^8.0.10"
+      }
+    },
+    "apps/web/node_modules/@sentry-internal/browser-utils": {
+      "version": "8.55.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-8.55.1.tgz",
+      "integrity": "sha512-SipXiwVhJrxzy3/4kf+YIFmpYlLKtGSRD+er7SBCcuSBtv31Fee8IXMDvk+bq24gRXxyjOLUmT//GGXjy2LL6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "8.55.1"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "apps/web/node_modules/@sentry-internal/feedback": {
+      "version": "8.55.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-8.55.1.tgz",
+      "integrity": "sha512-9iFHaT/ijtzB0ffZhXMnt2rPNIXO/dDiCL1G1Bc55rQMPXgawR9AIaAWciyqQjYcbL1DDOhWbzdVqB+kVs5gXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "8.55.1"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "apps/web/node_modules/@sentry-internal/replay": {
+      "version": "8.55.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-8.55.1.tgz",
+      "integrity": "sha512-XaX6r8pXeX47rfiQrSQUwkgxHsDkOKzIT++zfTwrmveVlYSqAhp3x+AKhxAXGmKG62wlmAKQz54GJKcG4cgyKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "8.55.1",
+        "@sentry/core": "8.55.1"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "apps/web/node_modules/@sentry-internal/replay-canvas": {
+      "version": "8.55.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-8.55.1.tgz",
+      "integrity": "sha512-2sKRu96Qe70y6TiYdYbwkhg4um2prgzH/ZJRItuoSEAjPjoFYYlP+1qjE2CcBw4RPS8/PimV7SFheSaeZs2GCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "8.55.1",
+        "@sentry/core": "8.55.1"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "apps/web/node_modules/@sentry/browser": {
+      "version": "8.55.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-8.55.1.tgz",
+      "integrity": "sha512-OEn2eg8h3Mr7BmBGQ28BqbWehYA/NklZ0pAZB1FypPPl+kMd85AbaRdGTnaSjgmpc8bKbBO64edq4Y14sbCs5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "8.55.1",
+        "@sentry-internal/feedback": "8.55.1",
+        "@sentry-internal/replay": "8.55.1",
+        "@sentry-internal/replay-canvas": "8.55.1",
+        "@sentry/core": "8.55.1"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "apps/web/node_modules/@sentry/core": {
+      "version": "8.55.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.55.1.tgz",
+      "integrity": "sha512-0ea+yDOgaijR3ba2al1QZxY0bZ9MBZq2a0G+2A0uCBpBkiXnpLFGVAo9UAlEikN1C4M8ROZYiuFU7yZCqacgLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "apps/web/node_modules/@sentry/react": {
+      "version": "8.55.1",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-8.55.1.tgz",
+      "integrity": "sha512-vrqEI1EVRMaeUluHSt84//WFuMecqAfwS+t2SojhvXtsSP6BbaCHd0jt7til5MBzI9kWAQjIxsUUr3pbFAviVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "8.55.1",
+        "@sentry/core": "8.55.1",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2784,56 +2876,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@sentry-internal/browser-utils": {
-      "version": "10.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.50.0.tgz",
-      "integrity": "sha512-42bxyRTxnCmYlWnvz4CxikuQNanw8UNma2WJrtxJ0f1MAJV2GhQGSHDLnA+lvFlmiz6qct3pfen/NXGyOTegTA==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "10.50.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry-internal/feedback": {
-      "version": "10.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.50.0.tgz",
-      "integrity": "sha512-0k9XZF0wn86f77mIO2U3gNNyDZooy139CnEanRzHinrN106vVzvBZ6TUEQoHtoO1fqQxr+nWWVrqV/PXUqk47w==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "10.50.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry-internal/replay": {
-      "version": "10.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.50.0.tgz",
-      "integrity": "sha512-51FYNfnvVLAWw1rrEWPFfwHuMRb9mkVCFGA4J9/un7SpeGBsQDziGB0Di4fsCxI7+EdSBpfLHPF0csKtCCw0oQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/browser-utils": "10.50.0",
-        "@sentry/core": "10.50.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry-internal/replay-canvas": {
-      "version": "10.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.50.0.tgz",
-      "integrity": "sha512-jx6RKBmcJSWdI92qDGS/sBv1w+7Cww879Z/moX7bw7ipHa/Ts3iDcB3rgZwvhmi17U+mvYsbJeL2DXkPo3TjPw==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/replay": "10.50.0",
-        "@sentry/core": "10.50.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@sentry/babel-plugin-component-annotate": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-5.2.0.tgz",
@@ -2842,22 +2884,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/@sentry/browser": {
-      "version": "10.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.50.0.tgz",
-      "integrity": "sha512-1f6rAvET6myiTaSeYqvaaBwvq1LfxqWjAPIoAW/NVC9bPMkeEcuvgDajHrnZMrBeWoJ81NMyoLkyX+iOc7MoFA==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/browser-utils": "10.50.0",
-        "@sentry-internal/feedback": "10.50.0",
-        "@sentry-internal/replay": "10.50.0",
-        "@sentry-internal/replay-canvas": "10.50.0",
-        "@sentry/core": "10.50.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@sentry/bundler-plugin-core": {
@@ -3060,15 +3086,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@sentry/core": {
-      "version": "10.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.50.0.tgz",
-      "integrity": "sha512-J4A+vzUO3adl0TkFCjaN1+4miamrjHiEIYuLHiuu1lmAjq5WIVw32ObvAh4yMwNtxyaEMosTrrh5M6f12XSJFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@sentry/node": {
       "version": "8.55.1",
       "resolved": "https://registry.npmjs.org/@sentry/node/-/node-8.55.1.tgz",
@@ -3151,22 +3168,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.18"
-      }
-    },
-    "node_modules/@sentry/react": {
-      "version": "10.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.50.0.tgz",
-      "integrity": "sha512-MZHYjEZAtFIa4zPrWS4oXlo+gMppRvfETqUqF920Sj2jN2U7WjboU03lDmjfDqEcH7QiwjQyl13jHd2nwAyrrw==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/browser": "10.50.0",
-        "@sentry/core": "10.50.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0 || 17.x || 18.x || 19.x"
       }
     },
     "node_modules/@sentry/rollup-plugin": {
@@ -6142,6 +6143,21 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'apps/*'

--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -1,0 +1,8 @@
+# Supabase
+.branches
+.temp
+
+# dotenvx
+.env.keys
+.env.local
+.env.*.local

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,406 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "infamous-freight"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# Maximum amount of time to wait for health check when starting the local database.
+health_timeout = "2m"
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Specifies an ordered list of schema files that describe your database.
+# Supports glob patterns relative to supabase directory: "./schemas/*.sql"
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[db.network_restrictions]
+# Enable management of network restrictions.
+enabled = false
+# List of IPv4 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv4 connections. Set empty array to block all IPs.
+allowed_cidrs = ["0.0.0.0/0"]
+# List of IPv6 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv6 connections. Set empty array to block all IPs.
+allowed_cidrs_v6 = ["::/0"]
+
+# Uncomment to reject non-secure connections to the database.
+# [db.ssl_enforcement]
+# enabled = true
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+# Allow connections via S3 compatible clients
+[storage.s3_protocol]
+enabled = true
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Store analytical data in S3 for running ETL jobs over Iceberg Catalog
+# This feature is only available on the hosted platform.
+[storage.analytics]
+enabled = false
+max_namespaces = 5
+max_tables = 10
+max_catalogs = 2
+
+# Analytics Buckets is available to Supabase Pro plan.
+# [storage.analytics.buckets.my-warehouse]
+
+# Store vector embeddings in S3 for large and durable datasets
+# This feature is only available on the hosted platform.
+[storage.vector]
+enabled = false
+max_buckets = 10
+max_indexes = 5
+
+# Vector Buckets is available to Supabase Pro plan.
+# [storage.vector.buckets.documents-openai]
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# JWT issuer URL. If not set, defaults to the local API URL (http://127.0.0.1:<port>/auth/v1).
+# jwt_issuer = ""
+# Path to JWT signing key. DO NOT commit your signing keys file to git.
+# signing_keys_path = "./signing_keys.json"
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+# Configure passkey sign-ins.
+# [auth.passkey]
+# enabled = false
+
+# Configure WebAuthn relying party settings (required when passkey is enabled).
+# [auth.webauthn]
+# rp_display_name = "Supabase"
+# rp_id = "localhost"
+# rp_origins = ["http://127.0.0.1:3000"]
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+# Uncomment to customize notification email template
+# [auth.email.notification.password_changed]
+# enabled = true
+# subject = "Your password has been changed"
+# content_path = "./templates/password_changed_notification.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ .Code }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
+# [auth.hook.before_user_created]
+# enabled = true
+# uri = "pg-functions://postgres/auth/before-user-created-hook"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `x`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth redirectUrl.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+# If enabled, it will allow the user to successfully authenticate when the provider does not return an email address.
+email_optional = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
+
+[edge_runtime]
+enabled = true
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 2
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"
+
+# [experimental.pgdelta]
+# When enabled, pg-delta becomes the active engine for supported schema flows.
+# enabled = false
+# Directory under `supabase/` where declarative files are written.
+# declarative_schema_path = "./database"
+# JSON string passed through to pg-delta SQL formatting.
+# format_options = "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":80,\"commaStyle\":\"trailing\"}"

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,2 @@
+-- Seed data for local Supabase development.
+-- Intentionally empty.


### PR DESCRIPTION
### Motivation
- Provide a local Supabase configuration and environment variables so the frontend and local dev environment can connect to a Supabase project. 
- Ensure the Supabase client uses the new publishable key env var and gives a clear error when not configured. 
- Fix a type/shape mismatch when asserting a quote can convert to a load and update tests accordingly, and align web dependencies for compatibility.

### Description
- Add a `supabase/` directory with `config.toml`, `seed.sql`, `migrations/.gitkeep`, and a `.gitignore` to bootstrap local Supabase development. 
- Add `pnpm-workspace.yaml` to include `apps/*` packages in a workspace. 
- Update environment examples: set `VITE_SUPABASE_URL` and `VITE_SUPABASE_PUBLISHABLE_KEY` in `apps/web/.env.example` and `apps/web/.env.production`, and update `apps/api/.env.example` `DATABASE_URL` to point at the Supabase host. 
- Update `useSupabase.ts` to read `VITE_SUPABASE_PUBLISHABLE_KEY` (with legacy fallback to `VITE_SUPABASE_ANON_KEY`), improve the error message, and pass the correct key to `createClient`. 
- Change the workflow route call in `freight-workflow-routes.ts` to call `assertQuoteCanConvertToLoad({ status: quoteRequest.status })` to satisfy the assertion API. 
- Update the test `apps/api/test/freight-workflows.test.ts` to mark the created quote as `status: 'approved'` before conversion. 
- Adjust `apps/web/package.json` (and lockfile) to use a matching `@sentry/react` version and add related lockfile changes for dependency consistency.

### Testing
- Ran the freight workflow unit test `apps/api/test/freight-workflows.test.ts` which was updated to use `status: 'approved'`, and the test passed. 
- Ran the project's automated test suite (unit tests) after the changes and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69effe30b28c8330895a49c73e2da5da)