### PR TITLE
Add SENTRY_ENABLED toggle, validate Sentry DSN, and update env/docs; align Fly port to 3000

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,7 @@ API_RATE_LIMIT_ENABLED=true
 
 # ——— Observability ———
 SENTRY_DSN=https://<public-key>@o<org>.ingest.us.sentry.io/<project-id>
+SENTRY_ENABLED=true
 
 # ——— Stripe ———
 STRIPE_SECRET_KEY=sk_test_...

--- a/.env.production
+++ b/.env.production
@@ -35,3 +35,4 @@ WEB_URL=https://infamousfreight.com
 
 # Observability (managed by Fly.io secrets)
 # SENTRY_DSN=https://<public-key>@o<org>.ingest.us.sentry.io/<project-id>
+# SENTRY_ENABLED=true

--- a/.env.production.example
+++ b/.env.production.example
@@ -36,6 +36,7 @@ NEXT_PUBLIC_SUPABASE_URL=<supabase-project-url>
 
 # Sentry, optional
 SENTRY_DSN=<api-sentry-dsn>
+SENTRY_ENABLED=true
 SENTRY_AUTH_TOKEN=<sentry-auth-token>
 SENTRY_ORG=<sentry-org>
 SENTRY_PROJECT=<sentry-project>

--- a/CODEX_ENV_VARIABLES.txt
+++ b/CODEX_ENV_VARIABLES.txt
@@ -20,7 +20,8 @@ DAT_API_KEY=YOUR_KEY
 TRUCKSTOP_API_KEY=YOUR_KEY
 LOADBOARD_API_KEY=YOUR_KEY
 SAMSARA_API_TOKEN=YOUR_TOKEN
-SENTRY_DSN=https://YOUR_KEY@sentry.io/ID
+SENTRY_DSN=https://<public-key>@o<org>.ingest.us.sentry.io/<project-id>
+SENTRY_ENABLED=true
 RATE_LIMIT_ENABLED=true
 
 # Frontend
@@ -28,4 +29,4 @@ VITE_API_URL=https://api.infamousfreight.com
 VITE_SUPABASE_URL=https://YOUR_PROJECT.supabase.co
 VITE_SUPABASE_PUBLISHABLE_KEY=YOUR_PUBLISHABLE_KEY
 VITE_SUPABASE_ANON_KEY=YOUR_ANON_KEY
-VITE_SENTRY_DSN=https://YOUR_KEY@sentry.io/ID
+VITE_SENTRY_DSN=https://<public-key>@o<org>.ingest.us.sentry.io/<project-id>

--- a/ENVIRONMENT_VARIABLES_COMPLETE.md
+++ b/ENVIRONMENT_VARIABLES_COMPLETE.md
@@ -25,6 +25,7 @@
 | LOADBOARD_API_KEY | Yes | Alternate/general loadboard API key. |
 | SAMSARA_API_TOKEN | Yes | Samsara API token. |
 | SENTRY_DSN | Optional | Backend Sentry DSN. |
+| SENTRY_ENABLED | Optional | Set to `false` to disable backend Sentry initialization. Defaults to enabled when DSN is valid. |
 | RATE_LIMIT_ENABLED | Yes | Enables API rate limiting (`true`/`false`). |
 
 ## Frontend (apps/web)
@@ -68,13 +69,14 @@ DAT_API_KEY=YOUR_KEY
 TRUCKSTOP_API_KEY=YOUR_KEY
 LOADBOARD_API_KEY=YOUR_KEY
 SAMSARA_API_TOKEN=YOUR_TOKEN
-SENTRY_DSN=https://YOUR_KEY@sentry.io/ID
+SENTRY_DSN=https://<public-key>@o<org>.ingest.us.sentry.io/<project-id>
+SENTRY_ENABLED=true
 RATE_LIMIT_ENABLED=true
 VITE_API_URL=https://api.infamousfreight.com
 VITE_SUPABASE_URL=https://YOUR_PROJECT.supabase.co
 VITE_SUPABASE_PUBLISHABLE_KEY=YOUR_PUBLISHABLE_KEY
 VITE_SUPABASE_ANON_KEY=YOUR_ANON_KEY
