### PR TITLE
Migrate CI to pnpm, add environment docs, and standardize API scripts/port

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -28,21 +28,24 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
+          cache: 'pnpm'
+
+      - name: Enable corepack
+        run: corepack enable
 
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Lint
-        run: npm run lint
+        run: pnpm run lint
 
       - name: Type check
         run: |
-          npx tsc -p apps/api/tsconfig.json --noEmit
-          npx tsc -p apps/web/tsconfig.json --noEmit
+          pnpm -C apps/api exec tsc -p tsconfig.json --noEmit
+          pnpm -C apps/web exec tsc -p tsconfig.json --noEmit
 
       - name: Test
-        run: npm --prefix apps/api run test:coverage
+        run: pnpm -C apps/api run test:coverage
 
   # ===== BUILD API =====
   build-api:
@@ -60,12 +63,15 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
+          cache: 'pnpm'
+
+      - name: Enable corepack
+        run: corepack enable
 
       - name: Install & Build
         run: |
-          npm ci
-          npm run build:api
+          pnpm install --frozen-lockfile
+          pnpm run build:api
 
       - name: Set lowercase image name
         run: echo "IMAGE_LOWER=$(echo '${{ env.IMAGE_NAME }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV

--- a/README.md
+++ b/README.md
@@ -122,6 +122,14 @@ npm run build
 npm run test
 ```
 
+## 🔐 Environment References
+
+For deployment-ready variable setup, use:
+
+- `docs/environment/ENVIRONMENT_VARIABLES_COMPLETE.md` (full reference + verification)
+- `docs/environment/CODEX_ENV_VARIABLES.txt` (quick copy/paste template)
+- `docs/environment/README.md` (usage notes)
+
 ---
 
 ## 🧰 Git Remote Troubleshooting
@@ -181,6 +189,8 @@ Public requests for `*.map` files are blocked (`404`). Sourcemaps are still uplo
 ## 🚀 Deployment
 
 ### GitHub Actions CI/CD
+
+CI uses pnpm workspace-native commands (`pnpm install --frozen-lockfile`, `pnpm -C apps/api run test:coverage`, `pnpm run build:api`) to keep lockfile behavior and workspace execution consistent across local and GitHub environments.
 
 Add these secrets to your GitHub repository:
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,13 +9,13 @@
   },
   "type": "commonjs",
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "pnpm run prisma:generate && tsc -p tsconfig.json",
     "start:dev": "tsx watch src/server.ts",
     "start:prod": "node dist/src/server.js",
-    "test": "jest --runInBand",
-    "test:coverage": "jest --coverage --runInBand",
+    "test": "node scripts/run-jest.cjs",
+    "test:coverage": "node scripts/run-jest.cjs --coverage",
     "lint": "tsc -p tsconfig.json --noEmit",
-    "prisma:generate": "npx prisma generate"
+    "prisma:generate": "pnpm exec prisma generate"
   },
   "dependencies": {
     "@prisma/client": "6.15.0",

--- a/apps/api/scripts/run-jest.cjs
+++ b/apps/api/scripts/run-jest.cjs
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+const { spawnSync } = require('node:child_process');
+
+const rawArgs = process.argv.slice(2);
+const filteredArgs = rawArgs.filter((arg) => arg !== '--');
+
+const hasRunInBand = filteredArgs.includes('--runInBand');
+const jestArgs = hasRunInBand ? filteredArgs : ['--runInBand', ...filteredArgs];
+
+const jestBin = require.resolve('jest/bin/jest');
+const result = spawnSync(process.execPath, [jestBin, ...jestArgs], {
+  stdio: 'inherit',
+});
+
+if (typeof result.status === 'number') {
+  process.exit(result.status);
+}
+
+process.exit(1);

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -28,7 +28,7 @@ async function bootstrap() {
   // API prefix
   app.setGlobalPrefix('api');
 
-  const port = process.env.PORT || 3001;
+  const port = process.env.PORT || 3000;
   await app.listen(port);
 
   console.log(`

