### PR TITLE
Add Docker runtime build and healthcheck job to CI

### DIFF
--- a/.github/workflows/full-validation.yml
+++ b/.github/workflows/full-validation.yml
@@ -60,3 +60,59 @@ jobs:
             echo "Ref: ${{ github.ref }}"
             echo "SHA: ${{ github.sha }}"
           } >> "$GITHUB_STEP_SUMMARY"
+
+  docker-runtime:
+    name: Docker runtime build and healthcheck
+    runs-on: ubuntu-latest
+    needs: validate
+    timeout-minutes: 20
+    env:
+      IMAGE_NAME: infamous-freight-local-check
+      CONTAINER_NAME: infamous-freight-runtime-check-${{ github.run_id }}-${{ github.run_attempt }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@5b527519f648035f8be57f79b1a08876fa6a6e64 # v3.11.1
+
+      - name: Build runtime image
+        run: docker build --pull -t "$IMAGE_NAME" .
+
+      - name: Start runtime container
+        run: docker run -d --name "$CONTAINER_NAME" -p 3000:3000 "$IMAGE_NAME"
+
+      - name: Probe health endpoint
+        run: |
+          for i in {1..30}; do
+            if ! docker ps --format '{{.Names}}' | grep -qx "$CONTAINER_NAME"; then
+              echo "Container is not running." >&2
+              docker logs "$CONTAINER_NAME" || true
+              exit 1
+            fi
+            health_status="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$CONTAINER_NAME")"
+            if [ "$health_status" = "healthy" ]; then
+              echo "Container healthcheck is healthy."
+              exit 0
+            fi
+            if [ "$health_status" = "unhealthy" ]; then
+              echo "Container healthcheck is unhealthy." >&2
+              docker logs "$CONTAINER_NAME" || true
+              exit 1
+            fi
+            if curl -fsS http://127.0.0.1:3000/api/health >/dev/null; then
+              echo "Health endpoint is ready."
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Health endpoint did not become ready in time." >&2
+          docker logs "$CONTAINER_NAME" || true
+          exit 1
+
+      - name: Cleanup container
+        if: always()
+        run: |
+          docker rm -f "$CONTAINER_NAME" || true
+          docker image rm -f "$IMAGE_NAME" || true

--- a/.github/workflows/full-validation.yml
+++ b/.github/workflows/full-validation.yml
@@ -69,6 +69,7 @@ jobs:
     env:
       IMAGE_NAME: infamous-freight-local-check
       CONTAINER_NAME: infamous-freight-runtime-check-${{ github.run_id }}-${{ github.run_attempt }}
+      DATABASE_URL: postgresql://user:pass@127.0.0.1:5432/db
 
     steps:
       - name: Checkout
@@ -81,33 +82,52 @@ jobs:
         run: docker build --pull -t "$IMAGE_NAME" .
 
       - name: Start runtime container
-        run: docker run -d --name "$CONTAINER_NAME" -p 3000:3000 "$IMAGE_NAME"
-
-      - name: Probe health endpoint
         run: |
-          for i in {1..30}; do
+          docker run -d \
+            --name "$CONTAINER_NAME" \
+            -e DATABASE_URL="$DATABASE_URL" \
+            -e NODE_ENV=production \
+            -e PORT=3000 \
+            -e HOST=0.0.0.0 \
+            -p 3000:3000 \
+            "$IMAGE_NAME"
+
+      - name: Probe Docker healthcheck
+        run: |
+          for i in {1..60}; do
             if ! docker ps --format '{{.Names}}' | grep -qx "$CONTAINER_NAME"; then
               echo "Container is not running." >&2
               docker logs "$CONTAINER_NAME" || true
               exit 1
             fi
+
             health_status="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$CONTAINER_NAME")"
-            if [ "$health_status" = "healthy" ]; then
-              echo "Container healthcheck is healthy."
-              exit 0
-            fi
-            if [ "$health_status" = "unhealthy" ]; then
-              echo "Container healthcheck is unhealthy." >&2
-              docker logs "$CONTAINER_NAME" || true
-              exit 1
-            fi
-            if curl -fsS http://127.0.0.1:3000/api/health >/dev/null; then
-              echo "Health endpoint is ready."
-              exit 0
-            fi
-            sleep 2
+            echo "Docker health status: $health_status"
+
+            case "$health_status" in
+              healthy)
+                curl -fsS http://127.0.0.1:3000/api/health >/dev/null
+                echo "Container healthcheck is healthy and /api/health responds."
+                exit 0
+                ;;
+              unhealthy)
+                echo "Container healthcheck is unhealthy." >&2
+                docker logs "$CONTAINER_NAME" || true
+                exit 1
+                ;;
+              none)
+                if curl -fsS http://127.0.0.1:3000/api/health >/dev/null; then
+                  echo "No Docker HEALTHCHECK present, but /api/health responds."
+                  exit 0
+                fi
+                ;;
+            esac
+
+            sleep 5
           done
-          echo "Health endpoint did not become ready in time." >&2
+
+          echo "Docker healthcheck did not become healthy in time." >&2
+          docker inspect "$CONTAINER_NAME" || true
           docker logs "$CONTAINER_NAME" || true
           exit 1
 


### PR DESCRIPTION
### Motivation

- Add a runtime-level smoke test to CI to verify the built Docker image starts and exposes a healthy HTTP health endpoint.

### Description

- Introduces a new `docker-runtime` job in `.github/workflows/full-validation.yml` that builds the image with `docker build`, runs a container, and maps port `3000`.
- The job sets up Docker Buildx, checks out the repo, and starts the container using `docker run -d` with a unique `CONTAINER_NAME` per run.
- Adds a probe loop that inspects container health via `docker inspect` and attempts an HTTP GET to `http://127.0.0.1:3000/api/health`, printing container logs on failures.
- Ensures cleanup with a final step that force-removes the container and image using `docker rm -f` and `docker image rm -f` in an `if: always()` step.

### Testing

- The existing validation steps executed in CI are `pnpm install --frozen-lockfile`, `pnpm run lint`, `pnpm run build`, and `pnpm run test -- --runInBand` as part of the `validate` job.
- The new `docker-runtime` job builds the Docker image and runs the healthcheck probe loop against `http://127.0.0.1:3000/api/health` and reports container logs on failure.
- The workflow (including the new `docker-runtime` job) was executed in CI and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f40b5ec1ac833091549b809c810d4f)