### PR TITLE
Add tools install/verify scripts, npm tasks, README docs, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,20 @@ Maintainers must upload the resulting PNG via **Settings → General → Social 
 
 ## ⚡ Quick Start
 
+### 0️⃣ Install Infamous Freight tools
+
+```bash
+pnpm run tools:install
+```
+
+This installs required local CLIs used by deployment, validation, and operational scripts.
+
+```bash
+pnpm run tools:verify
+```
+
+Use this to confirm `flyctl`, `supabase`, and `stripe` CLIs are available before running deployment flows.
+
 ### 1️⃣ Install dependencies + bootstrap environment files
 
 ```bash

--- a/apps/api/test/verify-required-clis-script.test.ts
+++ b/apps/api/test/verify-required-clis-script.test.ts
@@ -1,0 +1,55 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+describe('verify-required-clis.sh', () => {
+  const sourceScript = path.resolve(__dirname, '..', '..', '..', 'scripts', 'verify-required-clis.sh');
+
+  it('fails when required CLIs are missing', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'verify-clis-missing-'));
+    const scriptDir = path.join(tmp, 'scripts');
+    fs.mkdirSync(scriptDir, { recursive: true });
+    const scriptPath = path.join(scriptDir, 'verify-required-clis.sh');
+    fs.copyFileSync(sourceScript, scriptPath);
+    fs.chmodSync(scriptPath, 0o755);
+
+    const result = spawnSync('bash', [scriptPath], {
+      cwd: tmp,
+      encoding: 'utf8',
+      env: { ...process.env, PATH: '/usr/bin:/bin' },
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('flyctl missing');
+    expect(result.stderr).toContain('supabase missing');
+    expect(result.stderr).toContain('stripe missing');
+  });
+
+  it('passes when required CLIs exist in .tools/bin', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'verify-clis-present-'));
+    const toolsDir = path.join(tmp, '.tools', 'bin');
+    const scriptDir = path.join(tmp, 'scripts');
+    fs.mkdirSync(toolsDir, { recursive: true });
+    fs.mkdirSync(scriptDir, { recursive: true });
+
+    for (const tool of ['flyctl', 'supabase', 'stripe']) {
+      const toolPath = path.join(toolsDir, tool);
+      fs.writeFileSync(toolPath, '#!/usr/bin/env bash\nexit 0\n');
+      fs.chmodSync(toolPath, 0o755);
+    }
+
+    const scriptPath = path.join(scriptDir, 'verify-required-clis.sh');
+    fs.copyFileSync(sourceScript, scriptPath);
+    fs.chmodSync(scriptPath, 0o755);
+
+    const result = spawnSync('bash', [scriptPath], {
+      cwd: tmp,
+      encoding: 'utf8',
+      env: { ...process.env, PATH: '/usr/bin:/bin' },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('All required Infamous Freight tools are installed.');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -45,7 +45,9 @@
     "smoke:api:health": "bash scripts/smoke-api-health.sh",
     "snapshot:prod": "bash scripts/production-snapshot.sh",
     "setup:deps-docker": "bash scripts/bootstrap-deps-docker.sh",
-    "social-preview:generate": "node scripts/generate-social-preview.mjs"
+    "social-preview:generate": "node scripts/generate-social-preview.mjs",
+    "tools:install": "bash scripts/install-required-clis.sh",
+    "tools:verify": "bash scripts/verify-required-clis.sh"
   },
   "devDependencies": {
     "@resvg/resvg-js": "^2.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@resvg/resvg-js':
+        specifier: ^2.6.2
+        version: 2.6.2
       concurrently:
         specifier: ^9.0.0
         version: 9.2.1
@@ -1072,6 +1075,82 @@ packages:
   '@remix-run/router@1.23.2':
     resolution: {integrity: sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==}
     engines: {node: '>=14.0.0'}
+
+  '@resvg/resvg-js-android-arm-eabi@2.6.2':
+    resolution: {integrity: sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [android]
+
+  '@resvg/resvg-js-android-arm64@2.6.2':
+    resolution: {integrity: sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@resvg/resvg-js-darwin-arm64@2.6.2':
+    resolution: {integrity: sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@resvg/resvg-js-darwin-x64@2.6.2':
+    resolution: {integrity: sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@resvg/resvg-js-linux-arm-gnueabihf@2.6.2':
+    resolution: {integrity: sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@resvg/resvg-js-linux-arm64-gnu@2.6.2':
+    resolution: {integrity: sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@resvg/resvg-js-linux-arm64-musl@2.6.2':
+    resolution: {integrity: sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@resvg/resvg-js-linux-x64-gnu@2.6.2':
+    resolution: {integrity: sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@resvg/resvg-js-linux-x64-musl@2.6.2':
+    resolution: {integrity: sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@resvg/resvg-js-win32-arm64-msvc@2.6.2':
+    resolution: {integrity: sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@resvg/resvg-js-win32-ia32-msvc@2.6.2':
+    resolution: {integrity: sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@resvg/resvg-js-win32-x64-msvc@2.6.2':
+    resolution: {integrity: sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@resvg/resvg-js@2.6.2':
+    resolution: {integrity: sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==}
+    engines: {node: '>= 10'}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
@@ -4596,6 +4675,57 @@ snapshots:
       react-redux: 9.2.0(@types/react@18.3.28)(react@18.3.1)(redux@5.0.1)
 
   '@remix-run/router@1.23.2': {}
+
+  '@resvg/resvg-js-android-arm-eabi@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-android-arm64@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-darwin-arm64@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-darwin-x64@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-arm-gnueabihf@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-arm64-gnu@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-arm64-musl@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-x64-gnu@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-x64-musl@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-win32-arm64-msvc@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-win32-ia32-msvc@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-win32-x64-msvc@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js@2.6.2':
+    optionalDependencies:
+      '@resvg/resvg-js-android-arm-eabi': 2.6.2
+      '@resvg/resvg-js-android-arm64': 2.6.2
+      '@resvg/resvg-js-darwin-arm64': 2.6.2
+      '@resvg/resvg-js-darwin-x64': 2.6.2
+      '@resvg/resvg-js-linux-arm-gnueabihf': 2.6.2
+      '@resvg/resvg-js-linux-arm64-gnu': 2.6.2
+      '@resvg/resvg-js-linux-arm64-musl': 2.6.2
+      '@resvg/resvg-js-linux-x64-gnu': 2.6.2
+      '@resvg/resvg-js-linux-x64-musl': 2.6.2
+      '@resvg/resvg-js-win32-arm64-msvc': 2.6.2
+      '@resvg/resvg-js-win32-ia32-msvc': 2.6.2
+      '@resvg/resvg-js-win32-x64-msvc': 2.6.2
 
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     optional: true

--- a/scripts/install-required-clis.sh
+++ b/scripts/install-required-clis.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-TOOLS_DIR="${PWD}/.tools/bin"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+TOOLS_DIR="${REPO_ROOT}/.tools/bin"
 mkdir -p "${TOOLS_DIR}"
 
 install_flyctl() {
@@ -9,7 +11,7 @@ install_flyctl() {
     echo "flyctl already installed"
     return
   fi
-  curl -fsSL https://fly.io/install.sh | FLYCTL_INSTALL="${PWD}/.tools" sh
+  curl -fsSL https://fly.io/install.sh | FLYCTL_INSTALL="${REPO_ROOT}/.tools" sh
 }
 
 install_supabase() {
@@ -57,3 +59,5 @@ install_stripe
 
 echo "Required CLIs are available in ${TOOLS_DIR}."
 echo "Add to PATH: export PATH=\"${TOOLS_DIR}:\$PATH\""
+
+bash "${SCRIPT_DIR}/verify-required-clis.sh"

--- a/scripts/verify-required-clis.sh
+++ b/scripts/verify-required-clis.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+TOOLS_DIR="${REPO_ROOT}/.tools/bin"
+missing=0
+
+check_cli() {
+  local cli="$1"
+  if command -v "$cli" >/dev/null 2>&1 || [[ -x "${TOOLS_DIR}/${cli}" ]]; then
+    echo "✅ ${cli} found"
+  else
+    echo "❌ ${cli} missing (run: pnpm run tools:install)" >&2
+    missing=1
+  fi
+}
+
+check_cli flyctl
+check_cli supabase
+check_cli stripe
+
+if [[ "$missing" -ne 0 ]]; then
+  exit 1
+fi
+
+echo "All required Infamous Freight tools are installed."


### PR DESCRIPTION
### Motivation

- Provide a reproducible way to install and verify required local CLIs (`flyctl`, `supabase`, `stripe`) for development and deployment flows.
- Make the tools discoverable and easy to run from workspace scripts via `pnpm` tasks.
- Ensure the verification logic is covered by a unit test to avoid regressions.

### Description

- Added `scripts/verify-required-clis.sh` to check for `flyctl`, `supabase`, and `stripe` in PATH or in the repo `.tools/bin` and exit non-zero when any are missing.
- Updated `scripts/install-required-clis.sh` to resolve paths relative to the repository root and to invoke the new verifier after installation.
- Added npm scripts `tools:install` and `tools:verify` that wrap the install and verify scripts in `package.json` and updated the lockfile to include the new dependency snapshots for `@resvg/resvg-js`.
- Added a unit test `apps/api/test/verify-required-clis-script.test.ts` which exercises the verify script behavior for both missing and present tool scenarios.

### Testing

- Ran the repository test suite including the new test file `apps/api/test/verify-required-clis-script.test.ts`, and the tests completed successfully.
- Executed the `verify-required-clis.sh` logic within the test using `spawnSync` to simulate missing and present CLI binaries, and assertions passed for both cases.
- Updated `pnpm-lock.yaml` was generated/updated as part of dependency changes and was validated during the install step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f414aaa9308330b4a907f08257cb87)