### PR TITLE
chore(api): enable isolatedModules in tsconfig

### DIFF
--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "node",
     "strict": true,
     "esModuleInterop": true,
+    "isolatedModules": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "outDir": "dist",


### PR DESCRIPTION
### Motivation
- Enable `isolatedModules` in the API TypeScript config to catch non‑emit-friendly constructs early and align the backend with isolated-module transpilation expectations.

### Description
- Added `"isolatedModules": true` to `apps/api/tsconfig.json` under `compilerOptions` to enforce isolated module compilation behavior for the API project.

### Testing
- Verified the change by inspecting the file with `git status --short && nl -ba apps/api/tsconfig.json | sed -n '1,80p'`, which confirmed the new option is present; no automated test suites were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f159c91fcc833090853ba7da023a65)