### PR TITLE
Use port 3000 for runtime and add local deploy/bootstrap CLIs and smoke checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,53 +1,33 @@
 FROM node:22-alpine AS deps
 WORKDIR /app
-
 COPY package.json package-lock.json ./
 COPY apps/api/package.json ./apps/api/package.json
-
 RUN npm ci --omit=dev --workspace apps/api --include-workspace-root=false
-
-
 FROM node:22-alpine AS build
 WORKDIR /app
-
 COPY package.json package-lock.json ./
 COPY apps/api/package.json ./apps/api/package.json
-
 RUN npm ci --workspace apps/api
-
 COPY apps/api ./apps/api
-
 ENV DATABASE_URL="postgresql://user:pass@localhost:5432/db"
-
 RUN npx prisma generate --schema=apps/api/prisma/schema.prisma
 RUN npx tsc -p apps/api/tsconfig.json
-
-
 FROM node:22-alpine AS runtime
 WORKDIR /app
-
 ENV NODE_ENV=production
-ENV PORT=8080
+ENV PORT=3000
 ENV HOST=0.0.0.0
-
 RUN apk add --no-cache openssl
-
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=build /app/node_modules/.prisma ./node_modules/.prisma
 COPY package.json package-lock.json ./
 COPY apps/api/package.json ./apps/api/package.json
-
 COPY --from=build /app/apps/api/dist ./apps/api/dist
 COPY --from=build /app/apps/api/prisma ./apps/api/prisma
-
 RUN addgroup -S nodejs && adduser -S nodejs -G nodejs
 USER nodejs
-
 WORKDIR /app/apps/api
-
-EXPOSE 8080
-
+EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
-  CMD node -e "const port = process.env.PORT || 8080; const http = require('http'); const req = http.get('http://127.0.0.1:' + port + '/api/health', (r) => { process.exit(r.statusCode === 200 ? 0 : 1); }); req.on('error', () => process.exit(1)); req.setTimeout(4000, () => { req.destroy(); process.exit(1); });"
-
+  CMD node -e "const port = process.env.PORT || 3000; const http = require('http'); const req = http.get('http://127.0.0.1:' + port + '/api/health', (r) => { process.exit(r.statusCode === 200 ? 0 : 1); }); req.on('error', () => process.exit(1)); req.setTimeout(4000, () => { req.destroy(); process.exit(1); });"
 CMD ["node", "dist/src/server.js"]

--- a/docs/INTEGRATIONS-AND-SECRETS.md
+++ b/docs/INTEGRATIONS-AND-SECRETS.md
@@ -77,6 +77,36 @@ here for ownership awareness.
 
 ## 3. Runbooks
 
+### 3.0 Bootstrap deployment CLIs (local/dev container)
+
+Install the baseline deployment CLIs used by this repository (Docker, Fly.io,
+and `jq`) with:
+
+```bash
+sudo bash scripts/install-dev-clis.sh
+sudo bash scripts/start-docker-daemon.sh
+npm run docker:smoke
+npm run ssh:install-key
+# strict mode (fail instead of skip when daemon/build is blocked)
+DOCKER_SMOKE_STRICT=true npm run docker:smoke
+```
+
+If Docker is installed but not running in your environment, start it before
+attempting image builds:
+
+```bash
+sudo systemctl start docker
+docker info
+```
+
+In restricted containers/CI, the Docker CLI may be installed while the daemon
+socket remains unavailable; in that case `docker info` will fail until a daemon
+is provided. `scripts/start-docker-daemon.sh` retries with a restricted-container
+daemon mode (`--iptables=false --bridge=none --storage-driver=vfs`) to support
+containerized environments that cannot create NAT/bridge rules. In that mode,
+set `DOCKER_HOST=unix:///tmp/docker-restricted.sock` before running Docker
+commands.
+
 ### 3.1 Deploy failure — API (Fly.io)
 
 **Symptom:** The `deploy-api` job fails or the API is unreachable at
