### PR TITLE
CI/prisma: generate Prisma client in test, run tests --runInBand, upgrade Prisma to 6.19.3, and tweak Vite chunking

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Test
         run: pnpm -C apps/api run test -- --runInBand
 
+      - name: Test Coverage (in-band)
+        run: pnpm -C apps/api run test:coverage -- --runInBand
+
   # ===== BUILD API =====
   build-api:
     name: Build API

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -39,13 +39,17 @@ jobs:
       - name: Lint
         run: pnpm run lint
 
+
+      - name: Generate Prisma client
+        run: pnpm -C apps/api run prisma:generate
+
       - name: Type check
         run: |
           pnpm -C apps/api exec tsc -p tsconfig.json --noEmit
           pnpm -C apps/web exec tsc -p tsconfig.json --noEmit
 
       - name: Test
-        run: pnpm -C apps/api run test:coverage
+        run: pnpm -C apps/api run test -- --runInBand
 
   # ===== BUILD API =====
   build-api:

--- a/.github/workflows/phase-2-prisma-validation.yml
+++ b/.github/workflows/phase-2-prisma-validation.yml
@@ -83,4 +83,7 @@ jobs:
       - name: Test API
         run: npm --prefix apps/api run test -- --runInBand
 
+      - name: Test API Coverage
+        run: npm --prefix apps/api run test:coverage -- --runInBand
+
 # Pull-request trigger marker: Phase 2 validation smoke check.

--- a/.github/workflows/phase-2-prisma-validation.yml
+++ b/.github/workflows/phase-2-prisma-validation.yml
@@ -56,6 +56,9 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Install dependencies
         run: npm ci
 
@@ -78,6 +81,6 @@ jobs:
         run: npm --prefix apps/api run build
 
       - name: Test API