-VITE_SENTRY_DSN=https://YOUR_KEY@sentry.io/ID
+VITE_SENTRY_DSN=https://<public-key>@o<org>.ingest.us.sentry.io/<project-id>
 ```
 
 ## Verification commands

--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ Public requests for `*.map` files are blocked (`404`). Sourcemaps are still uplo
 | Variable | Purpose | Required |
 |---|---|---|
 | `SENTRY_DSN` | Sentry DSN for the API runtime (`apps/api`) | No |
+| `SENTRY_ENABLED` | Set to `false` to disable API Sentry even when DSN is set | No |
 | `VITE_SENTRY_DSN` | Sentry DSN for the web app | No |
 | `VITE_SENTRY_ENABLED` | Set to `false` to disable even when DSN is set | No |
 | `SENTRY_AUTH_TOKEN` | CI secret for sourcemap upload | No |
@@ -354,6 +355,8 @@ Add these secrets to your GitHub repository:
 - 🔐 `VITE_API_URL` — Production API URL
 - 🔐 `VITE_STRIPE_PUBLIC_KEY` — Stripe publishable key
 - 🔐 `SENTRY_AUTH_TOKEN` — optional Sentry auth token for sourcemap upload
+- ⚙️ `SENTRY_DSN` — optional API runtime DSN (set in Fly secrets if preferred)
+- ⚙️ `SENTRY_ENABLED` — optional API runtime toggle (`true`/`false`)
 - ⚙️ `SENTRY_ORG` — optional Sentry org slug
 - ⚙️ `SENTRY_PROJECT` — optional Sentry project slug
 
@@ -370,6 +373,17 @@ Push to `main` and the pipeline deploys:
 flyctl deploy --app infamous-freight
 ```
 
+Set API runtime variables in Fly before deploying (examples):
+
+```bash
+flyctl secrets set \
+  DATABASE_URL=... \
+  STRIPE_SECRET_KEY=... \
+  STRIPE_WEBHOOK_SECRET=... \
+  SENTRY_DSN=https://<public-key>@o<org>.ingest.us.sentry.io/<project-id> \
+  SENTRY_ENABLED=true
+```
+
 #### Web (Netlify)
 
 Netlify auto-deploys from the `main` branch via its native Git integration. For manual deploys:
