### PR TITLE
Enhance Fly deployment workflow: add pnpm/Node build, Docker build, schedule, and health check

### DIFF
--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -1,4 +1,4 @@
-name: Deploy Fly API
+name: Deploy Infamous Freight
 
 on:
   workflow_dispatch:
@@ -8,7 +8,13 @@ on:
       - Dockerfile
       - fly.toml
       - apps/api/**
+      - prisma/**
+      - package.json
+      - pnpm-lock.yaml
+      - pnpm-workspace.yaml
       - .github/workflows/deploy-fly.yml
+  schedule:
+    - cron: '0 0 * * *'
 
 concurrency:
   group: fly-api-production
@@ -19,62 +25,65 @@ permissions:
 
 jobs:
   deploy:
-    name: Deploy API to Fly.io
+    name: Build and deploy API to Fly.io
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    permissions:
-      contents: read
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: pnpm
 
       - name: Validate required secrets
         run: |
           set -euo pipefail
           if [ -z "${FLY_API_TOKEN:-}" ]; then
             echo "ERROR: GitHub Actions secret FLY_API_TOKEN is missing."
-            echo "Add the rotated Fly deploy token at: Repository Settings -> Secrets and variables -> Actions."
             exit 1
           fi
-          echo "Required Fly deploy secret is present."
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
-      - name: Set up flyctl
-        uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1  # master (2026-04-08)
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
-      - name: Deploy API
+      - name: Prisma Generate
+        run: pnpm --filter @infamous-freight/api prisma:generate
+
+      - name: Build API
+        run: pnpm --filter @infamous-freight/api build
+
+      - name: Build Docker image
+        run: docker build -f Dockerfile -t infamous-freight:ci .
+
+      - name: Setup Flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master (2026-04-08)
+
+      - name: Deploy to Fly
         run: flyctl deploy --remote-only --app infamous-freight
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
-      - name: Verify Fly root health endpoint
-        run: |
-          set -euo pipefail
-          for attempt in {1..18}; do
-            if curl --fail --show-error --silent https://infamous-freight.fly.dev/health; then
-              echo "Fly root health check passed"
-              exit 0
-            fi
-            echo "Root health check attempt ${attempt} failed; retrying in 10 seconds..."
-            sleep 10
-          done
-          echo "Fly root health check failed"
-          exit 1
-
-      - name: Verify Fly API health endpoint
+      - name: Verify deployment health
         run: |
           set -euo pipefail
           for attempt in {1..18}; do
             if curl --fail --show-error --silent https://infamous-freight.fly.dev/api/health; then
-              echo "Fly API health check passed"
+              echo "Health check passed"
               exit 0
             fi
-            echo "API health check attempt ${attempt} failed; retrying in 10 seconds..."
+            echo "Health check attempt ${attempt} failed; retrying in 10 seconds..."
             sleep 10
           done
-          echo "Fly API health check failed"
+          echo "Health check failed"
           exit 1
-
-# Deployment retrigger after workflow route TypeScript fix.

--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -10,6 +10,7 @@ on:
       - apps/api/**
       - prisma/**
       - package.json
+      - package-lock.json
       - pnpm-lock.yaml
       - pnpm-workspace.yaml
       - .github/workflows/deploy-fly.yml

--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@c3e6b5a9d4d7cb3a9635f0b2f7f6f691f4c8a1e2 # v4
         with:
           version: 10
 


### PR DESCRIPTION
### Motivation

- Rename and generalize the workflow for the `infamous-freight` service and ensure builds run reliably before deploy.  
- Expand path triggers to include `prisma`, `package.json`, and pnpm lock/workspace files so schema/dependency changes trigger the workflow.  
- Add scheduled runs and explicit build steps to run `pnpm` installs, generate Prisma client, and produce a Docker image prior to deployment.

### Description

- Renamed the workflow to `Deploy Infamous Freight` and updated the job name to `Build and deploy API to Fly.io`.  
- Added a daily `schedule` trigger and expanded `paths` to include `prisma/**`, `package.json`, `pnpm-lock.yaml`, and `pnpm-workspace.yaml`.  
- Added `pnpm` and Node setup steps, an `Install dependencies` step (`pnpm install --frozen-lockfile`), `Prisma Generate` (`pnpm --filter @infamous-freight/api prisma:generate`), and `Build API` (`pnpm --filter @infamous-freight/api build`).  
- Added a Docker build step (`docker build -f Dockerfile -t infamous-freight:ci .`), moved `flyctl` setup after image build, and run deploy with `flyctl deploy --remote-only --app infamous-freight`.  
- Simplified the post-deploy health verification to a single `Verify deployment health` step that checks `https://infamous-freight.fly.dev/api/health` and removed the previous root health check and some redundant workflow permissions/comments.

### Testing

- No automated tests were executed as part of this PR; the updated GitHub Actions workflow includes a post-deploy health check that will run on future deployments and validate the service endpoint.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f191d71e44833099d5aa8cd5958bb4)