### PR TITLE
Add SENTRY_DISABLE_UPLOAD opt-out and disable uploads on Netlify builds

### DIFF
--- a/apps/web/.env.production
+++ b/apps/web/.env.production
@@ -24,3 +24,4 @@ VITE_APP_VERSION=1.0.0
 # Observability
 VITE_SENTRY_DSN=https://<public-key>@o<org>.ingest.us.sentry.io/<project-id>
 VITE_SENTRY_ENABLED=true
+

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -6,17 +6,19 @@ import { sentryVitePlugin } from '@sentry/vite-plugin';
 const sentryAuthToken = process.env.SENTRY_AUTH_TOKEN;
 const sentryOrg = process.env.SENTRY_ORG;
 const sentryProject = process.env.SENTRY_PROJECT;
-// Enable sourcemap generation and upload only when all Sentry CI vars are present,
-// or when explicitly requested via SENTRY_SOURCEMAPS=1.
-const enableSentryPlugin =
+// Enable Sentry uploads when credentials exist, but allow CI to opt out
+// and avoid hard build failures on auth issues.
+const hasSentryCredentials =
   Boolean(sentryAuthToken) && Boolean(sentryOrg) && Boolean(sentryProject);
+const disableSentryUpload = process.env.SENTRY_DISABLE_UPLOAD === '1';
+const enableSentryUpload = hasSentryCredentials && !disableSentryUpload;
 const uploadSourcemaps =
-  enableSentryPlugin || process.env.SENTRY_SOURCEMAPS === '1';
+  enableSentryUpload || process.env.SENTRY_SOURCEMAPS === '1';
 
 export default defineConfig({
   plugins: [
     react(),
-    ...(enableSentryPlugin
+    ...(enableSentryUpload
       ? [
           sentryVitePlugin({
             org: sentryOrg as string,

--- a/netlify.toml
+++ b/netlify.toml
@@ -11,6 +11,8 @@
   NPM_FLAGS = "--legacy-peer-deps"
   # Skip the UI-installed @netlify/plugin-nextjs — this is a Vite app, not Next.js.
   NETLIFY_NEXT_PLUGIN_SKIP = "true"
+  # Keep Netlify builds green when Sentry auth token is missing/stale.
+  SENTRY_DISABLE_UPLOAD = "1"
 
 # Canonical host: redirect every alternate hostname to https://www.infamousfreight.com
 [[redirects]]


### PR DESCRIPTION
### Motivation

- Prevent Netlify builds from failing when Sentry credentials are missing or stale by allowing sourcemap upload to be explicitly disabled.

### Description

- Add support for an opt-out env var `SENTRY_DISABLE_UPLOAD` and compute `enableSentryUpload` in `apps/web/vite.config.ts` so uploads only occur when credentials exist and uploads are not disabled.
- Keep `SENTRY_SOURCEMAPS` as an override and preserve the plugin's auth-failure tolerant `errorHandler` that logs skipped uploads instead of failing the build.
- Set `SENTRY_DISABLE_UPLOAD = "1"` in `netlify.toml` build environment to keep Netlify builds green, and add a trailing newline in `apps/web/.env.production`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2831b17e48330878e53c49b79ab66)