--- a/docs/environment/CODEX_ENV_VARIABLES.txt
+++ b/docs/environment/CODEX_ENV_VARIABLES.txt
@@ -1,0 +1,31 @@
+# Codex quick-reference environment variables
+# Backend
+NODE_ENV=production
+PORT=3000
+DATABASE_URL=postgresql://user:password@host:5432/infamous_freight
+CORS_ORIGINS=https://www.infamousfreight.com,https://app.infamousfreight.com
+WEB_APP_URL=https://www.infamousfreight.com
+STRIPE_SECRET_KEY=sk_live_YOUR_KEY
+STRIPE_WEBHOOK_SECRET=whsec_YOUR_SECRET
+STRIPE_CHECKOUT_SUCCESS_URL=https://www.infamousfreight.com/billing/success
+STRIPE_CHECKOUT_CANCEL_URL=https://www.infamousfreight.com/billing/cancel
+STRIPE_PORTAL_RETURN_URL=https://www.infamousfreight.com/billing
+SUPABASE_URL=https://YOUR_PROJECT.supabase.co
+SUPABASE_SERVICE_KEY=YOUR_SERVICE_KEY
+REDIS_HOST=redis.infamousfreight.com
+REDIS_PORT=6379
+REDIS_PASSWORD=YOUR_PASSWORD
+REDIS_DB=0
+DAT_API_KEY=YOUR_KEY
+TRUCKSTOP_API_KEY=YOUR_KEY
+LOADBOARD_API_KEY=YOUR_KEY
+SAMSARA_API_TOKEN=YOUR_TOKEN
+SENTRY_DSN=https://YOUR_KEY@sentry.io/ID
+API_RATE_LIMIT_ENABLED=true
+
+# Frontend
+VITE_API_URL=https://api.infamousfreight.com
+VITE_SUPABASE_URL=https://YOUR_PROJECT.supabase.co
+VITE_SUPABASE_PUBLISHABLE_KEY=YOUR_PUBLISHABLE_KEY
+VITE_SUPABASE_ANON_KEY=YOUR_ANON_KEY
+VITE_SENTRY_DSN=https://YOUR_KEY@sentry.io/ID

--- a/docs/environment/ENVIRONMENT_VARIABLES_COMPLETE.md
+++ b/docs/environment/ENVIRONMENT_VARIABLES_COMPLETE.md
@@ -1,0 +1,97 @@
+# Infamous Freight Environment Variables (Complete)
+
+## Backend (apps/api)
+
+| Variable | Required | Description |
+|---|---:|---|
+| NODE_ENV | Yes | Runtime mode (`production` in deploy). |
+| PORT | Yes | API bind port (`3000` in production, `3001` local default). |
+| DATABASE_URL | Yes | PostgreSQL connection string for Prisma. |
+| CORS_ORIGINS | Yes | Comma-separated allowed origins. |
+| WEB_APP_URL | Yes | Canonical frontend URL used by API flows. |
+| STRIPE_SECRET_KEY | Yes | Stripe server-side secret key. |
+| STRIPE_WEBHOOK_SECRET | Yes | Stripe webhook signing secret. |
+| STRIPE_CHECKOUT_SUCCESS_URL | Yes | Success redirect URL for checkout. |
+| STRIPE_CHECKOUT_CANCEL_URL | Yes | Cancel redirect URL for checkout. |
+| STRIPE_PORTAL_RETURN_URL | Yes | Return URL for Stripe customer portal. |
+| SUPABASE_URL | Yes | Supabase project URL. |
+| SUPABASE_SERVICE_KEY | Yes | Supabase service role key (server only). |
+| REDIS_HOST | Yes | Redis host. |
+| REDIS_PORT | Yes | Redis port (typically `6379`). |
+| REDIS_PASSWORD | Yes | Redis password. |
+| REDIS_DB | Yes | Redis DB index (typically `0`). |
+| DAT_API_KEY | Yes | DAT loadboard API key. |
+| TRUCKSTOP_API_KEY | Yes | Truckstop API key. |
+| LOADBOARD_API_KEY | Yes | Alternate/general loadboard API key. |
+| SAMSARA_API_TOKEN | Yes | Samsara API token. |
+| SENTRY_DSN | Optional | Backend Sentry DSN. |
+| API_RATE_LIMIT_ENABLED | Yes | Enables API rate limiting (`true`/`false`). |
+
+## Frontend (apps/web)
+
+| Variable | Required | Description |
+|---|---:|---|
+| VITE_API_URL | Yes | Public API base URL. |
+| VITE_SUPABASE_URL | Yes | Supabase project URL for client SDK. |
+| VITE_SUPABASE_PUBLISHABLE_KEY | Yes | Supabase publishable key for frontend. |
+| VITE_SUPABASE_ANON_KEY | Optional | Backward-compatible anon key for older frontend setups. |
+| VITE_SENTRY_DSN | Optional | Frontend Sentry DSN. |
+
+## Secrets (do not commit)
+
+Set these in secret stores (CI/Fly/Codex secrets), not tracked files:
+
+- `NPM_TOKEN`
+- `GITHUB_TOKEN`
+- `PRIVATE_REGISTRY_TOKEN`
+
+Use `PORT=3001` locally only if your development setup runs the API on 3001.
+
+## Example values template
+
+```env
+NODE_ENV=production
+PORT=3000
+DATABASE_URL=postgresql://user:password@host:5432/infamous_freight
+CORS_ORIGINS=https://www.infamousfreight.com,https://app.infamousfreight.com
+WEB_APP_URL=https://www.infamousfreight.com
+STRIPE_SECRET_KEY=sk_live_YOUR_KEY
+STRIPE_WEBHOOK_SECRET=whsec_YOUR_SECRET
+STRIPE_CHECKOUT_SUCCESS_URL=https://www.infamousfreight.com/billing/success
+STRIPE_CHECKOUT_CANCEL_URL=https://www.infamousfreight.com/billing/cancel
+STRIPE_PORTAL_RETURN_URL=https://www.infamousfreight.com/billing
+SUPABASE_URL=https://YOUR_PROJECT.supabase.co
+SUPABASE_SERVICE_KEY=YOUR_SERVICE_KEY
+REDIS_HOST=redis.infamousfreight.com
+REDIS_PORT=6379
+REDIS_PASSWORD=YOUR_PASSWORD
+REDIS_DB=0
+DAT_API_KEY=YOUR_KEY
+TRUCKSTOP_API_KEY=YOUR_KEY
+LOADBOARD_API_KEY=YOUR_KEY
+SAMSARA_API_TOKEN=YOUR_TOKEN
+SENTRY_DSN=https://YOUR_KEY@sentry.io/ID
+API_RATE_LIMIT_ENABLED=true
+VITE_API_URL=https://api.infamousfreight.com
+VITE_SUPABASE_URL=https://YOUR_PROJECT.supabase.co
+VITE_SUPABASE_PUBLISHABLE_KEY=YOUR_PUBLISHABLE_KEY
+VITE_SUPABASE_ANON_KEY=YOUR_ANON_KEY
+VITE_SENTRY_DSN=https://YOUR_KEY@sentry.io/ID
+```
+
+## Verification commands
+
+```bash
+test -n "$NODE_ENV" && echo "✓ NODE_ENV is set"
+test -n "$DATABASE_URL" && echo "✓ DATABASE_URL is set"
+test -n "$STRIPE_SECRET_KEY" && echo "✓ STRIPE_SECRET_KEY is set"
+printenv | sort
+```
+
+
+## Source of truth templates
+
+For exact local/dev defaults and additional optional integrations, reference:
+
+- Root API template: `.env.example`
+- Web template: `apps/web/.env.example`

