### PR TITLE
Add Sentry observability env vars and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,9 @@ PORT=3001
 JWT_SECRET=your-super-secret-jwt-key-change-this-in-production
 API_RATE_LIMIT_ENABLED=true
 
+# ——— Observability ———
+SENTRY_DSN=https://<public-key>@o<org>.ingest.us.sentry.io/<project-id>
+
 # ——— Stripe ———
 STRIPE_SECRET_KEY=sk_test_...
 STRIPE_WEBHOOK_SECRET=whsec_...

--- a/.env.production
+++ b/.env.production
@@ -32,3 +32,6 @@ WEB_URL=https://infamousfreight.com
 
 # Email (managed by Fly.io secrets)
 # SENDGRID_API_KEY=...
+
+# Observability (managed by Fly.io secrets)
+# SENTRY_DSN=https://<public-key>@o<org>.ingest.us.sentry.io/<project-id>

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Public requests for `*.map` files are blocked (`404`). Sourcemaps are still uplo
 
 | Variable | Purpose | Required |
 |---|---|---|
+| `SENTRY_DSN` | Sentry DSN for the API runtime (`apps/api`) | No |
 | `VITE_SENTRY_DSN` | Sentry DSN for the web app | No |
 | `VITE_SENTRY_ENABLED` | Set to `false` to disable even when DSN is set | No |
 | `SENTRY_AUTH_TOKEN` | CI secret for sourcemap upload | No |

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -2,3 +2,6 @@
 # The Prisma config also loads ../../.env by default.
 
 DATABASE_URL=postgresql://postgres:[YOUR-PASSWORD]@db.wnaievjffghrztjuvutp.supabase.co:5432/postgres
+
+# Optional: API runtime error tracking
+SENTRY_DSN=https://<public-key>@o<org>.ingest.us.sentry.io/<project-id>

--- a/apps/web/.env.production
+++ b/apps/web/.env.production
@@ -20,3 +20,7 @@ VITE_ENABLE_VOICE=true
 VITE_ENABLE_AUCTION=true
 VITE_ENABLE_ANALYTICS=true
 VITE_APP_VERSION=1.0.0
+
+# Observability
+VITE_SENTRY_DSN=https://<public-key>@o<org>.ingest.us.sentry.io/<project-id>
+VITE_SENTRY_ENABLED=true


### PR DESCRIPTION
### Motivation

- Provide first-class observability configuration examples for Sentry across the repo so developers can enable error monitoring for API and web runtime. 
- Surface Sentry-related production configuration as managed secrets to avoid leaking credentials in repo files. 

### Description

- Added `SENTRY_DSN` to the project root `/.env.example` as an optional Observability variable and to `apps/api/.env.example` for API runtime error tracking. 
- Added commented `SENTRY_DSN` lines under Observability in `/.env.production` to indicate the value is managed by Fly.io secrets. 
- Added `VITE_SENTRY_DSN` and `VITE_SENTRY_ENABLED` to `apps/web/.env.production` so the frontend can be configured to send errors to Sentry. 
- Updated `README.md` optional environment variables table to list `SENTRY_DSN` for the API runtime along with existing web Sentry vars. 

### Testing

- No automated tests were modified or required for these documentation and example environment changes. 
- No CI or automated test runs were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f13b645100833085e93a4d586c8c03)