### PR TITLE
Validate Sentry DSN before init, redact committed DSN examples, add `typecheck` script

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -14,7 +14,7 @@ VITE_SUPABASE_PUBLISHABLE_KEY=sb_publishable_A--wLALxTW5UkOcgFnubLQ_SX_knoSR
 
 # Sentry error monitoring
 # apps/web is a Vite + React app. Do not use the Vue or Next.js Sentry wizard here.
-VITE_SENTRY_DSN=https://6bfe6c333544c976cbba3633aad08ad4@o4511126931963904.ingest.us.sentry.io/4511126932226048
+VITE_SENTRY_DSN=https://<public-key>@o<org-id>.ingest.us.sentry.io/<project-id>
 # Set to "false" to disable Sentry even when a DSN is present.
 # Defaults to enabled in production when DSN is set.
 VITE_SENTRY_ENABLED=true

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "build": "tsc && vite build",
     "preview": "vite preview",
+    "typecheck": "tsc --noEmit",
     "lint": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -10,10 +10,32 @@ const sentryEnabledEnv: string = import.meta.env.VITE_SENTRY_ENABLED ?? '';
 const sentryEnvironment: string = import.meta.env.MODE;
 const isProd = sentryEnvironment === 'production';
 
+const isValidSentryDsn = (dsn: string): boolean => {
+  if (!dsn || /<[^>]+>/.test(dsn)) {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(dsn);
+    const hasValidHost = /^o\d+\.ingest(?:\.[a-z0-9-]+)?\.sentry\.io$/.test(parsed.hostname);
+    const hasProjectId = /^\/\d+$/.test(parsed.pathname);
+    const hasPublicKey = parsed.username.length > 0;
+
+    return parsed.protocol === 'https:' && hasValidHost && hasProjectId && hasPublicKey;
+  } catch {
+    return false;
+  }
+};
+
+
+if (!isValidSentryDsn(sentryDsn) && sentryDsn.length > 0 && sentryEnabledEnv !== 'false') {
+  console.warn('Sentry is disabled because VITE_SENTRY_DSN is not a valid ingest DSN.');
+}
+
 // Sentry is active when a DSN is present and not explicitly disabled.
 // Set VITE_SENTRY_ENABLED=false to opt out even if a DSN is configured.
 const sentryEnabled =
-  sentryDsn.length > 0 &&
+  isValidSentryDsn(sentryDsn) &&
   sentryEnabledEnv !== 'false' &&
   (isProd || sentryEnabledEnv === 'true');
 

--- a/docs/INTEGRATIONS-AND-SECRETS.md
+++ b/docs/INTEGRATIONS-AND-SECRETS.md
@@ -51,7 +51,7 @@ Set these in **Netlify → Site settings → Environment variables** for the web
 | `VITE_STRIPE_PUBLIC_KEY` | Payments team | Stripe publishable key, `pk_live_...` | Used by `@stripe/stripe-js` to initialise the Stripe payment element |
 | `VITE_SUPABASE_URL` | Platform team | Supabase project URL | Used by the web client for Supabase auth and client calls |
 | `VITE_SUPABASE_ANON_KEY` | Platform team | Supabase anon key | Public Supabase client key used by the browser app |
-| `VITE_SENTRY_DSN` | Platform team | `https://6bfe6c333544c976cbba3633aad08ad4@o4511126931963904.ingest.us.sentry.io/4511126932226048` | Connects the React web app to the `infamous-freight` Sentry project |
+| `VITE_SENTRY_DSN` | Platform team | `https://<public-key>@o<org-id>.ingest.us.sentry.io/<project-id>` | Connects the React web app to the `infamous-freight` Sentry project |
 | `VITE_SENTRY_ENABLED` | Platform team | `true` | Enables Sentry in production when the DSN is present; set to `false` for emergency disable |
 | `SENTRY_AUTH_TOKEN` | Platform team | Sentry auth token with release/source-map permissions | Allows the Sentry Vite plugin to upload production source maps during Netlify builds |
 | `SENTRY_ORG` | Platform team | `infmous` | Sentry organization slug |
@@ -167,7 +167,7 @@ push to `main`. GitHub Actions does not deploy the web app.
    ```bash
    VITE_API_URL=https://api.infamousfreight.com \
    VITE_STRIPE_PUBLIC_KEY=pk_live_... \
-   VITE_SENTRY_DSN=https://6bfe6c333544c976cbba3633aad08ad4@o4511126931963904.ingest.us.sentry.io/4511126932226048 \
+   VITE_SENTRY_DSN=https://<public-key>@o<org-id>.ingest.us.sentry.io/<project-id> \
    VITE_SENTRY_ENABLED=true \
    npm run build:web
    ```
@@ -176,7 +176,7 @@ push to `main`. GitHub Actions does not deploy the web app.
    Add or correct the variable in Netlify → Site settings → Environment variables.
    For Sentry, set:
    ```env
-   VITE_SENTRY_DSN=https://6bfe6c333544c976cbba3633aad08ad4@o4511126931963904.ingest.us.sentry.io/4511126932226048
+   VITE_SENTRY_DSN=https://<public-key>@o<org-id>.ingest.us.sentry.io/<project-id>
    VITE_SENTRY_ENABLED=true
    SENTRY_ORG=infmous
    SENTRY_PROJECT=infamous-freight


### PR DESCRIPTION
### Motivation
- Prevent accidental use of a real or placeholder Sentry DSN in the browser by validating the DSN at runtime and removing sensitive/example values from example files. 
- Make local CI-friendly type checks easier to run with an explicit `typecheck` npm script. 

### Description
- Added a DSN validation helper `isValidSentryDsn` in `apps/web/src/main.tsx` and gated Sentry initialization on its result, with a `console.warn` when a DSN is present but invalid. 
- Replaced the committed real-looking Sentry DSN in `apps/web/.env.example` with a generic placeholder `https://<public-key>@o<org-id>.ingest.us.sentry.io/<project-id>`. 
- Updated documentation `docs/INTEGRATIONS-AND-SECRETS.md` to use the same placeholder instead of a concrete DSN. 
- Added a `typecheck` script (`tsc --noEmit`) to `apps/web/package.json` to allow running type checking independently. 

### Testing
- Ran `npm run typecheck` (calls `tsc --noEmit`) and it completed successfully. 
- Ran `npm run lint` (configured to `tsc --noEmit`) and it completed successfully. 
- Performed a local `npm run build` for the web app and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f28e91879c8330a451a526bc743bef)