### PR TITLE
Disable Sentry Netlify build plugin to avoid deploy failures when auth token is missing

### DIFF
--- a/apps/web/.netlify/netlify.toml
+++ b/apps/web/.netlify/netlify.toml
@@ -31,6 +31,7 @@ origin = "ui"
 package = "@sentry/netlify-build-plugin"
 
 [plugins.inputs]
+disable = true
 
 [build]
 publish = "/opt/build/repo/apps/web/dist"

--- a/netlify.toml
+++ b/netlify.toml
@@ -85,3 +85,10 @@
 # UI-configured installation that was missing the manifest.
 [[plugins]]
   package = "@netlify/plugin-sitemap"
+
+# Prevent deploy failures when Netlify UI has @sentry/netlify-build-plugin
+# enabled but SENTRY_AUTH_TOKEN is missing or stale (401 on release creation).
+[[plugins]]
+  package = "@sentry/netlify-build-plugin"
+  [plugins.inputs]
+    disable = true


### PR DESCRIPTION
### Motivation
- Prevent Netlify deploy failures caused by the UI-enabled `@sentry/netlify-build-plugin` when `SENTRY_AUTH_TOKEN` is missing or stale (which can produce 401s during release creation). 

### Description
- Added a `[[plugins]]` entry for `@sentry/netlify-build-plugin` with `[plugins.inputs] disable = true` to the repository `netlify.toml` and included an explanatory comment. 
- Mirrored the change by adding `disable = true` under the existing `@sentry/netlify-build-plugin` entry in `apps/web/.netlify/netlify.toml`. 
- Minor whitespace/newline normalization at the end of `apps/web/.netlify/netlify.toml`.

### Testing
- No automated tests were run for this configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f28c614fb883308fa75981bbb1bb12)