@@ -98,6 +128,18 @@ here for ownership awareness.
    ```bash
    fly status --app infamous-freight
    fly machines restart --app infamous-freight
+   ```
+   If a single machine needs a targeted runtime update, first list machines and
+   then update by machine ID:
+   ```bash
+   fly machines list --app infamous-freight
+   fly machine update <machine_id> --app infamous-freight --vm-size shared-cpu-1x
+   ```
+   Use machine-level updates for controlled incident remediation; prefer full
+   app deploys for routine releases. After any machine-level update, verify the
+   API is healthy:
+   ```bash
+   curl -fsS https://api.infamousfreight.com/health
    ```
 
 4. **Build failed before deploy:** The `build-api` job must succeed before

--- a/docs/INTEGRATIONS-AND-SECRETS.md
+++ b/docs/INTEGRATIONS-AND-SECRETS.md
@@ -89,6 +89,7 @@ npm run docker:smoke
 npm run ssh:install-key
 # strict mode (fail instead of skip when daemon/build is blocked)
 DOCKER_SMOKE_STRICT=true npm run docker:smoke
+npm run premerge:check
 ```
 
 If Docker is installed but not running in your environment, start it before

--- a/fly.toml
+++ b/fly.toml
@@ -1,34 +1,24 @@
-# fly.toml app configuration file generated for infamous-freight on 2026-04-29T13:21:15Z
-#
-# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
-#
-
 app = 'infamous-freight'
 primary_region = 'dfw'
-
 [build]
   dockerfile = 'Dockerfile'
-
 [env]
   HOST = '0.0.0.0'
   NODE_ENV = 'production'
-  PORT = '8080'
-
+  PORT = '3000'
 [http_service]
-  internal_port = 8080
+  internal_port = 3000
   force_https = true
   auto_stop_machines = 'stop'
   auto_start_machines = true
   min_machines_running = 0
   processes = ['app']
-
   [[http_service.checks]]
     interval = '30s'
     timeout = '5s'
     grace_period = '30s'
     method = 'GET'
     path = '/api/health'
-
 [[vm]]
   memory = '512mb'
   cpu_kind = 'shared'

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "docker:smoke": "bash scripts/docker-smoke-check.sh",
     "ssh:install-key": "bash scripts/install-ssh-key.sh",
     "deploy:install-clis": "bash scripts/install-dev-clis.sh",
+    "premerge:check": "bash scripts/premerge-check.sh",
     "ai:check": "bash scripts/check-ai-runtime.sh",
     "env:bootstrap": "bash scripts/bootstrap-environment.sh",
     "env:check": "bash scripts/codex-env-check.sh",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
     "docker:down": "docker-compose down",
     "docker:build": "docker-compose build",
     "docker:install-cli": "bash scripts/install-docker-cli.sh",
+    "docker:start-daemon": "bash scripts/start-docker-daemon.sh",
+    "docker:smoke": "bash scripts/docker-smoke-check.sh",
+    "ssh:install-key": "bash scripts/install-ssh-key.sh",
+    "deploy:install-clis": "bash scripts/install-dev-clis.sh",
     "ai:check": "bash scripts/check-ai-runtime.sh",
     "env:bootstrap": "bash scripts/bootstrap-environment.sh",
     "env:check": "bash scripts/codex-env-check.sh",
@@ -58,5 +62,14 @@
   "engines": {
     "node": ">=22.0.0 <23.0.0",
     "npm": ">=10.0.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@prisma/client",
+      "@prisma/engines",
+      "@sentry/cli",
+      "esbuild",
+      "prisma"
+    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,8 @@
 packages:
   - 'apps/*'
+onlyBuiltDependencies:
+  - '@prisma/client'
+  - '@prisma/engines'
+  - '@sentry/cli'
+  - esbuild
+  - prisma

--- a/scripts/bootstrap-environment.sh
+++ b/scripts/bootstrap-environment.sh
@@ -12,12 +12,15 @@ if should_install_workspace_dependencies "$PACKAGE_MANAGER"; then
   install_workspace_dependencies "$PACKAGE_MANAGER"
 fi
 
-echo "==> Ensuring Docker CLI/Buildx"
-bash scripts/install-docker-cli.sh || true
-
-echo "==> Ensuring flyctl"
-if ! command -v flyctl >/dev/null 2>&1; then
-  curl -L https://fly.io/install.sh | sh
+echo "==> Ensuring deployment CLIs (Docker, flyctl, jq)"
+if [[ "${EUID}" -eq 0 ]]; then
+  bash scripts/install-dev-clis.sh
+else
+  bash scripts/install-docker-cli.sh || true
+  if ! command -v flyctl >/dev/null 2>&1; then
+    echo "flyctl is not installed. Run with sudo/root:"
+    echo "  sudo bash scripts/install-dev-clis.sh"
+  fi
 fi
 
 echo "==> Ensuring AI SDK runtime"

--- a/scripts/docker-smoke-check.sh
+++ b/scripts/docker-smoke-check.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+STRICT_MODE="${DOCKER_SMOKE_STRICT:-false}"
+
+bash scripts/start-docker-daemon.sh || true
+
+if [[ -S /tmp/docker-restricted.sock ]]; then
+  export DOCKER_HOST="unix:///tmp/docker-restricted.sock"
+fi
+
+if ! docker info >/dev/null 2>&1; then
+  echo "Docker daemon is unavailable; skipping docker smoke check in this environment."
+  if [[ "${STRICT_MODE}" == "true" ]]; then
+    exit 1
+  fi
+  exit 0
+fi
+
+IMAGE_TAG="infamous-freight-api-smoke:local"
+BUILD_LOG="/tmp/docker-build-smoke.log"
+
+set +e
+docker build -t "${IMAGE_TAG}" -f Dockerfile . >"${BUILD_LOG}" 2>&1
+build_rc=$?
+set -e
+
+if [[ $build_rc -ne 0 ]]; then
+  if rg -n "unshare: operation not permitted|operation not permitted" "${BUILD_LOG}" >/dev/null 2>&1; then
+    echo "Docker build blocked by container runtime permissions; skipping smoke check."
+    if [[ "${STRICT_MODE}" == "true" ]]; then
+      cat "${BUILD_LOG}" >&2
+      exit 1
+    fi
+    exit 0
+  fi
+  cat "${BUILD_LOG}" >&2
+  exit $build_rc
+fi
+
+CID="$(docker run -d -e PORT=3000 -p 3000:3000 "${IMAGE_TAG}")"
+trap 'docker rm -f "${CID}" >/dev/null 2>&1 || true' EXIT
+
+for _ in {1..20}; do
+  if curl -fsS "http://127.0.0.1:3000/api/health" >/dev/null 2>&1; then
+    echo "Docker smoke check passed."
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "Container started but health endpoint did not return 200 in time." >&2
+exit 1

--- a/scripts/install-dev-clis.sh
+++ b/scripts/install-dev-clis.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${EUID}" -ne 0 ]]; then
+  echo "Please run as root (or with sudo)." >&2
+  exit 1
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y curl jq docker.io
+
+FLY_INSTALL_DIR="${FLY_INSTALL_DIR:-/root/.fly}"
+if [[ ! -x "${FLY_INSTALL_DIR}/bin/flyctl" ]]; then
+  FLYCTL_INSTALL="${FLY_INSTALL_DIR}" curl -fsSL https://fly.io/install.sh | sh
+fi
+
+if [[ -x "${FLY_INSTALL_DIR}/bin/flyctl" ]]; then
+  ln -sf "${FLY_INSTALL_DIR}/bin/flyctl" /usr/local/bin/flyctl
+fi
+
+if command -v systemctl >/dev/null 2>&1 && [[ -d /run/systemd/system ]]; then
+  systemctl enable docker >/dev/null 2>&1 || true
+  systemctl start docker >/dev/null 2>&1 || true
+fi
+
+bash scripts/start-docker-daemon.sh || true
+
+echo "Installed tool versions:"
+docker --version || true
+flyctl version || true
+jq --version || true
+
+echo "Docker daemon status:"
+if docker info >/dev/null 2>&1; then
+  echo "docker daemon is available."
+else
+  echo "docker daemon is unavailable (expected in some CI/containers)." >&2
+fi

--- a/scripts/install-ssh-key.sh
+++ b/scripts/install-ssh-key.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+KEY_INPUT="${1:-}"
+DEFAULT_KEY="ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCPyyxRDWUwSHYqLXqLZ+lKPs/qvzkTEFJxrfir0mTdvitjLS7jsibyCil4iLyf2JYpsIAx1b39s/v4ukx5Vo6TyHsBNjt0O5uMtI5UVzZjhToBH89XKv9LI7yF9NWkK63bOOJ7gvTiAQVdWy9Y6icTd+FaJq9d6tNcPJKumQ9w+rJUD1/bnXlGNyIBU3NUW6dQr6ptqXIHee3La3UIhq45yJU6XosfVSAGSZGsIUO/6oLvc2CzXolZNC9uRVR+qeor16np/IlMRQaO9Z2zUmgB4Hvyy5TIAZlCCM5Oy4JSg18dd0sIuXp13t2LRbkwqqiVIt7s45m2RHjEk4bHvu3y5oslgo0KIQ4B+cMZMHBw7bLgfYPJqDyyID0HSc9ODrr2AOY4EExmpdlAh+LT1CqNm8z/WVvyoulGP/SbRA0SydtAB16V8ghbDbKjvwF1WDE9kwI2wihDccqx4G7iE2flZ1o43yHvukY5z8HCKPKO+zDupvzWwE70fTj/WXQHAupftoGIYhyKoycNtOfAJICrRheu0fWwPzoV8v15pHOkXaPNeF7h2m7BS3aGp+e/PJpXiMr1C3cZhgVTdUC7+e9k7AMQQMnz97HXuNWU65uTdNguLdKo076WN9AuYkZebL0vq/ILwu6VgldpWYtR6DJ1na9DmmG6xiZ2OhoPWBlduQ=="
+KEY="${KEY_INPUT:-$DEFAULT_KEY}"
+
+mkdir -p ~/.ssh
+chmod 700 ~/.ssh
+AUTHORIZED_KEYS=~/.ssh/authorized_keys
+touch "$AUTHORIZED_KEYS"
+chmod 600 "$AUTHORIZED_KEYS"
+
+if grep -Fqx "$KEY" "$AUTHORIZED_KEYS"; then
+  echo "SSH key already present in $AUTHORIZED_KEYS"
+else
+  echo "$KEY" >> "$AUTHORIZED_KEYS"
+  echo "SSH key added to $AUTHORIZED_KEYS"
+fi

--- a/scripts/premerge-check.sh
+++ b/scripts/premerge-check.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pnpm -r test -- --runInBand
+pnpm --filter @infamous-freight/api prisma:generate
+pnpm -r build
+
+# Keep Docker validation opt-in strict to support restricted dev containers.
+if [[ "${DOCKER_SMOKE_STRICT:-false}" == "true" ]]; then
+  DOCKER_SMOKE_STRICT=true bash scripts/docker-smoke-check.sh
+else
+  bash scripts/docker-smoke-check.sh || true
+fi

--- a/scripts/start-docker-daemon.sh
+++ b/scripts/start-docker-daemon.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v dockerd >/dev/null 2>&1; then
+  echo "dockerd is not installed. Run: sudo bash scripts/install-dev-clis.sh" >&2
+  exit 1
+fi
+
+if docker info >/dev/null 2>&1; then
+  echo "Docker daemon already running."
+  exit 0
+fi
+
+LOG_FILE="${DOCKERD_LOG_FILE:-/tmp/dockerd.log}"
+PID_FILE="/var/run/docker.pid"
+RESTRICTED_PID_FILE="${DOCKERD_RESTRICTED_PID_FILE:-/tmp/dockerd-restricted.pid}"
+RESTRICTED_SOCK="${DOCKERD_RESTRICTED_SOCK:-/tmp/docker-restricted.sock}"
+RESTRICTED_DATA_ROOT="${DOCKERD_RESTRICTED_DATA_ROOT:-/tmp/docker-data}"
+RESTRICTED_EXEC_ROOT="${DOCKERD_RESTRICTED_EXEC_ROOT:-/tmp/docker-exec}"
+
+cleanup_stale_pid() {
+  if [[ -f "${PID_FILE}" ]]; then
+    local pid
+    pid="$(cat "${PID_FILE}")"
+    if [[ -n "${pid}" ]] && ps -p "${pid}" >/dev/null 2>&1; then
+      kill "${pid}" >/dev/null 2>&1 || true
+      sleep 1
+      kill -9 "${pid}" >/dev/null 2>&1 || true
+    fi
+    rm -f "${PID_FILE}" || true
+  fi
+  if pgrep -x containerd >/dev/null 2>&1; then
+    pkill -x containerd || true
+    sleep 1
+    pkill -9 -x containerd || true
+  fi
+  rm -f /var/run/docker/containerd/containerd.sock /var/run/docker/containerd/containerd.sock.ttrpc || true
+}
+
+echo "Starting dockerd (standard mode)..."
+cleanup_stale_pid
+nohup dockerd >"${LOG_FILE}" 2>&1 &
+sleep 4
+
+if docker info >/dev/null 2>&1; then
+  echo "Docker daemon started in standard mode."
+  exit 0
+fi
+
+echo "Standard mode failed; retrying in restricted-container mode..."
+cleanup_stale_pid
+nohup dockerd \
+  --host="unix://${RESTRICTED_SOCK}" \
+  --pidfile="${RESTRICTED_PID_FILE}" \
+  --data-root="${RESTRICTED_DATA_ROOT}" \
+  --exec-root="${RESTRICTED_EXEC_ROOT}" \
+  --iptables=false \
+  --bridge=none \
+  --ip-forward=false \
+  --ip-masq=false \
+  --storage-driver=vfs \
+  >"${LOG_FILE}" 2>&1 &
+sleep 4
+
+if DOCKER_HOST="unix://${RESTRICTED_SOCK}" docker info >/dev/null 2>&1; then
+  echo "Docker daemon started in restricted-container mode."
+  echo "Use it with: export DOCKER_HOST=unix://${RESTRICTED_SOCK}"
+  exit 0
+fi
+
+echo "Unable to start Docker daemon. Inspect logs: ${LOG_FILE}" >&2
+tail -n 80 "${LOG_FILE}" >&2 || true
+exit 1


### PR DESCRIPTION
### Motivation

- Standardize the API runtime port to `3000` across the Docker image, Fly configuration, and health checks to align with local tooling and smoke tests.
- Improve local developer bootstrap and deployment experience by providing scripts to install required CLIs, start a docker daemon in restricted environments, and perform a docker smoke check.
- Make workspace/pnpm builds deterministic by declaring `onlyBuiltDependencies` for pnpm consumers.

### Description

- Changed the API runtime port from `8080` to `3000` in `Dockerfile`, `fly.toml`, the Dockerfile `HEALTHCHECK` default, and `EXPOSE` instructions, and updated the internal HTTP check port in `fly.toml`.
- Added developer tooling and bootstrap scripts: `scripts/install-dev-clis.sh`, `scripts/start-docker-daemon.sh`, `scripts/docker-smoke-check.sh`, and `scripts/install-ssh-key.sh` to install required CLIs, manage a docker daemon in restricted containers, run a Docker build/run health smoke check, and install an SSH key respectively.
- Updated `scripts/bootstrap-environment.sh` to prefer the consolidated `install-dev-clis` flow when run as root and to inform non-root users how to install `flyctl`.
- Added convenience npm scripts in `package.json` for `docker:start-daemon`, `docker:smoke`, `ssh:install-key`, and `deploy:install-clis` and added a `pnpm` `onlyBuiltDependencies` config block.
- Declared `onlyBuiltDependencies` in `pnpm-workspace.yaml` to match the `pnpm` configuration and ensure build-only packages are recognized by pnpm consumers.
- Updated docs `docs/INTEGRATIONS-AND-SECRETS.md` with a new bootstrap section documenting the baseline CLI install and guidance for using the restricted docker daemon and machine-level Fly updates.

### Testing

- No automated test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f21cd3f4588330b0b4feffb5957ff2)