### PR TITLE
Introduce Prisma client factory with Accelerate support and improve web UI accessibility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@prisma/client": "6.19.3",
+    "@prisma/extension-accelerate": "3.0.1",
     "@sentry/node": "^8.55.1",
     "cors": "^2.8.5",
     "dotenv": "^17.4.2",

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -3,9 +3,9 @@
  * Creates sample data for first carrier onboarding
  */
 
-import { PrismaClient } from '@prisma/client';
+import { createPrismaClient } from '../src/prisma-client';
 
-const prisma = new PrismaClient();
+const prisma = createPrismaClient();
 
 async function main() {
   console.log('🌱 Seeding database...');

--- a/apps/api/src/ai-usage.ts
+++ b/apps/api/src/ai-usage.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'crypto';
 import { PrismaClient } from '@prisma/client';
+import { createPrismaClient } from './prisma-client';
 
 export type AiUsageInput = {
   carrierId: string;
@@ -184,6 +185,6 @@ export function createAiUsageStore(): AiUsageStore {
     throw new Error('DATABASE_URL is required outside of test mode.');
   }
 
-  prismaClient ??= new PrismaClient();
+  prismaClient ??= createPrismaClient();
   return new PrismaAiUsageStore(prismaClient);
 }

--- a/apps/api/src/data-store.ts
+++ b/apps/api/src/data-store.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'crypto';
 import { PrismaClient } from '@prisma/client';
+import { createPrismaClient } from './prisma-client';
 import { BillingSyncPayload } from './billing';
 
 type BaseRecord = {
@@ -1002,6 +1003,6 @@ export function createDataStore(): DataStore {
     throw new Error('DATABASE_URL is required outside of test mode.');
   }
 
-  prismaClient ??= new PrismaClient();
+  prismaClient ??= createPrismaClient();
   return new PrismaDataStore(prismaClient);
 }

--- a/apps/api/src/prisma-client.ts
+++ b/apps/api/src/prisma-client.ts
@@ -1,0 +1,27 @@
+import { PrismaClient } from '@prisma/client';
+import { withAccelerate } from '@prisma/extension-accelerate';
+
+let client: PrismaClient | null = null;
+
+export function createPrismaClient(): PrismaClient {
+  if (client) return client;
+
+  const databaseUrl = process.env.DATABASE_URL;
+
+  if (typeof databaseUrl === 'string' && databaseUrl.trim().length === 0) {
+    throw new Error('DATABASE_URL is set but empty.');
+  }
+  const useAccelerate = typeof databaseUrl === 'string' && databaseUrl.startsWith('prisma+postgres://');
+
+  if (useAccelerate) {
+    const accelerateBase = new PrismaClient({
+      accelerateUrl: databaseUrl,
+    } as ConstructorParameters<typeof PrismaClient>[0]);
+
+    client = accelerateBase.$extends(withAccelerate()) as unknown as PrismaClient;
+    return client;
+  }
+
+  client = new PrismaClient();
+  return client;
+}

--- a/apps/api/src/stripe-webhook-events.ts
+++ b/apps/api/src/stripe-webhook-events.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from '@prisma/client';
+import { createPrismaClient } from './prisma-client';
 
 export type StripeWebhookEventStatus = 'received' | 'processed' | 'failed' | 'ignored';
 
@@ -65,6 +66,6 @@ export function createStripeWebhookEventStore(): StripeWebhookEventStore {
     throw new Error('DATABASE_URL is required outside of test mode.');
   }
 
-  prismaClient ??= new PrismaClient();
+  prismaClient ??= createPrismaClient();
   return new PrismaStripeWebhookEventStore(prismaClient);
 }

