### PR TITLE
ci: add full validation workflow

### DIFF
--- a/.github/workflows/full-validation.yml
+++ b/.github/workflows/full-validation.yml
@@ -1,0 +1,46 @@
+name: Full Validation
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: full-validation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Install, lint, build, and test
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm run lint
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Test
+        run: pnpm run test -- --runInBand


### PR DESCRIPTION
## Summary

Adds a dedicated Full Validation workflow that runs the full recommended validation path automatically:

- `pnpm install --frozen-lockfile`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test -- --runInBand`

## Why

The repo already has CI/CD, but the existing workflow does not run the full root build command in the PR validation path. This workflow makes the manual validation checklist repeatable on every PR and push to `main`.

## Notes

- Uses `pnpm` because the repo has a `pnpm-lock.yaml` and existing CI is already pnpm-based.
- Includes `workflow_dispatch` so it can be run manually from GitHub Actions.