### PR TITLE
Update Netlify build command to `npm run build`

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
 
 [build]
   publish = "apps/web/dist"
-  command = "npm run build:web"
+  command = "npm run build"
 
 [build.environment]
   NODE_VERSION = "20"


### PR DESCRIPTION
### Motivation
- Use the repository's generic build script name so Netlify runs the correct build for this Vite app by switching from `npm run build:web` to `npm run build`.

### Description
- Update the `[build] command` in `netlify.toml` from `npm run build:web` to `npm run build`.

### Testing
- No automated tests were run for this configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2cea4fe748330bca43a16543817fa)