--- a/apps/web/src/components/ui/Sidebar.tsx
+++ b/apps/web/src/components/ui/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { NavLink, useLocation } from 'react-router-dom';
+import { NavLink } from 'react-router-dom';
 import { useAppStore } from '@/store/app-store';
 import { canAccessLaunchValidation } from '@/lib/launchValidationAccess';
 import {
@@ -12,10 +12,11 @@ type NavItem = {
   label: string;
   icon: LucideIcon;
   badge?: string;
+  end?: boolean;
 };
 
 const baseNavItems: NavItem[] = [
-  { path: '/', label: 'Operations', icon: LayoutDashboard },
+  { path: '/', label: 'Operations', icon: LayoutDashboard, end: true },
   { path: '/quotes', label: 'Quotes', icon: ClipboardList },
   { path: '/loads', label: 'Loads', icon: Truck },
   { path: '/dispatch', label: 'Dispatch Board', icon: Radio },
@@ -38,13 +39,13 @@ const settingsNavItem: NavItem = { path: '/settings', label: 'Settings', icon: S
 
 const Sidebar: React.FC = () => {
   const { sidebarOpen, toggleSidebar, logout, user } = useAppStore();
-  const location = useLocation();
   const navItems: NavItem[] = canAccessLaunchValidation(user?.role)
     ? [...baseNavItems, launchValidationNavItem, settingsNavItem]
     : [...baseNavItems, settingsNavItem];
 
   return (
     <aside
+      aria-label="Primary navigation"
       className={`fixed left-0 top-0 h-full bg-infamous-card border-r border-infamous-border z-50 flex flex-col transition-all duration-300 ${
         sidebarOpen ? 'w-64' : 'w-16'
       }`}
@@ -57,14 +58,16 @@ const Sidebar: React.FC = () => {
           </div>
           {sidebarOpen && (
             <div>
-              <h1 className="text-sm font-extrabold tracking-tight leading-none">INFAMOUS</h1>
+              <span className="text-sm font-extrabold tracking-tight leading-none">INFAMOUS</span>
               <p className="text-[10px] text-gray-500 leading-none">FREIGHT</p>
             </div>
           )}
         </div>
         <button
           onClick={toggleSidebar}
-          className={`ml-auto text-gray-500 hover:text-white transition-colors p-1 rounded-lg hover:bg-infamous-border ${!sidebarOpen && 'hidden'}`}
+          aria-label={sidebarOpen ? 'Collapse sidebar' : 'Expand sidebar'}
+          aria-expanded={sidebarOpen}
+          className={`ml-auto text-gray-500 hover:text-white transition-colors p-1 rounded-lg hover:bg-infamous-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-infamous-orange ${!sidebarOpen && 'hidden'}`}
         >
           {sidebarOpen ? <ChevronLeft size={16} /> : <ChevronRight size={16} />}
         </button>
@@ -72,44 +75,48 @@ const Sidebar: React.FC = () => {
 
       {/* Navigation */}
       <nav className="flex-1 py-4 space-y-1 px-2 overflow-y-auto">
-        {navItems.map((item) => {
-          const isActive = location.pathname === item.path;
-          return (
-            <NavLink
-              key={item.path}
-              to={item.path}
-              className={`flex items-center gap-3 px-3 py-2.5 rounded-xl transition-all group relative ${
-                isActive
-                  ? 'bg-infamous-orange/10 text-infamous-orange border border-infamous-orange/20'
-                  : 'text-gray-400 hover:text-white hover:bg-infamous-border'
-              } ${!sidebarOpen && 'justify-center'}`}
-            >
-              <item.icon size={20} className={isActive ? 'text-infamous-orange' : 'text-gray-500 group-hover:text-white'} />
-              {sidebarOpen && (
-                <>
-                  <span className="text-sm font-medium flex-1">{item.label}</span>
-                  {item.badge && (
-                    <span className="bg-infamous-orange text-white text-[10px] font-bold px-1.5 py-0.5 rounded-full min-w-[18px] text-center">
-                      {item.badge}
-                    </span>
-                  )}
-                </>
-              )}
-              {!sidebarOpen && item.badge && (
-                <span className="absolute -top-1 -right-1 w-4 h-4 bg-infamous-orange rounded-full text-[9px] font-bold text-white flex items-center justify-center">
-                  {item.badge}
-                </span>
-              )}
-            </NavLink>
-          );
-        })}
+        {navItems.map((item) => (
+          <NavLink
+            key={item.path}
+            to={item.path}
+            end={item.end}
+            aria-label={item.label}
+            className={({ isActive }) => `flex items-center gap-3 px-3 py-2.5 rounded-xl transition-all group relative ${
+              isActive
+                ? 'bg-infamous-orange/10 text-infamous-orange border border-infamous-orange/20'
+                : 'text-gray-400 hover:text-white hover:bg-infamous-border'
+            } ${!sidebarOpen ? 'justify-center' : ''}`}
+          >
+            {({ isActive }) => (
+              <>
+                <item.icon size={20} className={isActive ? 'text-infamous-orange' : 'text-gray-500 group-hover:text-white'} />
+                {sidebarOpen && (
+                  <>
+                    <span aria-hidden="true" className="text-sm font-medium flex-1">{item.label}</span>
+                    {item.badge && (
+                      <span aria-hidden="true" className="bg-infamous-orange text-white text-[10px] font-bold px-1.5 py-0.5 rounded-full min-w-[18px] text-center">
+                        {item.badge}
+                      </span>
+                    )}
+                  </>
+                )}
+                {!sidebarOpen && item.badge && (
+                  <span aria-hidden="true" className="absolute -top-1 -right-1 w-4 h-4 bg-infamous-orange rounded-full text-[9px] font-bold text-white flex items-center justify-center">
+                    {item.badge}
+                  </span>
+                )}
+              </>
+            )}
+          </NavLink>
+        ))}
       </nav>
 
       {/* Bottom */}
       <div className={`border-t border-infamous-border p-3 ${!sidebarOpen && 'flex justify-center'}`}>
         <button
           onClick={logout}
-          className={`flex items-center gap-3 px-3 py-2 rounded-xl text-gray-500 hover:text-red-400 hover:bg-red-500/10 transition-all ${!sidebarOpen && 'justify-center'}`}
+          aria-label="Log out"
+          className={`flex items-center gap-3 px-3 py-2 rounded-xl text-gray-500 hover:text-red-400 hover:bg-red-500/10 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-infamous-orange ${!sidebarOpen && 'justify-center'}`}
           title="Log Out"
         >
           <LogOut size={18} />

--- a/apps/web/src/components/ui/TopBar.tsx
+++ b/apps/web/src/components/ui/TopBar.tsx
@@ -2,20 +2,22 @@ import { Bell, Search, Command, CircleDot } from 'lucide-react';
 import { useAppStore } from '@/store/app-store';
 
 const TopBar: React.FC = () => {
-  const { user, sidebarOpen, notifications, unreadCount } = useAppStore();
+  const { user, sidebarOpen, unreadCount } = useAppStore();
 
   return (
-    <header className={`h-16 bg-infamous-card/80 backdrop-blur-xl border-b border-infamous-border flex items-center justify-between px-6 transition-all duration-300 ${sidebarOpen ? '' : ''}`}>
+    <header role="banner" className={`h-16 bg-infamous-card/80 backdrop-blur-xl border-b border-infamous-border flex items-center justify-between px-6 transition-all duration-300 ${sidebarOpen ? '' : ''}`}>
       {/* Search */}
-      <div className="flex items-center gap-3 flex-1 max-w-xl">
+      <div role="search" aria-label="Global" className="flex items-center gap-3 flex-1 max-w-xl">
         <div className="relative flex-1">
           <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-600" />
+          <label htmlFor="global-search" className="sr-only">Search loads, drivers, brokers</label>
           <input
+            id="global-search"
             type="text"
             placeholder="Search loads, drivers, brokers..."
-            className="w-full bg-[#1a1a1a] border border-infamous-border rounded-xl pl-10 pr-4 py-2 text-sm text-white placeholder-gray-600 focus:border-infamous-orange focus:outline-none transition-colors"
+            className="w-full bg-[#1a1a1a] border border-infamous-border rounded-xl pl-10 pr-4 py-2 text-sm text-white placeholder-gray-600 focus:border-infamous-orange focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-infamous-orange transition-colors"
           />
-          <div className="absolute right-3 top-1/2 -translate-y-1/2 flex items-center gap-1 text-gray-600">
+          <div aria-hidden="true" className="absolute right-3 top-1/2 -translate-y-1/2 flex items-center gap-1 text-gray-600">
             <Command size={12} />
             <span className="text-[10px]">K</span>
           </div>
@@ -25,10 +27,10 @@ const TopBar: React.FC = () => {
       {/* Actions */}
       <div className="flex items-center gap-3">
         {/* Notifications */}
-        <button className="relative p-2.5 rounded-xl text-gray-400 hover:text-white hover:bg-infamous-border transition-all">
+        <button aria-label={`Open notifications${unreadCount > 0 ? ` (${unreadCount} unread)` : ""}`} className="relative p-2.5 rounded-xl text-gray-400 hover:text-white hover:bg-infamous-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-infamous-orange transition-all">
           <Bell size={18} />
           {unreadCount > 0 && (
-            <span className="absolute top-1.5 right-1.5 w-4 h-4 bg-infamous-orange rounded-full text-[9px] font-bold text-white flex items-center justify-center">
+            <span aria-hidden="true" className="absolute top-1.5 right-1.5 w-4 h-4 bg-infamous-orange rounded-full text-[9px] font-bold text-white flex items-center justify-center">
               {unreadCount}
             </span>
           )}

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -7,7 +7,7 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
 }
 
 export function Button({ variant = 'default', className = '', type = 'button', ...props }: ButtonProps) {
-  const base = 'inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed';
+  const base = 'inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950';
   const byVariant: Record<ButtonVariant, string> = {
     default: 'bg-red-600 text-white hover:bg-red-700',
     outline: 'border border-zinc-700 text-zinc-100 hover:bg-zinc-800',

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -5,7 +5,7 @@ export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
 export function Input({ className = '', ...props }: InputProps) {
   return (
     <input
-      className={`w-full rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-red-600 ${className}`.trim()}
+      className={`w-full rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-600 ${className}`.trim()}
       {...props}
     />
   );

--- a/apps/web/src/layouts/AppLayout.tsx
+++ b/apps/web/src/layouts/AppLayout.tsx
@@ -94,7 +94,15 @@ const AppLayout: React.FC = () => {
   if (publicPaths.some((p) => location.pathname.startsWith(p))) {
     return (
       <>
-        <Outlet />
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[100] focus:rounded-md focus:bg-infamous-orange focus:px-3 focus:py-2 focus:text-white"
+        >
+          Skip to main content
+        </a>
+        <main id="main-content" tabIndex={-1}>
+          <Outlet />
+        </main>
         <Toaster position="top-right" toastOptions={{
           style: { background: '#1a1a1a', color: '#fff', border: '1px solid #333' },
         }} />
@@ -104,10 +112,16 @@ const AppLayout: React.FC = () => {
 
   return (
     <div className="flex h-screen w-screen bg-infamous-dark overflow-hidden">
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[100] focus:rounded-md focus:bg-infamous-orange focus:px-3 focus:py-2 focus:text-white"
+      >
+        Skip to main content
+      </a>
       <Sidebar />
       <div className={`flex flex-col flex-1 transition-all duration-300 ${sidebarOpen ? 'ml-64' : 'ml-16'}`}>
         <TopBar />
-        <main className="flex-1 overflow-y-auto p-6">
+        <main id="main-content" tabIndex={-1} className="flex-1 overflow-y-auto p-6">
           <Outlet />
         </main>
       </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@prisma/client':
         specifier: 6.19.3
         version: 6.19.3(prisma@6.19.3(typescript@5.9.3))(typescript@5.9.3)
+      '@prisma/extension-accelerate':
+        specifier: 3.0.1
+        version: 3.0.1(@prisma/client@6.19.3(prisma@6.19.3(typescript@5.9.3))(typescript@5.9.3))
       '@sentry/node':
         specifier: ^8.55.1
         version: 8.55.2
@@ -1039,6 +1042,12 @@ packages:
 
   '@prisma/engines@6.19.3':
     resolution: {integrity: sha512-RSYxtlYFl5pJ8ZePgMv0lZ9IzVCOdTPOegrs2qcbAEFrBI1G33h6wyC9kjQvo0DnYEhEVY0X4LsuFHXLKQk88g==}
+
+  '@prisma/extension-accelerate@3.0.1':
+    resolution: {integrity: sha512-xc+kn4AjjTzS9jsdD1JWCebB09y0Aj+C8GjjG7oUm81PF9psvmJOw5rxpl7tOEBz/8hmuNX996XL28ys/OLxVA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      '@prisma/client': '>=4.16.1'
 
   '@prisma/fetch-engine@6.19.3':
     resolution: {integrity: sha512-tKtl/qco9Nt7LU5iKhpultD8O4vMCZcU2CHjNTnRrL1QvSUr5W/GcyFPjNL87GtRrwBc7ubXXD9xy4EvLvt8JA==}
@@ -4551,6 +4560,10 @@ snapshots:
       '@prisma/engines-version': 7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7
       '@prisma/fetch-engine': 6.19.3
       '@prisma/get-platform': 6.19.3
+
+  '@prisma/extension-accelerate@3.0.1(@prisma/client@6.19.3(prisma@6.19.3(typescript@5.9.3))(typescript@5.9.3))':
+    dependencies:
+      '@prisma/client': 6.19.3(prisma@6.19.3(typescript@5.9.3))(typescript@5.9.3)
 
   '@prisma/fetch-engine@6.19.3':
     dependencies:


### PR DESCRIPTION
### Motivation
- Centralize Prisma client creation to enable optional use of the Prisma Accelerate extension when a special `DATABASE_URL` is used. 
- Replace ad-hoc `new PrismaClient()` usage to ensure consistent configuration and error handling for empty `DATABASE_URL` values. 
- Improve accessibility, keyboard navigation, and focus styles across the web UI components and layout.

### Description
- Added `apps/api/src/prisma-client.ts` which exports `createPrismaClient()` that reuses a singleton `PrismaClient`, validates `DATABASE_URL`, and wires `@prisma/extension-accelerate` when the URL starts with `prisma+postgres://`.
- Updated `apps/api/package.json` and lockfile to add the `@prisma/extension-accelerate` dependency.
- Replaced direct `new PrismaClient()` calls with `createPrismaClient()` in `prisma/seed.ts`, `src/ai-usage.ts`, `src/data-store.ts`, and `src/stripe-webhook-events.ts` to use the centralized client.
- Accessibility and UX fixes in the web app: enhanced `Sidebar`, `TopBar`, `AppLayout`, `button`, `input` components and other UI pieces with ARIA attributes, roles, skip-links, improved `NavLink` usage (including `end` handling), focus-visible rings, and improved labels and semantics.

### Testing
- Ran API unit tests with `pnpm -w -F apps/api test`, and the test suite completed successfully.  
- Performed type checking and linting via `pnpm -w -r test` and `pnpm -w -r lint`, and both succeeded.  
- Built the web app layout changes with a local build (`pnpm -w -r build`) to validate bundling and no runtime TypeScript errors occurred.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f295144df083309ef3c4fbfaf06003)