@@ -378,6 +392,15 @@ Netlify auto-deploys from the `main` branch via its native Git integration. For 
 npm install -g netlify-cli
 netlify deploy --prod --dir=apps/web/dist
 ```
+
+Netlify environment variables to set for web monitoring/builds:
+
+- `VITE_API_URL`
+- `VITE_SENTRY_DSN` (optional)
+- `VITE_SENTRY_ENABLED` (`true`/`false`, optional)
+- `SENTRY_AUTH_TOKEN` (optional, for sourcemap upload)
+- `SENTRY_ORG` (optional)
+- `SENTRY_PROJECT` (optional)
 
 ### Deploy verification
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -5,3 +5,4 @@ DATABASE_URL=postgresql://postgres:[YOUR-PASSWORD]@db.wnaievjffghrztjuvutp.supab
 
 # Optional: API runtime error tracking
 SENTRY_DSN=https://<public-key>@o<org>.ingest.us.sentry.io/<project-id>
+SENTRY_ENABLED=true

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -98,10 +98,40 @@ function requireBillingRole(req: Request, res: Response, next: NextFunction) {
   next();
 }
 
+function isValidSentryIngestDsn(dsn: string): boolean {
+  if (!dsn || /<[^>]+>/.test(dsn)) {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(dsn);
+    const hasIngestHost = /\.ingest(?:\.[a-z0-9-]+)?\.sentry\.io$/i.test(parsed.hostname);
+    const hasPublicKey = parsed.username.length > 0;
+    const hasProjectId = /^\/[0-9]+$/.test(parsed.pathname);
+
+    return hasIngestHost && hasPublicKey && hasProjectId;
+  } catch {
+    return false;
+  }
+}
+
 function initializeSentry() {
-  const dsn = process.env.SENTRY_DSN;
+  if (process.env.SENTRY_ENABLED === 'false') {
+    return;
+  }
+
+  const dsn = process.env.SENTRY_DSN ?? '';
 
   if (!dsn) {
+    return;
+  }
+
+  if (!isValidSentryIngestDsn(dsn)) {
+    console.warn('Sentry is disabled because SENTRY_DSN is not a valid ingest DSN URL.');
+    return;
+  }
+
+  if (Sentry.getClient()) {
     return;
   }
 
@@ -110,6 +140,7 @@ function initializeSentry() {
     environment: process.env.NODE_ENV ?? 'development',
     tracesSampleRate: 0,
   });
+
 }
 
 function getAllowedCorsOrigins(): string[] {

--- a/apps/api/test/sentry-config.test.ts
+++ b/apps/api/test/sentry-config.test.ts
@@ -1,0 +1,84 @@
+const sentryState = { initialized: false };
+
+jest.mock('@sentry/node', () => ({
+  init: jest.fn(() => {
+    sentryState.initialized = true;
+  }),
+  getClient: jest.fn(() => (sentryState.initialized ? { id: 'client' } : undefined)),
+  captureException: jest.fn(),
+}));
+
+describe('sentry configuration', () => {
+  const originalDsn = process.env.SENTRY_DSN;
+  const originalSentryEnabled = process.env.SENTRY_ENABLED;
+  let warnSpy: jest.SpyInstance;
+
+  const loadCreateApp = () => {
+    const { createApp } = require('../src/app') as typeof import('../src/app');
+    return createApp;
+  };
+
+  const loadSentry = () => require('@sentry/node') as { init: jest.Mock };
+
+  beforeEach(() => {
+    jest.resetModules();
+    sentryState.initialized = false;
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    if (originalDsn === undefined) {
+      delete process.env.SENTRY_DSN;
+    } else {
+      process.env.SENTRY_DSN = originalDsn;
+    }
+    if (originalSentryEnabled === undefined) {
+      delete process.env.SENTRY_ENABLED;
+    } else {
+      process.env.SENTRY_ENABLED = originalSentryEnabled;
+    }
+    jest.clearAllMocks();
+    warnSpy.mockRestore();
+  });
+
+  it('initializes Sentry when ingest DSN is valid', () => {
+    process.env.SENTRY_DSN = 'https://public-key-example@o123456.ingest.us.sentry.io/1234567';
+
+    const createApp = loadCreateApp();
+    createApp();
+
+    expect(loadSentry().init).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not initialize Sentry when DSN is invalid', () => {
+    process.env.SENTRY_DSN = 'invalid-dsn';
+
+    const createApp = loadCreateApp();
+    createApp();
+
+    expect(loadSentry().init).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Sentry is disabled because SENTRY_DSN is not a valid ingest DSN URL.',
+    );
+  });
+
+  it('initializes Sentry only once even when createApp is called multiple times', () => {
+    process.env.SENTRY_DSN = 'https://public-key-example@o123456.ingest.us.sentry.io/1234567';
+
+    const createApp = loadCreateApp();
+    createApp();
+    createApp();
+
+    expect(loadSentry().init).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not initialize Sentry when explicitly disabled', () => {
+    process.env.SENTRY_ENABLED = 'false';
+    process.env.SENTRY_DSN = 'https://public-key-example@o123456.ingest.us.sentry.io/1234567';
+
+    const createApp = loadCreateApp();
+    createApp();
+
+    expect(loadSentry().init).not.toHaveBeenCalled();
+  });
+});

--- a/fly.toml
+++ b/fly.toml
@@ -12,10 +12,11 @@ primary_region = 'dfw'
 [env]
   HOST = '0.0.0.0'
   NODE_ENV = 'production'
-  PORT = '8080'
+  PORT = '3000'
+  SENTRY_ENABLED = 'true'
 
 [http_service]
-  internal_port = 8080
+  internal_port = 3000
   force_https = true
   auto_stop_machines = 'stop'
   auto_start_machines = true


### PR DESCRIPTION
### Motivation

- Provide a safe, explicit runtime toggle for Sentry so deployments can opt out of initializing the SDK even when a DSN is present. 
- Avoid accidental Sentry initialization from placeholder or malformed DSNs by validating ingest DSN format before calling the SDK. 
- Keep environment examples, documentation, and deployment config consistent with the new toggle and runtime port settings.

### Description

- Added `SENTRY_ENABLED` to multiple environment templates and docs (`.env.example`, `.env.production`, `.env.production.example`, `CODEX_ENV_VARIABLES.txt`, `ENVIRONMENT_VARIABLES_COMPLETE.md`, `README.md`, and `apps/api/.env.example`).
- Implemented `isValidSentryIngestDsn()` and updated `initializeSentry()` in `apps/api/src/app.ts` to skip initialization when `SENTRY_ENABLED='false'`, skip on empty/invalid DSNs, warn on invalid DSNs, and avoid double-initialization by checking `Sentry.getClient()`.
- Added unit tests in `apps/api/test/sentry-config.test.ts` that mock `@sentry/node` and verify initialization behavior for valid DSNs, invalid DSNs (with warning), idempotent initialization, and explicit disabling via `SENTRY_ENABLED`.
- Updated `fly.toml` to use internal `PORT` and `internal_port` of `3000` and added `SENTRY_ENABLED = 'true'` to the Fly environment to match the application defaults.

### Testing

- Ran API unit tests with Jest specifically exercising the Sentry config tests in `apps/api/test/sentry-config.test.ts`, and all tests in that file passed. 
- Verified the new behavior via the mocked `@sentry/node` in tests to ensure initialization occurs only for valid ingest DSNs and is skipped when disabled. 
- No changes to production integration tests were required for this configuration-only update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2fcacae6083308dcbcdec7a071aac)