### PR TITLE
Add robust tooltip formatting, enhance Supabase realtime hook, and update ProductHunt share icons

### DIFF
--- a/apps/web/src/components/DynamicPricing.tsx
+++ b/apps/web/src/components/DynamicPricing.tsx
@@ -94,7 +94,11 @@ const DynamicPricing: React.FC<DynamicPricingProps> = ({ origin = 'Chicago, IL',
             <YAxis domain={['auto', 'auto']} stroke="#555" fontSize={12} tickFormatter={(v) => `$${v}`} />
             <Tooltip
               contentStyle={{ background: '#1a1a1a', border: '1px solid #333', borderRadius: '8px', fontSize: '12px' }}
-              formatter={(value: number) => [`$${value.toFixed(2)}`, 'Rate/Mile']}
+              formatter={(value) => {
+                const parsedValue = typeof value === 'number' ? value : Number(value ?? 0);
+                const numericValue = Number.isFinite(parsedValue) ? parsedValue : 0;
+                return [`$${numericValue.toFixed(2)}`, 'Rate/Mile'];
+              }}
             />
             <ReferenceLine y={marketAvg} stroke="#555" strokeDasharray="3 3" label={{ value: 'Avg', fill: '#888', fontSize: 10 }} />
             <Line type="monotone" dataKey="rate" stroke="#ff3d00" strokeWidth={2} dot={{ fill: '#ff3d00', r: 4 }} activeDot={{ r: 6 }} />

--- a/apps/web/src/hooks/useSupabase.ts
+++ b/apps/web/src/hooks/useSupabase.ts
@@ -144,18 +144,65 @@ export function useSupabaseStorage() {
   return { uploadFile, getPublicUrl, deleteFile };
 }
 
-export function useSupabaseRealtime(channel: string, event: string, callback: (payload: unknown) => void) {
+type RealtimeDbEvent = 'INSERT' | 'UPDATE' | 'DELETE' | '*';
+
+type SupabaseRealtimeOptions = {
+  channel: string;
+  table: string;
+  callback: (payload: unknown) => void;
+  schema?: string;
+  event?: RealtimeDbEvent;
+  /**
+   * Supabase Postgres changes filter expression, e.g. `tenantId=eq.<tenant-id>`.
+   * Prefer tenant-scoped filters to avoid cross-tenant realtime events.
+   */
+  filter?: string;
+};
+
+function normalizeRealtimeOptions(
+  optionsOrChannel: SupabaseRealtimeOptions | string,
+  tableOrEvent?: string,
+  callback?: (payload: unknown) => void
+): SupabaseRealtimeOptions {
+  if (typeof optionsOrChannel === 'string') {
+    if (!tableOrEvent || !callback) {
+      throw new Error('useSupabaseRealtime legacy signature requires channel, table, and callback.');
+    }
+
+    return {
+      channel: optionsOrChannel,
+      table: tableOrEvent,
+      callback,
+    };
+  }
+
+  return optionsOrChannel;
+}
+
+export function useSupabaseRealtime(options: SupabaseRealtimeOptions): void;
+export function useSupabaseRealtime(channel: string, table: string, callback: (payload: unknown) => void): void;
+export function useSupabaseRealtime(
+  optionsOrChannel: SupabaseRealtimeOptions | string,
+  tableOrEvent?: string,
+  callbackArg?: (payload: unknown) => void
+) {
+  const { channel, table, callback, schema = 'public', event = '*', filter } = normalizeRealtimeOptions(
+    optionsOrChannel,
+    tableOrEvent,
+    callbackArg
+  );
+
   useEffect(() => {
     const supabase = getSupabase();
     const sub = supabase
       .channel(channel)
-      .on('postgres_changes', { event: '*', schema: 'public', table: event }, callback)
+      .on('postgres_changes', { event, schema, table, filter }, callback)
       .subscribe();
 
     return () => {
-      sub.unsubscribe();
+      void sub.unsubscribe();
     };
-  }, [channel, event, callback]);
+  }, [callback, channel, event, filter, schema, table]);
 }
 
 export { getSupabase };

--- a/apps/web/src/pages/ProductHunt.tsx
+++ b/apps/web/src/pages/ProductHunt.tsx
@@ -4,7 +4,7 @@
  */
 import { useEffect } from 'react';
 import { motion } from 'framer-motion';
-import { ArrowUpRight, MessageSquare, Twitter, Linkedin, Users, TrendingUp, Zap } from 'lucide-react';
+import { ArrowUpRight, MessageSquare, Send, Share2, Users, TrendingUp, Zap } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
 export default function ProductHunt() {
@@ -161,7 +161,7 @@ export default function ProductHunt() {
               rel="noopener noreferrer"
               className="flex items-center gap-2 bg-zinc-900 border border-zinc-800 rounded-lg px-4 py-2 hover:bg-zinc-800 transition-colors"
             >
-              <Twitter className="h-4 w-4" />
+              <Send className="h-4 w-4" />
               <span className="text-sm">Tweet</span>
             </a>
             <a 
@@ -170,7 +170,7 @@ export default function ProductHunt() {
               rel="noopener noreferrer"
               className="flex items-center gap-2 bg-zinc-900 border border-zinc-800 rounded-lg px-4 py-2 hover:bg-zinc-800 transition-colors"
             >
-              <Linkedin className="h-4 w-4" />
+              <Share2 className="h-4 w-4" />
               <span className="text-sm">Share</span>
             </a>
           </div>


### PR DESCRIPTION
### Motivation

- Prevent runtime errors in charts when tooltip values are not numeric and provide a safe fallback formatting. 
- Make the Supabase realtime hook more flexible and type-safe by supporting a structured options object, scoped filters, and explicit schema/event configuration. 
- Update the Product Hunt landing share buttons to use replacement icons that better match the intended actions.

### Description

- Updated the chart `Tooltip` formatter in `DynamicPricing.tsx` to safely parse values, ensure finite numbers, and fallback to `0` for non-numeric inputs before formatting. 
- Reworked `useSupabaseRealtime` in `useSupabase.ts` to introduce `RealtimeDbEvent` and `SupabaseRealtimeOptions` types, added a `normalizeRealtimeOptions` helper to support both legacy and options-object signatures, and extended the subscription to accept `schema` and `filter` parameters. 
- Adjusted the `useEffect` dependency list and used `void sub.unsubscribe()` on cleanup to satisfy linting/type rules. 
- Replaced `Twitter`/`Linkedin` icons with `Send`/`Share2` in `ProductHunt.tsx` and updated imports to reflect the icon changes.

### Testing

- Ran TypeScript type-check with `tsc --noEmit`, which completed successfully. 
- Ran ESLint (`yarn lint`), which returned no new errors. 
- Performed a local dev build/smoke start, and the affected pages rendered without runtime errors in the tested flows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f13d87ae688330bf2535ca4a3d28ed)