### PR TITLE
Run API tests in-band, fix Prisma accelerate mocks, and add web metadata + OG assets

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,8 +12,8 @@
     "build": "npm run prisma:generate && tsc -p tsconfig.json",
     "start:dev": "tsx watch src/server.ts",
     "start:prod": "node dist/src/server.js",
-    "test": "node scripts/run-jest.cjs",
-    "test:coverage": "node scripts/run-jest.cjs --coverage",
+    "test": "node scripts/run-jest.cjs --runInBand",
+    "test:coverage": "node scripts/run-jest.cjs --runInBand --coverage",
     "lint": "tsc -p tsconfig.json --noEmit",
     "prisma:generate": "prisma generate"
   },

--- a/apps/api/test/prisma-client.test.ts
+++ b/apps/api/test/prisma-client.test.ts
@@ -17,7 +17,7 @@ describe('createPrismaClient', () => {
       return { PrismaClient };
     });
 
-    jest.doMock('@prisma/extension-accelerate', () => ({ withAccelerate: undefined }));
+    jest.doMock('@prisma/extension-accelerate', () => ({ withAccelerate: undefined }), { virtual: true });
 
     const { createPrismaClient } = require('../src/prisma-client') as typeof import('../src/prisma-client');
 
@@ -40,7 +40,7 @@ describe('createPrismaClient', () => {
     });
 
     const withAccelerate = jest.fn(() => ({ name: 'accelerate-extension' }));
-    jest.doMock('@prisma/extension-accelerate', () => ({ withAccelerate }));
+    jest.doMock('@prisma/extension-accelerate', () => ({ withAccelerate }), { virtual: true });
 
     const { createPrismaClient } = require('../src/prisma-client') as typeof import('../src/prisma-client');
 

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -5,13 +5,50 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#0a0a0a" />
-    <meta name="description" content="Infamous Freight — The freight dispatch platform built by truckers, for truckers. Auto-dispatch AI, rate negotiation, voice booking, and ELD sync." />
+    <meta name="color-scheme" content="dark" />
+    <meta
+      name="description"
+      content="Infamous Freight is an AI-powered freight command center with auto-dispatch, rate negotiation, voice booking, ELD sync, and end-to-end shipment visibility."
+    />
+    <meta
+      name="keywords"
+      content="freight management system, trucking dispatch software, AI dispatch, TMS, rate negotiation, ELD integration"
+    />
+
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Infamous Freight" />
+    <meta property="og:url" content="/" />
+    <meta property="og:title" content="Infamous Freight — AI Freight Command Center" />
+    <meta
+      property="og:description"
+      content="Run dispatch, visibility, and carrier operations from one AI-powered operating system built for modern fleets."
+    />
+    <meta property="og:image" content="/og-image.svg" />
+    <meta property="og:image:alt" content="Infamous Freight AI Freight Command Center" />
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Infamous Freight — AI Freight Command Center" />
+    <meta
+      name="twitter:description"
+      content="Automate dispatch workflows, improve lane decisions, and keep customers informed in real time."
+    />
+    <meta name="twitter:image" content="/og-image.svg" />
+    <meta name="twitter:image:alt" content="Infamous Freight AI Freight Command Center" />
+
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet" />
-    <title>Infamous Freight — Freight Command Center</title>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap"
+      rel="stylesheet"
+    />
+
+    <title>Infamous Freight — AI Freight Command Center</title>
     <style>
-      body { background: #0a0a0a; margin: 0; font-family: 'Inter', system-ui, sans-serif; }
+      body {
+        background: #0a0a0a;
+        margin: 0;
+        font-family: 'Inter', system-ui, sans-serif;
+      }
     </style>
   </head>
   <body>

--- a/apps/web/public/favicon.svg
+++ b/apps/web/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Infamous Freight">
+  <rect width="64" height="64" rx="12" fill="#0a0a0a"/>
+  <path d="M14 20h36v8H14zm0 12h24v8H14zm0 12h30v8H14z" fill="#f97316"/>
+</svg>

--- a/apps/web/public/og-image.svg
+++ b/apps/web/public/og-image.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-label="Infamous Freight preview">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0a0a0a"/>
+      <stop offset="100%" stop-color="#171717"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <rect x="80" y="80" width="1040" height="470" rx="24" fill="#111827" stroke="#27272a"/>
+  <text x="140" y="250" fill="#f97316" font-size="56" font-family="Inter, Arial, sans-serif" font-weight="700">Infamous Freight</text>
+  <text x="140" y="320" fill="#ffffff" font-size="44" font-family="Inter, Arial, sans-serif" font-weight="600">AI Freight Command Center</text>
+  <text x="140" y="390" fill="#a1a1aa" font-size="30" font-family="Inter, Arial, sans-serif">Dispatch • Rate Negotiation • ELD Sync • Visibility</text>
+</svg>


### PR DESCRIPTION
### Motivation
- Ensure Jest runs reliably in CI by forcing serial test execution for the API package with `--runInBand`.
- Allow tests to mock an optional dependency (`@prisma/extension-accelerate`) correctly by using virtual mocks so behavior can be validated when the extension is absent or present.
- Improve SEO and social sharing for the web app by adding richer meta tags, Open Graph/Twitter cards, and site assets.

### Description
- Updated `apps/api/package.json` test scripts to `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2d5add07c8330b8143bb6c86fc3f5)