--- a/docs/environment/README.md
+++ b/docs/environment/README.md
@@ -1,0 +1,6 @@
+# Environment Configuration Docs
+
+- `ENVIRONMENT_VARIABLES_COMPLETE.md`: full backend/frontend variable reference, security notes, and verification commands.
+- `CODEX_ENV_VARIABLES.txt`: quick copy/paste template for Codex environment setup.
+
+These files intentionally use placeholder values only. Do not commit real credentials.


### PR DESCRIPTION
### Motivation

- Switch GitHub Actions to a pnpm-first workflow to keep lockfile and workspace execution consistent across local and CI environments. 
- Provide clear, deploy-ready environment variable references for backend and frontend in repo documentation. 
- Ensure API build and test steps run necessary generation and consistent Jest flags, and align the runtime port to production defaults.

### Description

- Updated `.github/workflows/ci-cd.yml` to use `pnpm` caching, run `corepack enable`, install with `pnpm install --frozen-lockfile`, and invoke lint/typecheck/tests with `pnpm` (e.g. `pnpm -C apps/api run test:coverage`).
- Added `corepack enable` steps to workflow to ensure `pnpm` is available in the Actions environment. 
- Modified `apps/api/package.json` so `build` runs `pnpm run prisma:generate && tsc`, `test`/`test:coverage` call `node scripts/run-jest.cjs`, and `prisma:generate` uses `pnpm exec prisma generate`.
- Added `apps/api/scripts/run-jest.cjs` which wraps Jest to ensure `--runInBand` is always included when running tests.
- Changed API default port in `apps/api/src/main.ts` from `3001` to `3000` and updated the startup message to reflect the port and environment.
- Added environment documentation under `docs/environment/` including `ENVIRONMENT_VARIABLES_COMPLETE.md`, `CODEX_ENV_VARIABLES.txt`, and a `README.md`, and updated `README.md` to reference these files and note CI uses pnpm workspace-native commands.

### Testing

- No automated tests were executed as part of this change; CI pipeline changes will be validated when the updated workflow runs on GitHub Actions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1afed26548330889499279eb3db40)