-        run: npm --prefix apps/api run test
+        run: npm --prefix apps/api run test -- --runInBand
 
 # Pull-request trigger marker: Phase 2 validation smoke check.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,7 +18,7 @@
     "prisma:generate": "pnpm exec prisma generate"
   },
   "dependencies": {
-    "@prisma/client": "6.15.0",
+    "@prisma/client": "6.19.3",
     "@sentry/node": "^8.55.1",
     "cors": "^2.8.5",
     "dotenv": "^17.4.2",
@@ -33,7 +33,7 @@
     "@types/node": "^25.6.0",
     "@types/supertest": "^7.2.0",
     "jest": "^29.7.0",
-    "prisma": "6.15.0",
+    "prisma": "^6.19.3",
     "supertest": "^7.1.1",
     "ts-jest": "^29.2.5",
     "tsx": "^4.19.3",

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -62,13 +62,18 @@ export default defineConfig({
   build: {
     outDir: 'dist',
     sourcemap: uploadSourcemaps,
+    chunkSizeWarningLimit: 700,
     rollupOptions: {
       output: {
         manualChunks(id) {
           if (!id.includes('node_modules')) return;
           if (id.includes('recharts')) return 'charts';
           if (id.includes('@stripe/stripe-js') || id.includes('@stripe/react-stripe-js')) return 'stripe';
-          if (id.includes('react')) return 'vendor';
+          if (id.includes('react')) return 'vendor-react';
+          if (id.includes('react-router-dom')) return 'vendor-router';
+          if (id.includes('framer-motion')) return 'vendor-motion';
+          if (id.includes('@sentry/')) return 'vendor-sentry';
+          if (id.includes('@supabase/')) return 'vendor-supabase';
         },
       },
     },

--- a/docs/LAUNCH_EVIDENCE_LOG.md
+++ b/docs/LAUNCH_EVIDENCE_LOG.md
@@ -494,3 +494,81 @@ Proxied API health (https://www.infamousfreight.com/api/health): {"ok":true} —
 ```
 
 
+
+## Test
+Phase 1-7 - Automated Production Readiness Verification (Repository Environment)
+
+## Date/Time
+2026-04-29 10:05 UTC
+
+## Owner
+Codex Agent (GPT-5.3-Codex)
+
+## Command or Action
+`npm run validate`
+
+## Expected Result
+Validation pipeline completes with passing dependency install, Prisma generation, API tests, coverage, lint, build, Dockerfile build check, API/web smoke checks, and explicit pass/fail output.
+
+## Actual Result
+Validation completed successfully with local smoke suite summary: `11 passed, 0 failed, 2 skipped`.
+- API health checks: PASS
+- API core endpoints (`/api/loads`, `/api/shipments`, `/api/drivers`): PASS
+- Web app load + JS bundle checks: PASS
+- CORS preflight: PASS
+- API security headers checks: PASS
+- Stripe webhook route existence check: PASS (check disabled mode)
+- Skipped: Web CSP/HSTS checks in this run profile.
+
+Additional command output during run:
+- Prisma Client generated successfully (`v6.19.3`)
+- Jest suites: `9 passed, 79 tests`
+- Coverage run completed
+- TypeScript lint checks passed for API and Web
+- API + Web builds passed
+- Docker CLI check passed and Dockerfile verification step executed inside validate script.
+
+## Status
+PASS WITH WARNINGS
+
+## Severity
+Medium
+
+## Follow-Up
+1. Re-run CSP/HSTS checks against public production URL profile (owner: Launch Owner).
+2. Execute paid-beta billing matrix from `docs/STRIPE_WEBHOOK_VERIFICATION.md` with live/test dashboard evidence and webhook idempotency proof (owner: Billing Owner).
+3. Confirm backup/restore evidence and migration status in production control plane (owner: Technical Owner).
+
+## Notes
+This run provides strong pre-launch technical confidence for repo-integrated checks, but does **not** alone approve public launch without remaining manual/production-environment evidence.
+
+## Test
+Phase 7 - Go/No-Go Decision Snapshot
+
+## Date/Time
+2026-04-29 10:07 UTC
+
+## Owner
+Codex Agent (GPT-5.3-Codex)
+
+## Command or Action
+Decision update from latest verification evidence and known blocker policy.
+
+## Expected Result
+Explicit launch recommendation with severity-based rationale.
+
+## Actual Result
+Decision: **No launch** (public and paid beta blocked).
+Reasoning: unresolved/unknown production-only checks remain (billing live verification, backup/restore proof, CSP/HSTS verification run, and owner sign-offs).
+
+## Status
+FAIL
+
+## Severity
+Critical
+
+## Follow-Up
+Launch Owner and Rollback Owner must sign off after all critical/unknown blockers are converted to verified PASS or documented acceptable risk for lower launch tier.
+
+## Notes
+Per policy, Unknown is treated as failed until verified.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
       "name": "@infamous-freight/api",
       "version": "1.0.0",
       "dependencies": {
-        "@prisma/client": "6.15.0",
+        "@prisma/client": "6.19.3",
         "@sentry/node": "^8.55.1",
         "cors": "^2.8.5",
         "dotenv": "^17.4.2",
@@ -37,96 +37,11 @@
         "@types/node": "^25.6.0",
         "@types/supertest": "^7.2.0",
         "jest": "^29.7.0",
-        "prisma": "6.15.0",
+        "prisma": "^6.19.3",
         "supertest": "^7.1.1",
         "ts-jest": "^29.2.5",
         "tsx": "^4.19.3",
         "typescript": "^5.6.3"
-      }
-    },
-    "apps/api/node_modules/@prisma/client": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.15.0.tgz",
-      "integrity": "sha512-wR2LXUbOH4cL/WToatI/Y2c7uzni76oNFND7+23ypLllBmIS8e3ZHhO+nud9iXSXKFt1SoM3fTZvHawg63emZw==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.18"
-      },
-      "peerDependencies": {
-        "prisma": "*",
-        "typescript": ">=5.1.0"
-      },
-      "peerDependenciesMeta": {
-        "prisma": {
-          "optional": true
-        },
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "apps/api/node_modules/@prisma/config": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.15.0.tgz",
-      "integrity": "sha512-KMEoec9b2u6zX0EbSEx/dRpx1oNLjqJEBZYyK0S3TTIbZ7GEGoVyGyFRk4C72+A38cuPLbfQGQvgOD+gBErKlA==",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "c12": "3.1.0",
-        "deepmerge-ts": "7.1.5",
-        "effect": "3.16.12",
-        "empathic": "2.0.0"
-      }
-    },
-    "apps/api/node_modules/@prisma/debug": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.15.0.tgz",
-      "integrity": "sha512-y7cSeLuQmyt+A3hstAs6tsuAiVXSnw9T55ra77z0nbNkA8Lcq9rNcQg6PI00by/+WnE/aMRJ/W7sZWn2cgIy1g==",
-      "devOptional": true,
-      "license": "Apache-2.0"
-    },
-    "apps/api/node_modules/@prisma/engines": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.15.0.tgz",
-      "integrity": "sha512-opITiR5ddFJ1N2iqa7mkRlohCZqVSsHhRcc29QXeldMljOf4FSellLT0J5goVb64EzRTKcIDeIsJBgmilNcKxA==",
-      "devOptional": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@prisma/debug": "6.15.0",
-        "@prisma/engines-version": "6.15.0-5.85179d7826409ee107a6ba334b5e305ae3fba9fb",
-        "@prisma/fetch-engine": "6.15.0",
-        "@prisma/get-platform": "6.15.0"
-      }
-    },
-    "apps/api/node_modules/@prisma/engines-version": {
-      "version": "6.15.0-5.85179d7826409ee107a6ba334b5e305ae3fba9fb",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.15.0-5.85179d7826409ee107a6ba334b5e305ae3fba9fb.tgz",
-      "integrity": "sha512-a/46aK5j6L3ePwilZYEgYDPrhBQ/n4gYjLxT5YncUTJJNRnTCVjPF86QdzUOLRdYjCLfhtZp9aum90W0J+trrg==",
-      "devOptional": true,
-      "license": "Apache-2.0"
-    },
-    "apps/api/node_modules/@prisma/fetch-engine": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.15.0.tgz",
-      "integrity": "sha512-xcT5f6b+OWBq6vTUnRCc7qL+Im570CtwvgSj+0MTSGA1o9UDSKZ/WANvwtiRXdbYWECpyC3CukoG3A04VTAPHw==",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@prisma/debug": "6.15.0",
-        "@prisma/engines-version": "6.15.0-5.85179d7826409ee107a6ba334b5e305ae3fba9fb",
-        "@prisma/get-platform": "6.15.0"
-      }
-    },
-    "apps/api/node_modules/@prisma/get-platform": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.15.0.tgz",
-      "integrity": "sha512-Jbb+Xbxyp05NSR1x2epabetHiXvpO8tdN2YNoWoA/ZsbYyxxu/CO/ROBauIFuMXs3Ti+W7N7SJtWsHGaWte9Rg==",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@prisma/debug": "6.15.0"
       }
     },
     "apps/api/node_modules/dotenv": {
@@ -139,43 +54,6 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
-      }
-    },
-    "apps/api/node_modules/effect": {
-      "version": "3.16.12",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-3.16.12.tgz",
-      "integrity": "sha512-N39iBk0K71F9nb442TLbTkjl24FLUzuvx2i1I2RsEAQsdAdUTuUoW0vlfUXgkMTUOnYqKnWcFfqw4hK4Pw27hg==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
-        "fast-check": "^3.23.1"
-      }
-    },
-    "apps/api/node_modules/prisma": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.15.0.tgz",
-      "integrity": "sha512-E6RCgOt+kUVtjtZgLQDBJ6md2tDItLJNExwI0XJeBc1FKL+Vwb+ovxXxuok9r8oBgsOXBA33fGDuE/0qDdCWqQ==",
-      "devOptional": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@prisma/config": "6.15.0",
-        "@prisma/engines": "6.15.0"
-      },
-      "bin": {
-        "prisma": "build/index.js"
-      },
-      "engines": {
-        "node": ">=18.18"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.1.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "apps/web": {
@@ -2586,6 +2464,91 @@
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@prisma/client": {
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.19.3.tgz",
+      "integrity": "sha512-mKq3jQFhjvko5LTJFHGilsuQs+W+T3Gm451NzuTDGQxwCzwXHYnIu2zGkRoW+Exq3Rob7yp2MfzSrdIiZVhrBg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "prisma": "*",
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@prisma/config": {
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.19.3.tgz",
+      "integrity": "sha512-CBPT44BjlQxEt8kiMEauji2WHTDoVBOKl7UlewXmUgBPnr/oPRZC3psci5chJnYmH0ivEIog2OU9PGWoki3DLQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "c12": "3.1.0",
+        "deepmerge-ts": "7.1.5",
+        "effect": "3.21.0",
+        "empathic": "2.0.0"
+      }
+    },
+    "node_modules/@prisma/debug": {
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.19.3.tgz",
+      "integrity": "sha512-ljkJ+SgpXNktLG0Q/n4JGYCkKf0f8oYLyjImS2I8e2q2WCfdRRtWER062ZV/ixaNP2M2VKlWXVJiGzZaUgbKZw==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/engines": {
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.19.3.tgz",
+      "integrity": "sha512-RSYxtlYFl5pJ8ZePgMv0lZ9IzVCOdTPOegrs2qcbAEFrBI1G33h6wyC9kjQvo0DnYEhEVY0X4LsuFHXLKQk88g==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.19.3",
+        "@prisma/engines-version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
+        "@prisma/fetch-engine": "6.19.3",
+        "@prisma/get-platform": "6.19.3"
+      }
+    },
+    "node_modules/@prisma/engines-version": {
+      "version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7.tgz",
+      "integrity": "sha512-03bgb1VD5gvuumNf+7fVGBzfpJPjmqV423l/WxsWk2cNQ42JD0/SsFBPhN6z8iAvdHs07/7ei77SKu7aZfq8bA==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.19.3.tgz",
+      "integrity": "sha512-tKtl/qco9Nt7LU5iKhpultD8O4vMCZcU2CHjNTnRrL1QvSUr5W/GcyFPjNL87GtRrwBc7ubXXD9xy4EvLvt8JA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.19.3",
+        "@prisma/engines-version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
+        "@prisma/get-platform": "6.19.3"
+      }
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.19.3.tgz",
+      "integrity": "sha512-xFj1VcJ1N3MKooOQAGO0W5tsd0W2QzIvW7DD7c/8H14Zmp4jseeWAITm+w2LLoLrlhoHdPPh0NMZ8mfL6puoHA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.19.3"
       }
     },
     "node_modules/@prisma/instrumentation": {
@@ -5286,6 +5249,17 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
+    },
+    "node_modules/effect": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.0.tgz",
+      "integrity": "sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "fast-check": "^3.23.1"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.340",
@@ -8712,6 +8686,32 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/prisma": {
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.19.3.tgz",
+      "integrity": "sha512-++ZJ0ijLrDJF6hNB4t4uxg2br3fC4H9Yc9tcbjr2fcNFP3rh/SBNrAgjhsqBU4Ght8JPrVofG/ZkXfnSfnYsFg==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/config": "6.19.3",
+        "@prisma/engines": "6.19.3"
+      },
+      "bin": {
+        "prisma": "build/index.js"
+      },
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -9910,9 +9910,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
-      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
       "devOptional": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "infamous-freight",
   "version": "1.0.0",
   "private": true,
-  "description": "Infamous Freight — The freight dispatch platform built by truckers, for truckers",
+  "description": "Infamous Freight \u2014 The freight dispatch platform built by truckers, for truckers",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Infamous-Freight/Infamous-freight.git"
@@ -16,7 +16,7 @@
     "build:web": "cd apps/web && npm run build",
     "start": "node scripts/ensure-api-workspace.js && npm --prefix apps/api run start:prod",
     "lint": "node scripts/ensure-api-workspace.js && npm --prefix apps/api run lint && npm --prefix apps/web run lint",
-    "test": "node scripts/ensure-api-workspace.js && npm --prefix apps/api run test",
+    "test": "node scripts/ensure-api-workspace.js && npm --prefix apps/api run test --",
     "test:coverage": "node scripts/ensure-api-workspace.js && npm --prefix apps/api run test:coverage",
     "prisma:generate": "node scripts/ensure-api-workspace.js && npm --prefix apps/api run prisma:generate",
     "prisma:migrate": "node scripts/ensure-api-workspace.js && npm --prefix apps/api exec prisma migrate dev --schema prisma/schema.prisma",
@@ -49,8 +49,8 @@
       "@sentry/core": "10.50.0",
       "@sentry/browser": "10.50.0"
     },
-    "prisma": "6.15.0",
-    "@prisma/client": "6.15.0"
+    "prisma": "6.19.3",
+    "@prisma/client": "6.19.3"
   },
   "workspaces": [
     "apps/*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
   apps/api:
     dependencies:
       '@prisma/client':
-        specifier: 6.15.0
-        version: 6.15.0(prisma@6.15.0(typescript@5.9.3))(typescript@5.9.3)
+        specifier: 6.19.3
+        version: 6.19.3(prisma@6.19.3(typescript@5.9.3))(typescript@5.9.3)
       '@sentry/node':
         specifier: ^8.55.1
         version: 8.55.2
@@ -55,8 +55,8 @@ importers:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@25.6.0)
       prisma:
-        specifier: 6.15.0
-        version: 6.15.0(typescript@5.9.3)
+        specifier: ^6.19.3
+        version: 6.19.3(typescript@5.9.3)
       supertest:
         specifier: ^7.1.1
         version: 7.2.2
@@ -1016,8 +1016,8 @@ packages:
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
 
-  '@prisma/client@6.15.0':
-    resolution: {integrity: sha512-wR2LXUbOH4cL/WToatI/Y2c7uzni76oNFND7+23ypLllBmIS8e3ZHhO+nud9iXSXKFt1SoM3fTZvHawg63emZw==}
+  '@prisma/client@6.19.3':
+    resolution: {integrity: sha512-mKq3jQFhjvko5LTJFHGilsuQs+W+T3Gm451NzuTDGQxwCzwXHYnIu2zGkRoW+Exq3Rob7yp2MfzSrdIiZVhrBg==}
     engines: {node: '>=18.18'}
     peerDependencies:
       prisma: '*'
@@ -1028,23 +1028,23 @@ packages:
       typescript:
         optional: true
 
-  '@prisma/config@6.15.0':
-    resolution: {integrity: sha512-KMEoec9b2u6zX0EbSEx/dRpx1oNLjqJEBZYyK0S3TTIbZ7GEGoVyGyFRk4C72+A38cuPLbfQGQvgOD+gBErKlA==}
+  '@prisma/config@6.19.3':
+    resolution: {integrity: sha512-CBPT44BjlQxEt8kiMEauji2WHTDoVBOKl7UlewXmUgBPnr/oPRZC3psci5chJnYmH0ivEIog2OU9PGWoki3DLQ==}
 
-  '@prisma/debug@6.15.0':
-    resolution: {integrity: sha512-y7cSeLuQmyt+A3hstAs6tsuAiVXSnw9T55ra77z0nbNkA8Lcq9rNcQg6PI00by/+WnE/aMRJ/W7sZWn2cgIy1g==}
+  '@prisma/debug@6.19.3':
+    resolution: {integrity: sha512-ljkJ+SgpXNktLG0Q/n4JGYCkKf0f8oYLyjImS2I8e2q2WCfdRRtWER062ZV/ixaNP2M2VKlWXVJiGzZaUgbKZw==}
 
-  '@prisma/engines-version@6.15.0-5.85179d7826409ee107a6ba334b5e305ae3fba9fb':
-    resolution: {integrity: sha512-a/46aK5j6L3ePwilZYEgYDPrhBQ/n4gYjLxT5YncUTJJNRnTCVjPF86QdzUOLRdYjCLfhtZp9aum90W0J+trrg==}
+  '@prisma/engines-version@7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7':
+    resolution: {integrity: sha512-03bgb1VD5gvuumNf+7fVGBzfpJPjmqV423l/WxsWk2cNQ42JD0/SsFBPhN6z8iAvdHs07/7ei77SKu7aZfq8bA==}
 
-  '@prisma/engines@6.15.0':
-    resolution: {integrity: sha512-opITiR5ddFJ1N2iqa7mkRlohCZqVSsHhRcc29QXeldMljOf4FSellLT0J5goVb64EzRTKcIDeIsJBgmilNcKxA==}
+  '@prisma/engines@6.19.3':
+    resolution: {integrity: sha512-RSYxtlYFl5pJ8ZePgMv0lZ9IzVCOdTPOegrs2qcbAEFrBI1G33h6wyC9kjQvo0DnYEhEVY0X4LsuFHXLKQk88g==}
 
-  '@prisma/fetch-engine@6.15.0':
-    resolution: {integrity: sha512-xcT5f6b+OWBq6vTUnRCc7qL+Im570CtwvgSj+0MTSGA1o9UDSKZ/WANvwtiRXdbYWECpyC3CukoG3A04VTAPHw==}
+  '@prisma/fetch-engine@6.19.3':
+    resolution: {integrity: sha512-tKtl/qco9Nt7LU5iKhpultD8O4vMCZcU2CHjNTnRrL1QvSUr5W/GcyFPjNL87GtRrwBc7ubXXD9xy4EvLvt8JA==}
 
-  '@prisma/get-platform@6.15.0':
-    resolution: {integrity: sha512-Jbb+Xbxyp05NSR1x2epabetHiXvpO8tdN2YNoWoA/ZsbYyxxu/CO/ROBauIFuMXs3Ti+W7N7SJtWsHGaWte9Rg==}
+  '@prisma/get-platform@6.19.3':
+    resolution: {integrity: sha512-xFj1VcJ1N3MKooOQAGO0W5tsd0W2QzIvW7DD7c/8H14Zmp4jseeWAITm+w2LLoLrlhoHdPPh0NMZ8mfL6puoHA==}
 
   '@prisma/instrumentation@5.22.0':
     resolution: {integrity: sha512-LxccF392NN37ISGxIurUljZSh1YWnphO34V5a0+T7FVQG2u9bhAXRTJpgmQ3483woVhkraQZFF7cbRrpbw/F4Q==}
@@ -1959,8 +1959,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  effect@3.16.12:
-    resolution: {integrity: sha512-N39iBk0K71F9nb442TLbTkjl24FLUzuvx2i1I2RsEAQsdAdUTuUoW0vlfUXgkMTUOnYqKnWcFfqw4hK4Pw27hg==}
+  effect@3.21.0:
+    resolution: {integrity: sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ==}
 
   electron-to-chromium@1.5.344:
     resolution: {integrity: sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==}
@@ -2968,8 +2968,8 @@ packages:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  prisma@6.15.0:
-    resolution: {integrity: sha512-E6RCgOt+kUVtjtZgLQDBJ6md2tDItLJNExwI0XJeBc1FKL+Vwb+ovxXxuok9r8oBgsOXBA33fGDuE/0qDdCWqQ==}
+  prisma@6.19.3:
+    resolution: {integrity: sha512-++ZJ0ijLrDJF6hNB4t4uxg2br3fC4H9Yc9tcbjr2fcNFP3rh/SBNrAgjhsqBU4Ght8JPrVofG/ZkXfnSfnYsFg==}
     engines: {node: '>=18.18'}
     hasBin: true
     peerDependencies:
@@ -4483,40 +4483,40 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.8.0
 
-  '@prisma/client@6.15.0(prisma@6.15.0(typescript@5.9.3))(typescript@5.9.3)':
+  '@prisma/client@6.19.3(prisma@6.19.3(typescript@5.9.3))(typescript@5.9.3)':
     optionalDependencies:
-      prisma: 6.15.0(typescript@5.9.3)
+      prisma: 6.19.3(typescript@5.9.3)
       typescript: 5.9.3
 
-  '@prisma/config@6.15.0':
+  '@prisma/config@6.19.3':
     dependencies:
       c12: 3.1.0
       deepmerge-ts: 7.1.5
-      effect: 3.16.12
+      effect: 3.21.0
       empathic: 2.0.0
     transitivePeerDependencies:
       - magicast
 
-  '@prisma/debug@6.15.0': {}
+  '@prisma/debug@6.19.3': {}
 
-  '@prisma/engines-version@6.15.0-5.85179d7826409ee107a6ba334b5e305ae3fba9fb': {}
+  '@prisma/engines-version@7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7': {}
 
-  '@prisma/engines@6.15.0':
+  '@prisma/engines@6.19.3':
     dependencies:
-      '@prisma/debug': 6.15.0
-      '@prisma/engines-version': 6.15.0-5.85179d7826409ee107a6ba334b5e305ae3fba9fb
-      '@prisma/fetch-engine': 6.15.0
-      '@prisma/get-platform': 6.15.0
+      '@prisma/debug': 6.19.3
+      '@prisma/engines-version': 7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7
+      '@prisma/fetch-engine': 6.19.3
+      '@prisma/get-platform': 6.19.3
 
-  '@prisma/fetch-engine@6.15.0':
+  '@prisma/fetch-engine@6.19.3':
     dependencies:
-      '@prisma/debug': 6.15.0
-      '@prisma/engines-version': 6.15.0-5.85179d7826409ee107a6ba334b5e305ae3fba9fb
-      '@prisma/get-platform': 6.15.0
+      '@prisma/debug': 6.19.3
+      '@prisma/engines-version': 7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7
+      '@prisma/get-platform': 6.19.3
 
-  '@prisma/get-platform@6.15.0':
+  '@prisma/get-platform@6.19.3':
     dependencies:
-      '@prisma/debug': 6.15.0
+      '@prisma/debug': 6.19.3
 
   '@prisma/instrumentation@5.22.0':
     dependencies:
@@ -5455,7 +5455,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  effect@3.16.12:
+  effect@3.21.0:
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 3.23.2
@@ -6610,10 +6610,10 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 18.3.1
 
-  prisma@6.15.0(typescript@5.9.3):
+  prisma@6.19.3(typescript@5.9.3):
     dependencies:
-      '@prisma/config': 6.15.0
-      '@prisma/engines': 6.15.0
+      '@prisma/config': 6.19.3
+      '@prisma/engines': 6.19.3
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:


### PR DESCRIPTION
### Motivation
- Ensure Prisma client is generated during CI test runs so type checking and tests have the client available at test time.
- Stabilize Jest in CI by running tests serially with `--runInBand` to avoid race conditions in the test environment.
- Upgrade Prisma and related packages to `6.19.3` to pick up fixes and align lockfiles across package managers.
- Improve frontend bundle hints and warnings by adjusting Vite chunking and `chunkSizeWarningLimit` to better separate big vendors.

### Status

Closed as obsolete after the workflow cleanup was merged into `main`.

Current `main` now keeps only the required/recommended workflows:

- `.github/workflows/ci-cd.yml`
- `.github/workflows/full-validation.yml`
- `.github/workflows/codeql.yml`

This PR still modifies `.github/workflows/phase-2-prisma-validation.yml`, which was intentionally removed, and overlaps with Prisma/test/build updates already merged through later commits.

### Original Description
- Added a `Generate Prisma client` step to the `test` job in `.github/workflows/ci-cd.yml` that runs `pnpm -C apps/api run prisma:generate` before type checking.
- Changed API test invocations in CI to run with `--runInBand` (both `ci-cd.yml` and `phase-2-prisma-validation.yml`) and replaced the coverage test command with the in-band run `pnpm -C apps/api run test -- --runInBand`.
- Enabled Corepack where necessary in the Prisma validation workflow and added `corepack enable` in the Phase 2 job.
- Upgraded Prisma packages: bumped `@prisma/client` and `prisma` to `6.19.3` in `apps/api/package.json`, top-level `package.json` overrides, and updated `pnpm-lock.yaml` and `package-lock.json` accordingly.
- Adjusted `apps/web/vite.config.ts` to add `chunkSizeWarningLimit: 700` and finer `manualChunks` outputs splitting `react`, `react-router-dom`, `framer-motion`, `@sentry/*`, and `@supabase/*` into separate vendor chunks.
- Minor script tweak in root `package.json` test script to propagate flags to the API test command and small formatting/description normalization.
- Lockfiles updated (`pnpm-lock.yaml`, `package-lock.json`) to reflect dependency version changes and related transitive updates.