### PR TITLE
Add dev CLI installer and document deployment CLI bootstrap and Fly machine update steps

### DIFF
--- a/docs/INTEGRATIONS-AND-SECRETS.md
+++ b/docs/INTEGRATIONS-AND-SECRETS.md
@@ -77,6 +77,27 @@ here for ownership awareness.
 
 ## 3. Runbooks
 
+### 3.0 Bootstrap deployment CLIs (local/dev container)
+
+Install the baseline deployment CLIs used by this repository (Docker, Fly.io,
+and `jq`) with:
+
+```bash
+sudo bash scripts/install-dev-clis.sh
+```
+
+If Docker is installed but not running in your environment, start it before
+attempting image builds:
+
+```bash
+sudo systemctl start docker
+docker info
+```
+
+In restricted containers/CI, the Docker CLI may be installed while the daemon
+socket remains unavailable; in that case `docker info` will fail until a daemon
+is provided.
+
 ### 3.1 Deploy failure — API (Fly.io)
 
 **Symptom:** The `deploy-api` job fails or the API is unreachable at
@@ -98,6 +119,18 @@ here for ownership awareness.
    ```bash
    fly status --app infamous-freight
    fly machines restart --app infamous-freight
+   ```
+   If a single machine needs a targeted runtime update, first list machines and
+   then update by machine ID:
+   ```bash
+   fly machines list --app infamous-freight
+   fly machine update <machine_id> --app infamous-freight --vm-size shared-cpu-1x
+   ```
+   Use machine-level updates for controlled incident remediation; prefer full
+   app deploys for routine releases. After any machine-level update, verify the
+   API is healthy:
+   ```bash
+   curl -fsS https://api.infamousfreight.com/health
    ```
 
 4. **Build failed before deploy:** The `build-api` job must succeed before

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "docker:down": "docker-compose down",
     "docker:build": "docker-compose build",
     "docker:install-cli": "bash scripts/install-docker-cli.sh",
-    "deploy:install-clis": "bash scripts/install-dev-clis.sh",
+    "deploy:install-clis": "sh -c 'if [ \"$(id -u)\" -eq 0 ]; then bash scripts/install-dev-clis.sh; elif command -v sudo >/dev/null 2>&1; then sudo bash scripts/install-dev-clis.sh; else echo \"Error: scripts/install-dev-clis.sh requires root. Re-run with sudo: sudo npm run deploy:install-clis\" >&2; exit 1; fi'",
     "ai:check": "bash scripts/check-ai-runtime.sh",
     "env:bootstrap": "bash scripts/bootstrap-environment.sh",
     "env:check": "bash scripts/codex-env-check.sh",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "docker:down": "docker-compose down",
     "docker:build": "docker-compose build",
     "docker:install-cli": "bash scripts/install-docker-cli.sh",
+    "deploy:install-clis": "bash scripts/install-dev-clis.sh",
     "ai:check": "bash scripts/check-ai-runtime.sh",
     "env:bootstrap": "bash scripts/bootstrap-environment.sh",
     "env:check": "bash scripts/codex-env-check.sh",

--- a/scripts/bootstrap-environment.sh
+++ b/scripts/bootstrap-environment.sh
@@ -12,12 +12,15 @@ if should_install_workspace_dependencies "$PACKAGE_MANAGER"; then
   install_workspace_dependencies "$PACKAGE_MANAGER"
 fi
 
-echo "==> Ensuring Docker CLI/Buildx"
-bash scripts/install-docker-cli.sh || true
-
-echo "==> Ensuring flyctl"
-if ! command -v flyctl >/dev/null 2>&1; then
-  curl -L https://fly.io/install.sh | sh
+echo "==> Ensuring deployment CLIs (Docker, flyctl, jq)"
+if [[ "${EUID}" -eq 0 ]]; then
+  bash scripts/install-dev-clis.sh
+else
+  bash scripts/install-docker-cli.sh || true
+  if ! command -v flyctl >/dev/null 2>&1; then
+    echo "flyctl is not installed. Run with sudo/root:"
+    echo "  sudo bash scripts/install-dev-clis.sh"
+  fi
 fi
 
 echo "==> Ensuring AI SDK runtime"

--- a/scripts/install-dev-clis.sh
+++ b/scripts/install-dev-clis.sh
@@ -12,7 +12,7 @@ apt-get install -y curl jq docker.io
 
 FLY_INSTALL_DIR="${FLY_INSTALL_DIR:-/root/.fly}"
 if [[ ! -x "${FLY_INSTALL_DIR}/bin/flyctl" ]]; then
-  FLYCTL_INSTALL="${FLY_INSTALL_DIR}" curl -fsSL https://fly.io/install.sh | sh
+  curl -fsSL https://fly.io/install.sh | FLYCTL_INSTALL="${FLY_INSTALL_DIR}" sh
 fi
 
 if [[ -x "${FLY_INSTALL_DIR}/bin/flyctl" ]]; then

--- a/scripts/install-dev-clis.sh
+++ b/scripts/install-dev-clis.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${EUID}" -ne 0 ]]; then
+  echo "Please run as root (or with sudo)." >&2
+  exit 1
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y curl jq docker.io
+
+FLY_INSTALL_DIR="${FLY_INSTALL_DIR:-/root/.fly}"
+if [[ ! -x "${FLY_INSTALL_DIR}/bin/flyctl" ]]; then
+  FLYCTL_INSTALL="${FLY_INSTALL_DIR}" curl -fsSL https://fly.io/install.sh | sh
+fi
+
+if [[ -x "${FLY_INSTALL_DIR}/bin/flyctl" ]]; then
+  ln -sf "${FLY_INSTALL_DIR}/bin/flyctl" /usr/local/bin/flyctl
+fi
+
+if command -v systemctl >/dev/null 2>&1 && [[ -d /run/systemd/system ]]; then
+  systemctl enable docker >/dev/null 2>&1 || true
+  systemctl start docker >/dev/null 2>&1 || true
+fi
+
+echo "Installed tool versions:"
+docker --version || true
+flyctl version || true
+jq --version || true
+
+echo "Docker daemon status:"
+if docker info >/dev/null 2>&1; then
+  echo "docker daemon is available."
+else
+  echo "docker daemon is unavailable (expected in some CI/containers)." >&2
+fi


### PR DESCRIPTION
### Motivation

- Provide a single, idempotent installer for baseline deployment CLIs (Docker, flyctl, jq) for local and dev-container bootstrapping. 
- Make the repository bootstrap robust to root vs non-root execution and surface guidance when the flyctl binary is not available. 
- Document machine-level Fly.io remediation steps and add a developer-friendly bootstrap section to the runbook. 

### Description

- Add `scripts/install-dev-clis.sh` which installs `curl`, `jq`, `docker.io`, and `flyctl`, ensures the Docker daemon is enabled/started, and reports versions and daemon status. 
- Update `scripts/bootstrap-environment.sh` to prefer the new installer when run as root and to warn non-root users how to install `flyctl`. 
- Add an `npm` script `deploy:install-clis` that runs the new installer. 
- Extend `docs/INTEGRATIONS-AND-SECRETS.md` with a new "3.0 Bootstrap deployment CLIs (local/dev container)" section and add Fly machine update steps to the API deploy runbook. 

### Testing

- Ran repository validation via `npm run validate`; the validation completed successfully. 
- Executed API unit tests via `npm test` (API workspace) and they passed. 
- Performed a non-root bootstrap smoke check with `bash scripts/bootstrap-environment.sh` to verify non-root behavior and messaging, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f21cd3f4588330b0b4feffb5957ff2)