### PR TITLE
Add fallback health server and improve Fly config health checks and concurrency

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -21,17 +21,23 @@ try {
   console.error(`API startup failed: ${startupError}`);
 
   const fallback = express();
-  const payload = {
-    status: 'degraded',
-    timestamp: new Date().toISOString(),
-  };
 
   fallback.get('/health', (_req, res) => {
-    res.status(200).json(payload);
+    res.status(503).json({
+      status: 'degraded',
+      error: 'api_startup_failed',
+      message: startupError,
+      timestamp: new Date().toISOString(),
+    });
   });
 
   fallback.get('/api/health', (_req, res) => {
-    res.status(200).json(payload);
+    res.status(503).json({
+      status: 'degraded',
+      error: 'api_startup_failed',
+      message: startupError,
+      timestamp: new Date().toISOString(),
+    });
   });
 
   fallback.listen(port, host, () => {

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1,12 +1,40 @@
 import dotenv from 'dotenv';
+import express from 'express';
 import { createApp } from './app';
 
 dotenv.config();
 
-const app = createApp();
+if (!process.env.DATABASE_URL) {
+  process.env.DATABASE_URL = process.env.Database_URL ?? process.env.database_url ?? '';
+}
+
 const port = Number(process.env.PORT ?? 3000);
 const host = process.env.HOST ?? '0.0.0.0';
 
-app.listen(port, host, () => {
-  console.log(`Infamous Freight API listening on ${host}:${port}`);
-});
+try {
+  const app = createApp();
+  app.listen(port, host, () => {
+    console.log(`Infamous Freight API listening on ${host}:${port}`);
+  });
+} catch (error) {
+  const startupError = error instanceof Error ? error.message : 'unknown_startup_error';
+  console.error(`API startup failed: ${startupError}`);
+
+  const fallback = express();
+  const payload = {
+    status: 'degraded',
+    timestamp: new Date().toISOString(),
+  };
+
+  fallback.get('/health', (_req, res) => {
+    res.status(200).json(payload);
+  });
+
+  fallback.get('/api/health', (_req, res) => {
+    res.status(200).json(payload);
+  });
+
+  fallback.listen(port, host, () => {
+    console.log(`Fallback health server listening on ${host}:${port}`);
+  });
+}

--- a/fly.toml
+++ b/fly.toml
@@ -22,15 +22,19 @@ primary_region = 'dfw'
   min_machines_running = 1
   processes = ['app']
 
-  [[http_service.checks]]
-    interval = '30s'
-    timeout = '10s'
-    grace_period = '60s'
-    method = 'GET'
-    path = '/api/health'
+[[http_service.checks]]
+  interval = '30s'
+  timeout = '15s'
+  grace_period = '90s'
+  method = 'GET'
+  path = '/api/health'
+
+[http_service.concurrency]
+  type = 'requests'
+  soft_limit = 25
+  hard_limit = 40
 
 [[vm]]
-  memory = '512mb'
   cpu_kind = 'shared'
   cpus = 1
   memory_mb = 512


### PR DESCRIPTION
### Motivation
- Make the API startup more resilient when environment variables or app initialization fail by providing a simple fallback health server.
- Ensure platform health checks get a deterministic degraded response when the main app cannot start so the instance can be observed and managed.
- Tune Fly deployment settings for more robust health-checking and request concurrency behavior.

### Description
- Add a `DATABASE_URL` fallback assignment that reads `Database_URL` or `database_url` into `process.env.DATABASE_URL` if unset.
- Wrap `createApp()` and `app.listen()` in a `try/catch` and, on error, start a minimal Express fallback server that exposes `GET /health` and `GET /api/health` returning a degraded JSON payload.
- Import `express` and log startup errors with a clear message when fallback mode is activated.
- Update `fly.toml` to adjust health check timings (`interval`, `timeout`, `grace_period`), add an `[http_service.concurrency]` block with `soft_limit` and `hard_limit`, and change the VM memory declaration to `memory_mb = 512`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f42304be948330a0313c60a58a5e11)