### PR TITLE
Extract jest-arg builder, improve run-jest script behavior, and add unit tests

### DIFF
--- a/apps/api/scripts/run-jest.cjs
+++ b/apps/api/scripts/run-jest.cjs
@@ -6,7 +6,7 @@ function buildJestArgs(rawArgs) {
 
   // Default to in-band execution for CI/local stability, while still allowing explicit override flags.
   const hasExplicitRunInBandSetting = filteredArgs.some((arg) =>
-    ['-i', '--runInBand', '--runInBand=true', '--runInBand=false'].includes(arg)
+    arg === '-i' || /^--runInBand(?:=(?:true|false))?$/i.test(arg)
   );
 
   return hasExplicitRunInBandSetting ? filteredArgs : ['--runInBand', ...filteredArgs];

--- a/apps/api/scripts/run-jest.cjs
+++ b/apps/api/scripts/run-jest.cjs
@@ -1,29 +1,44 @@
 #!/usr/bin/env node
 const { spawnSync } = require('node:child_process');
 
-const rawArgs = process.argv.slice(2);
-const filteredArgs = rawArgs.filter((arg) => arg !== '--');
+function buildJestArgs(rawArgs) {
+  const filteredArgs = rawArgs.filter((arg) => arg !== '--');
 
-const hasRunInBand = filteredArgs.some((arg) =>
-  ['-i', '--runInBand', '--runInBand=true'].includes(arg)
-);
-const jestArgs = hasRunInBand ? filteredArgs : ['--runInBand', ...filteredArgs];
+  // Default to in-band execution for CI/local stability, while still allowing explicit override flags.
+  const hasExplicitRunInBandSetting = filteredArgs.some((arg) =>
+    ['-i', '--runInBand', '--runInBand=true', '--runInBand=false'].includes(arg)
+  );
 
-const jestBin = require.resolve('jest/bin/jest');
-const result = spawnSync(process.execPath, [jestBin, ...jestArgs], {
-  stdio: 'inherit',
-});
-
-if (typeof result.status === 'number') {
-  process.exit(result.status);
+  return hasExplicitRunInBandSetting ? filteredArgs : ['--runInBand', ...filteredArgs];
 }
 
-if (result.error) {
-  throw result.error;
+function run() {
+  const rawArgs = process.argv.slice(2);
+  const jestArgs = buildJestArgs(rawArgs);
+
+  const jestBin = require.resolve('jest/bin/jest');
+  const result = spawnSync(process.execPath, [jestBin, ...jestArgs], {
+    stdio: 'inherit',
+  });
+
+  if (typeof result.status === 'number') {
+    process.exit(result.status);
+  }
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.signal) {
+    process.kill(process.pid, result.signal);
+    return;
+  }
+
+  process.exit(1);
 }
 
-if (result.signal) {
-  process.kill(process.pid, result.signal);
-  return;
+if (require.main === module) {
+  run();
 }
-process.exit(1);
+
+module.exports = { buildJestArgs };

--- a/apps/api/test/run-jest-script.test.ts
+++ b/apps/api/test/run-jest-script.test.ts
@@ -1,0 +1,29 @@
+const { buildJestArgs } = require('../scripts/run-jest.cjs') as {
+  buildJestArgs: (rawArgs: string[]) => string[];
+};
+
+describe('run-jest wrapper', () => {
+  it('adds --runInBand when no explicit runInBand flag is provided', () => {
+    expect(buildJestArgs(['--coverage'])).toEqual(['--runInBand', '--coverage']);
+  });
+
+  it('does not add --runInBand when explicitly enabled', () => {
+    expect(buildJestArgs(['--runInBand', '--coverage'])).toEqual(['--runInBand', '--coverage']);
+  });
+
+  it('does not add --runInBand when explicitly disabled', () => {
+    expect(buildJestArgs(['--runInBand=false', '--coverage'])).toEqual(['--runInBand=false', '--coverage']);
+  });
+
+  it('does not add --runInBand when shorthand -i is used', () => {
+    expect(buildJestArgs(['-i', '--coverage'])).toEqual(['-i', '--coverage']);
+  });
+
+  it('does not add --runInBand when explicitly set to true', () => {
+    expect(buildJestArgs(['--runInBand=true', '--coverage'])).toEqual(['--runInBand=true', '--coverage']);
+  });
+
+  it('strips npm passthrough separator', () => {
+    expect(buildJestArgs(['--', '--coverage'])).toEqual(['--runInBand', '--coverage']);
+  });
+});


### PR DESCRIPTION
### Motivation
- Make the `run-jest.cjs` wrapper more testable and robust by extracting the argument-building logic into a named function and exporting it for unit testing. 
- Ensure consistent default behavior of running Jest in-band while respecting explicit user flags (including explicit disabling) and properly handling child process signals and exit codes.

### Description
- Extracted argument handling into `buildJestArgs(rawArgs)` that strips the npm passthrough separator (`--`) and adds `--runInBand` unless an explicit runInBand flag (including `--runInBand=false`) or shorthand `-i` is provided. 
- Wrapped the execution logic in a `run()` function, kept the previous spawn behavior using `spawnSync`, and added proper handling for `result.status`, `result.error`, and `result.signal`. 
- Added a `require.main === module` guard to only execute `run()` when the script is invoked directly and exported `buildJestArgs` for testing. 
- Added unit tests `apps/api/test/run-jest-script.test.ts` that validate argument transformations and stripping of the `--` separator.

### Testing
- Added and ran the Jest unit test file `apps/api/test/run-jest-script.test.ts` which exercises `buildJestArgs`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2ba0a39588330a2c543380d72e43f)