### PR TITLE
Enforce approved quote conversion, relax QuoteLike typing, add Netlify security markers + updater script, and pin Sentry overrides

### DIFF
--- a/apps/api/src/freight-workflow-rules.ts
+++ b/apps/api/src/freight-workflow-rules.ts
@@ -1,6 +1,6 @@
 export type QuoteLike = {
   status?: unknown;
-};
+} & Record<string, unknown>;
 
 export class FreightWorkflowRuleError extends Error {
   constructor(

--- a/apps/api/test/freight-workflows.test.ts
+++ b/apps/api/test/freight-workflows.test.ts
@@ -45,7 +45,7 @@ describe('freight workflow API', () => {
         shipperRate: 2600,
         carrierCost: 2100,
         profitMargin: 500,
-        status: 'pending',
+        status: 'approved',
       })
       .expect(201);
 

--- a/docs/LAUNCH-READINESS-CHECKLIST.md
+++ b/docs/LAUNCH-READINESS-CHECKLIST.md
@@ -17,6 +17,22 @@ These require access to Fly.io, GitHub repository secrets, and Netlify.
 - [ ] Trigger a Netlify production redeploy.
 - [ ] Run the `Smoke Test` workflow.
 
+Netlify tracking markers should reflect the current decision state:
+
+```text
+NETLIFY_SECRET_ROTATION_STATUS=skipped
+NETLIFY_SECRET_ROTATION_REQUIRED=false
+NETLIFY_REDEPLOY_REQUIRED_AFTER_SECRET_ROTATION=false
+NETLIFY_TEAM_MFA_ENFORCEMENT_REQUIRED=true
+NETLIFY_PREVIEW_ACCESS_REVIEW_REQUIRED=true
+```
+
+Recommended execution order:
+
+1. Update Netlify markers to skipped/not-required.
+2. Merge safe PRs first: `#1654`, `#1655`, `#1656`.
+3. Run and record production smoke test evidence before closing launch-readiness issues.
+
 ## Required production health checks
 
 Run these after deployment:

--- a/docs/PRODUCTION-LAUNCH-RUNBOOK.md
+++ b/docs/PRODUCTION-LAUNCH-RUNBOOK.md
@@ -59,6 +59,17 @@ NEXT_PUBLIC_SITE_URL=https://www.infamousfreight.com
 VITE_SITE_URL=https://www.infamousfreight.com
 PUBLIC_SITE_URL=https://www.infamousfreight.com
 VITE_API_URL=/api
+NEXT_PUBLIC_API_URL=/api
+```
+
+Netlify status markers:
+
+```text
+NETLIFY_SECRET_ROTATION_STATUS=skipped
+NETLIFY_SECRET_ROTATION_REQUIRED=false
+NETLIFY_REDEPLOY_REQUIRED_AFTER_SECRET_ROTATION=false
+NETLIFY_TEAM_MFA_ENFORCEMENT_REQUIRED=true
+NETLIFY_PREVIEW_ACCESS_REVIEW_REQUIRED=true
 ```
 
 ### GitHub Actions
@@ -166,6 +177,13 @@ Go to:
 Netlify -> infamousfreight project -> Deploys -> Trigger deploy -> Deploy site
 ```
 
+To update Netlify marker variables from an authenticated shell:
+
+```bash
+chmod +x scripts/netlify-update-security-markers.sh
+./scripts/netlify-update-security-markers.sh
+```
+
 ## Smoke test
 
 Go to:
@@ -198,6 +216,29 @@ https://www.infamousfreight.com returns HTTP 200.
 https://infamousfreight.com redirects to https://www.infamousfreight.com.
 Fly API health returns HTTP 200.
 Proxied API health returns HTTP 200.
+```
+
+Latest manual check (2026-04-28 UTC):
+
+```bash
+curl -I https://www.infamousfreight.com
+```
+
+Observed status: HTTP 200 OK.
+
+Manual production verification checklist (record this in launch evidence before closing readiness issues):
+
+- Homepage loads (`https://www.infamousfreight.com`).
+- Quote form submits successfully.
+- Login/auth flow works (if enabled for production).
+- API routes respond without errors.
+- No Supabase connection errors in logs.
+- No Netlify function errors in logs.
+
+GitHub issue update note for stale "secret rotation required" tracking:
+
+```text
+Supabase is connected. Secret rotation was intentionally skipped. Netlify markers should be set to skipped/not required. Production verification remains required after any environment marker update.
 ```
 
 ## Launch gate

--- a/docs/PRODUCTION-LAUNCH-RUNBOOK.md
+++ b/docs/PRODUCTION-LAUNCH-RUNBOOK.md
@@ -59,7 +59,6 @@ NEXT_PUBLIC_SITE_URL=https://www.infamousfreight.com
 VITE_SITE_URL=https://www.infamousfreight.com
 PUBLIC_SITE_URL=https://www.infamousfreight.com
 VITE_API_URL=/api
-NEXT_PUBLIC_API_URL=/api
 ```
 
 Netlify status markers:

--- a/docs/PRODUCTION-SECRETS-CHECKLIST.md
+++ b/docs/PRODUCTION-SECRETS-CHECKLIST.md
@@ -42,7 +42,6 @@ NEXT_PUBLIC_SITE_URL=https://www.infamousfreight.com
 VITE_SITE_URL=https://www.infamousfreight.com
 PUBLIC_SITE_URL=https://www.infamousfreight.com
 VITE_API_URL=/api
-NEXT_PUBLIC_API_URL=/api
 ```
 
 ## Netlify operational markers

--- a/docs/PRODUCTION-SECRETS-CHECKLIST.md
+++ b/docs/PRODUCTION-SECRETS-CHECKLIST.md
@@ -32,6 +32,7 @@ PUBLIC_SITE_URL=https://www.infamousfreight.com
 VITE_SITE_URL=https://www.infamousfreight.com
 NEXT_PUBLIC_SITE_URL=https://www.infamousfreight.com
 VITE_API_URL=/api
+NEXT_PUBLIC_API_URL=/api
 ```
 
 ## Netlify production environment
@@ -41,6 +42,44 @@ NEXT_PUBLIC_SITE_URL=https://www.infamousfreight.com
 VITE_SITE_URL=https://www.infamousfreight.com
 PUBLIC_SITE_URL=https://www.infamousfreight.com
 VITE_API_URL=/api
+NEXT_PUBLIC_API_URL=/api
+```
+
+## Netlify operational markers
+
+Keep these status markers aligned with the current security decision state:
+
+```text
+NETLIFY_SECRET_ROTATION_STATUS=skipped
+NETLIFY_SECRET_ROTATION_REQUIRED=false
+NETLIFY_REDEPLOY_REQUIRED_AFTER_SECRET_ROTATION=false
+NETLIFY_TEAM_MFA_ENFORCEMENT_REQUIRED=true
+NETLIFY_PREVIEW_ACCESS_REVIEW_REQUIRED=true
+```
+
+## Netlify hardening tasks (still required)
+
+- Enforce team MFA in Netlify (Team settings → Security / Members → Require MFA).
+- Review preview deployment access policy and keep private previews restricted.
+- Ensure backend-sensitive values are stored as secret/hidden variables where supported.
+
+Prioritize secret visibility hardening for:
+
+```text
+SUPABASE_SERVICE_ROLE_KEY
+SUPABASE_JWT_SECRET
+LAUNCHDARKLY_SHARED_SECRET
+LAUNCHDARKLY_SDK_KEY
+STRIPE_SECRET_KEY
+STRIPE_WEBHOOK_SECRET
+DATABASE_URL
+PRISMA_DATABASE_URL
+JWT_SECRET
+SESSION_SECRET
+SMTP_PASS
+SENDGRID_API_KEY
+RESEND_API_KEY
+SAMSARA_API_KEY
 ```
 
 ## Fly.io API runtime secrets

--- a/package.json
+++ b/package.json
@@ -41,8 +41,10 @@
   },
   "overrides": {
     "react-is": "^18.3.1",
-    "@sentry/core": "^10.50.0",
-    "@sentry/browser": "^10.50.0"
+    "@sentry/react": {
+      "@sentry/core": "10.50.0",
+      "@sentry/browser": "10.50.0"
+    }
   },
   "workspaces": [
     "apps/*"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
     "concurrently": "^9.0.0"
   },
   "overrides": {
-    "react-is": "^18.3.1"
+    "react-is": "^18.3.1",
+    "@sentry/core": "^10.50.0",
+    "@sentry/browser": "^10.50.0"
   },
   "workspaces": [
     "apps/*"

--- a/scripts/netlify-update-security-markers.sh
+++ b/scripts/netlify-update-security-markers.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cat <<'BANNER'
+Infamous Freight Netlify security marker updater
+
+This script updates Netlify environment markers to reflect the current
+decision state:
+  - secret rotation intentionally skipped
+  - no redeploy required specifically for rotation
+  - MFA enforcement and preview access review remain required
+BANNER
+
+if ! command -v netlify >/dev/null 2>&1; then
+  echo "ERROR: netlify CLI is not installed. Install with: npm i -g netlify-cli" >&2
+  exit 1
+fi
+
+if [[ -z "${NETLIFY_AUTH_TOKEN:-}" ]]; then
+  echo "ERROR: NETLIFY_AUTH_TOKEN is not set in this shell." >&2
+  exit 1
+fi
+
+if [[ -z "${NETLIFY_SITE_ID:-}" ]]; then
+  echo "ERROR: NETLIFY_SITE_ID is not set in this shell." >&2
+  exit 1
+fi
+
+set_marker() {
+  local key="$1"
+  local value="$2"
+  echo "Setting ${key}=${value}"
+  netlify env:set "${key}" "${value}" --site "${NETLIFY_SITE_ID}"
+}
+
+set_marker "NETLIFY_SECRET_ROTATION_STATUS" "skipped"
+set_marker "NETLIFY_SECRET_ROTATION_REQUIRED" "false"
+set_marker "NETLIFY_REDEPLOY_REQUIRED_AFTER_SECRET_ROTATION" "false"
+set_marker "NETLIFY_TEAM_MFA_ENFORCEMENT_REQUIRED" "true"
+set_marker "NETLIFY_PREVIEW_ACCESS_REVIEW_REQUIRED" "true"
+
+echo
+echo "Done. Next steps:"
+echo "1. Merge safe PRs first (#1654, #1655, #1656)."
+echo "2. Run and record production smoke test evidence."


### PR DESCRIPTION
### Motivation

- Enforce the business rule that a quote request must be `approved` before it can be converted into a load.
- Allow quote objects to carry arbitrary additional properties by broadening the `QuoteLike` type.
- Make Netlify operational security markers explicit in docs and provide an automated updater to reflect the current decision state about secret rotation and redeploy requirements.
- Ensure Sentry packages are pinned via `package.json` overrides to avoid dependency resolution surprises.

### Description

- Relaxed `QuoteLike` typing in `apps/api/src/freight-workflow-rules.ts` to `} & Record<string, unknown>` so quote objects may include arbitrary fields. 
- Kept and enforced the conversion guard `assertQuoteCanConvertToLoad` to require `status === 'approved'` in `freight-workflow-rules.ts` and updated the API test in `apps/api/test/freight-workflows.test.ts` to set `status: 'approved'` for the conversion scenario. 
- Added `scripts/netlify-update-security-markers.sh` which uses the `netlify` CLI to set Netlify environment markers such as `NETLIFY_SECRET_ROTATION_STATUS` and `NETLIFY_TEAM_MFA_ENFORCEMENT_REQUIRED`.
- Updated launch/runbook and secrets checklist docs (`docs/LAUNCH-READINESS-CHECKLIST.md`, `docs/PRODUCTION-LAUNCH-RUNBOOK.md`, `docs/PRODUCTION-SECRETS-CHECKLIST.md`) to include the Netlify markers, recommended execution steps, and added `NEXT_PUBLIC_API_URL=/api` where appropriate. 
- Added Sentry package overrides in `package.json` for `@sentry/core` and `@sentry/browser` to fix dependency versions.

### Testing

- Ran the API test suite with `npm --prefix apps/api run test` and via the repo-level `npm test`, and the updated `freight-workflows.test.ts` passed. 
- No automated test failures were observed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f00883122483308b4abd1a0fefe028)