### PR TITLE
Add payroll API endpoints + payroll UI, PayPal checkout and AdSense support

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -437,18 +437,32 @@ function registerRoutes(app: express.Express, dataStore: DataStore) {
     });
   }));
 
+  const isValidIsoDateString = (value: unknown): value is string => {
+    if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+      return false;
+    }
+    const date = new Date(`${value}T00:00:00.000Z`);
+    return !Number.isNaN(date.getTime()) && date.toISOString().slice(0, 10) === value;
+  };
+
   app.post('/api/payroll/settlements', requireTenant, requireRole, wrapAsync(async (req, res) => {
     const tenantId = getRequiredTenantId(req);
     const { driverId, weekStart, weekEnd, netPay } = req.body ?? {};
-    if (!driverId || !weekStart || !weekEnd || typeof netPay !== 'number') {
-      throw new HttpError(400, 'invalid_payroll_settlement_payload', 'driverId, weekStart, weekEnd, and netPay are required.');
+    if (
+      !driverId ||
+      !isValidIsoDateString(weekStart) ||
+      !isValidIsoDateString(weekEnd) ||
+      !Number.isFinite(netPay) ||
+      weekStart > weekEnd
+    ) {
+      throw new HttpError(400, 'invalid_payroll_settlement_payload', 'driverId, weekStart, weekEnd, and netPay are required, dates must be valid ISO dates, netPay must be finite, and weekStart must be on or before weekEnd.');
     }
     const record: PayrollSettlementRecord = {
       id: crypto.randomUUID(),
       tenantId,
       driverId: String(driverId),
-      weekStart: String(weekStart),
-      weekEnd: String(weekEnd),
+      weekStart,
+      weekEnd,
       status: 'pending',
       netPay,
     };

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,7 +1,7 @@
 import cors from 'cors';
 import helmet from 'helmet';
 import express, { NextFunction, Request, Response } from 'express';
-import crypto from 'crypto';
+import { randomUUID } from 'crypto';
 import * as Sentry from '@sentry/node';
 import {
   createDataStore,

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -249,9 +249,22 @@ function registerWebhookRoute(app: express.Express, dataStore: DataStore) {
   }));
 }
 
+function createPayrollSettlementsStore() {
+  const allowInMemoryPayrollSettlements = process.env.ALLOW_IN_MEMORY_PAYROLL_SETTLEMENTS === 'true';
+  const isProduction = process.env.NODE_ENV === 'production';
+
+  if (isProduction && !allowInMemoryPayrollSettlements) {
+    throw new Error(
+      'In-memory payroll settlements are disabled in production. Persist settlements via DataStore or explicitly enable demo-only mode with ALLOW_IN_MEMORY_PAYROLL_SETTLEMENTS=true.',
+    );
+  }
+
+  return new Map<string, PayrollSettlementRecord[]>();
+}
+
 function registerRoutes(app: express.Express, dataStore: DataStore) {
   const aiUsageStore = createAiUsageStore();
-  const payrollSettlements = new Map<string, PayrollSettlementRecord[]>();
+  const payrollSettlements = createPayrollSettlementsStore();
 
   // Public lead intake endpoints — no authentication required
   app.post('/api/leads/quote', wrapAsync(async (req, res) => {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -419,7 +419,16 @@ function registerRoutes(app: express.Express, dataStore: DataStore) {
     const records = payrollSettlements.get(tenantId) ?? [];
     const settlements = records
       .filter((record) => record.driverId === driverId)
-      .sort((a, b) => (a.weekStart < b.weekStart ? 1 : -1));
+      .sort((a, b) => {
+        const aWeekStart = Date.parse(a.weekStart);
+        const bWeekStart = Date.parse(b.weekStart);
+
+        if (aWeekStart === bWeekStart) {
+          return 0;
+        }
+
+        return bWeekStart - aWeekStart;
+      });
     res.json(settlements);
   }));
 

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,6 +1,7 @@
 import cors from 'cors';
 import helmet from 'helmet';
 import express, { NextFunction, Request, Response } from 'express';
+import crypto from 'crypto';
 import * as Sentry from '@sentry/node';
 import {
   createDataStore,
@@ -23,6 +24,19 @@ import { createStripeWebhookEventStore } from './stripe-webhook-events';
 import { createFreightWorkflowRouter } from './freight-workflow-routes';
 
 type Role = 'owner' | 'admin' | 'dispatcher';
+type PayrollPaymentMethod = 'ach' | 'paypal' | 'check';
+
+type PayrollSettlementRecord = {
+  id: string;
+  tenantId: string;
+  driverId: string;
+  weekStart: string;
+  weekEnd: string;
+  status: 'pending' | 'approved' | 'paid';
+  netPay: number;
+  paymentMethod?: PayrollPaymentMethod;
+  paymentReference?: string;
+};
 
 const ALLOWED_ROLES: Role[] = ['owner', 'admin', 'dispatcher'];
 const BILLING_ROLES: Role[] = ['owner', 'admin'];
@@ -237,6 +251,7 @@ function registerWebhookRoute(app: express.Express, dataStore: DataStore) {
 
 function registerRoutes(app: express.Express, dataStore: DataStore) {
   const aiUsageStore = createAiUsageStore();
+  const payrollSettlements = new Map<string, PayrollSettlementRecord[]>();
 
   // Public lead intake endpoints — no authentication required
   app.post('/api/leads/quote', wrapAsync(async (req, res) => {
@@ -396,6 +411,50 @@ function registerRoutes(app: express.Express, dataStore: DataStore) {
   app.post('/api/shipments', requireTenant, requireRole, wrapAsync(async (req, res) => {
     const data = await dataStore.createShipment(getRequiredTenantId(req), req.body);
     res.status(201).json({ data });
+  }));
+
+  app.get('/api/payroll/settlements/:driverId', requireTenant, requireRole, wrapAsync(async (req, res) => {
+    const tenantId = getRequiredTenantId(req);
+    const driverId = req.params.driverId;
+    const records = payrollSettlements.get(tenantId) ?? [];
+    const settlements = records
+      .filter((record) => record.driverId === driverId)
+      .sort((a, b) => (a.weekStart < b.weekStart ? 1 : -1));
+    res.json(settlements);
+  }));
+
+  app.get('/api/payroll/earnings/:driverId', requireTenant, requireRole, wrapAsync(async (req, res) => {
+    const tenantId = getRequiredTenantId(req);
+    const driverId = req.params.driverId;
+    const records = payrollSettlements.get(tenantId) ?? [];
+    const settlements = records.filter((record) => record.driverId === driverId);
+    const totalNetPay = settlements.reduce((sum, record) => sum + record.netPay, 0);
+    res.json({
+      driverId,
+      tenantId,
+      settlementCount: settlements.length,
+      totalNetPay,
+    });
+  }));
+
+  app.post('/api/payroll/settlements', requireTenant, requireRole, wrapAsync(async (req, res) => {
+    const tenantId = getRequiredTenantId(req);
+    const { driverId, weekStart, weekEnd, netPay } = req.body ?? {};
+    if (!driverId || !weekStart || !weekEnd || typeof netPay !== 'number') {
+      throw new HttpError(400, 'invalid_payroll_settlement_payload', 'driverId, weekStart, weekEnd, and netPay are required.');
+    }
+    const record: PayrollSettlementRecord = {
+      id: crypto.randomUUID(),
+      tenantId,
+      driverId: String(driverId),
+      weekStart: String(weekStart),
+      weekEnd: String(weekEnd),
+      status: 'pending',
+      netPay,
+    };
+    const current = payrollSettlements.get(tenantId) ?? [];
+    payrollSettlements.set(tenantId, [...current, record]);
+    res.status(201).json(record);
   }));
 
   app.get('/api/freight-operations/:resource', requireTenant, requireRole, wrapAsync(async (req, res) => {

--- a/apps/api/test/payroll-routes.test.ts
+++ b/apps/api/test/payroll-routes.test.ts
@@ -1,0 +1,61 @@
+import request from 'supertest';
+import { createApp } from '../src/app';
+
+describe('payroll routes', () => {
+  it('requires tenant and role for settlements', async () => {
+    const app = createApp();
+
+    const noTenant = await request(app)
+      .get('/api/payroll/settlements/driver-1')
+      .set('x-user-role', 'dispatcher');
+
+    expect(noTenant.status).toBe(400);
+    expect(noTenant.body.error).toBe('tenant_id_required');
+
+    const noRole = await request(app)
+      .get('/api/payroll/settlements/driver-1')
+      .set('x-tenant-id', 'tenant-1');
+
+    expect(noRole.status).toBe(403);
+    expect(noRole.body.error).toBe('forbidden');
+  });
+
+  it('isolates payroll settlements by tenant and summarizes earnings', async () => {
+    const app = createApp();
+
+    const seedT1 = await request(app)
+      .post('/api/payroll/settlements')
+      .set('x-tenant-id', 'tenant-1')
+      .set('x-user-role', 'dispatcher')
+      .send({ driverId: 'driver-1', weekStart: '2026-04-01', weekEnd: '2026-04-07', netPay: 1200 });
+
+    expect(seedT1.status).toBe(201);
+
+    const seedT2 = await request(app)
+      .post('/api/payroll/settlements')
+      .set('x-tenant-id', 'tenant-2')
+      .set('x-user-role', 'dispatcher')
+      .send({ driverId: 'driver-1', weekStart: '2026-04-01', weekEnd: '2026-04-07', netPay: 900 });
+
+    expect(seedT2.status).toBe(201);
+
+    const listT1 = await request(app)
+      .get('/api/payroll/settlements/driver-1')
+      .set('x-tenant-id', 'tenant-1')
+      .set('x-user-role', 'dispatcher');
+
+    expect(listT1.status).toBe(200);
+    expect(listT1.body).toHaveLength(1);
+    expect(listT1.body[0].tenantId).toBe('tenant-1');
+    expect(listT1.body[0].netPay).toBe(1200);
+
+    const earningsT1 = await request(app)
+      .get('/api/payroll/earnings/driver-1')
+      .set('x-tenant-id', 'tenant-1')
+      .set('x-user-role', 'dispatcher');
+
+    expect(earningsT1.status).toBe(200);
+    expect(earningsT1.body.totalNetPay).toBe(1200);
+    expect(earningsT1.body.settlementCount).toBe(1);
+  });
+});

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -24,3 +24,10 @@ VITE_SENTRY_ENABLED=true
 SENTRY_ORG=infmous
 SENTRY_PROJECT=infamous-freight
 SENTRY_AUTH_TOKEN=your-sentry-auth-token
+
+# PayPal checkout (optional alternative payment flow)
+VITE_PAYPAL_CLIENT_ID=
+
+# Google AdSense (optional ads placements)
+VITE_ADSENSE_CLIENT=
+VITE_ADSENSE_LANDING_SLOT=

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
+    "@paypal/react-paypal-js": "^9.2.0",
     "@sentry/react": "^8.55.1",
     "@stripe/react-stripe-js": "^2.4.0",
     "@stripe/stripe-js": "^2.2.0",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -32,6 +32,8 @@ const ShipmentTrackingPage = lazy(() => import('@/pages/ShipmentTrackingPage'));
 const CustomerPortalPage = lazy(() => import('@/pages/CustomerPortalPage'));
 const CarrierPortalPage = lazy(() => import('@/pages/CarrierPortalPage'));
 const FreightAssistantPage = lazy(() => import('@/pages/FreightAssistantPage'));
+const PayrollPage = lazy(() => import('@/pages/PayrollPage'));
+const PaywallPage = lazy(() => import('@/pages/PaywallPage'));
 
 const RouteFallback = () => (
   <div className="h-full w-full flex items-center justify-center p-6">
@@ -63,6 +65,8 @@ function App() {
           <Route path="/carriers" element={<CarriersPage />} />
           <Route path="/accounting" element={<AccountingDashboardPage />} />
           <Route path="/quotes" element={<QuoteRequestsPage />} />
+          <Route path="/payroll" element={<PayrollPage />} />
+          <Route path="/paywall" element={<PaywallPage />} />
         </Route>
 
         {/* Public routes (no layout) — see src/lib/routes.ts */}

--- a/apps/web/src/components/AdsSlot.tsx
+++ b/apps/web/src/components/AdsSlot.tsx
@@ -1,0 +1,40 @@
+import { useEffect } from 'react';
+
+type AdsSlotProps = {
+  slot: string;
+  className?: string;
+};
+
+const adsenseClient = import.meta.env.VITE_ADSENSE_CLIENT;
+
+const AdsSlot: React.FC<AdsSlotProps> = ({ slot, className }) => {
+  useEffect(() => {
+    if (!adsenseClient) {
+      return;
+    }
+
+    try {
+      (window as Window & { adsbygoogle?: unknown[] }).adsbygoogle = (window as Window & { adsbygoogle?: unknown[] }).adsbygoogle || [];
+      (window as Window & { adsbygoogle?: unknown[] }).adsbygoogle?.push({});
+    } catch {
+      // no-op in local/dev environments where ad serving is blocked
+    }
+  }, []);
+
+  if (!adsenseClient) {
+    return null;
+  }
+
+  return (
+    <ins
+      className={`adsbygoogle block min-h-[120px] w-full rounded-xl border border-infamous-border bg-infamous-dark ${className ?? ''}`}
+      style={{ display: 'block' }}
+      data-ad-client={adsenseClient}
+      data-ad-slot={slot}
+      data-ad-format="auto"
+      data-full-width-responsive="true"
+    />
+  );
+};
+
+export default AdsSlot;

--- a/apps/web/src/components/PayPalCheckoutButton.tsx
+++ b/apps/web/src/components/PayPalCheckoutButton.tsx
@@ -1,0 +1,43 @@
+import { PayPalButtons, PayPalScriptProvider } from '@paypal/react-paypal-js';
+
+type PayPalCheckoutButtonProps = {
+  amountUsd: string;
+  disabled?: boolean;
+};
+
+const paypalClientId = import.meta.env.VITE_PAYPAL_CLIENT_ID;
+
+const PayPalCheckoutButton: React.FC<PayPalCheckoutButtonProps> = ({ amountUsd, disabled = false }) => {
+  if (!paypalClientId) {
+    return (
+      <p className="text-xs text-gray-500">
+        PayPal checkout is disabled. Set <code>VITE_PAYPAL_CLIENT_ID</code> to enable it.
+      </p>
+    );
+  }
+
+  return (
+    <PayPalScriptProvider options={{ clientId: paypalClientId, currency: 'USD', intent: 'capture' }}>
+      <PayPalButtons
+        style={{ layout: 'vertical', color: 'blue', shape: 'rect', label: 'paypal' }}
+        disabled={disabled}
+        createOrder={async (_, actions) => actions.order.create({
+          intent: 'CAPTURE',
+          purchase_units: [
+            {
+              amount: {
+                currency_code: 'USD',
+                value: amountUsd,
+              },
+            },
+          ],
+        })}
+        onApprove={async (_, actions) => {
+          await actions.order?.capture();
+        }}
+      />
+    </PayPalScriptProvider>
+  );
+};
+
+export default PayPalCheckoutButton;

--- a/apps/web/src/components/billing/BillingSettingsPanel.tsx
+++ b/apps/web/src/components/billing/BillingSettingsPanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import toast from 'react-hot-toast';
 import { CreditCard, ExternalLink, Loader2, ShieldCheck, Sparkles } from 'lucide-react';
 import { useAppStore } from '@/store/app-store';
+import PayPalCheckoutButton from '@/components/PayPalCheckoutButton';
 import {
   BillingInterval,
   BillingPlan,
@@ -177,6 +178,17 @@ const BillingSettingsPanel: React.FC = () => {
               {usageSummary?.actionCount ?? 0} logged
             </p>
           </div>
+        </div>
+      </div>
+
+
+      <div className="card">
+        <h3 className="text-lg font-semibold">Alternative Checkout</h3>
+        <p className="mt-1 text-sm text-gray-400">
+          Optional PayPal checkout for one-off payments while Stripe remains the primary subscription processor.
+        </p>
+        <div className="mt-4 max-w-sm">
+          <PayPalCheckoutButton amountUsd="99.00" disabled={!canManageBilling} />
         </div>
       </div>
 

--- a/apps/web/src/components/ui/Sidebar.tsx
+++ b/apps/web/src/components/ui/Sidebar.tsx
@@ -4,7 +4,7 @@ import { canAccessLaunchValidation } from '@/lib/launchValidationAccess';
 import {
   LayoutDashboard, Truck, Radio, Users, FileText, MessageSquare,
   TrendingUp, ShieldCheck, Settings, ChevronLeft, ChevronRight,
-  Zap, LogOut, ClipboardCheck, ClipboardList, DollarSign, type LucideIcon
+  Zap, LogOut, ClipboardCheck, ClipboardList, DollarSign, Lock, Wallet, type LucideIcon
 } from 'lucide-react';
 
 type NavItem = {
@@ -23,6 +23,8 @@ const baseNavItems: NavItem[] = [
   { path: '/carriers', label: 'Carriers', icon: Users },
   { path: '/drivers', label: 'Drivers', icon: Users },
   { path: '/accounting', label: 'Accounting', icon: DollarSign },
+  { path: '/payroll', label: 'Payroll', icon: Wallet },
+  { path: '/paywall', label: 'Paywall', icon: Lock },
   { path: '/invoices', label: 'Invoices', icon: FileText },
   { path: '/chat', label: 'Messages', icon: MessageSquare, badge: '3' },
   { path: '/analytics', label: 'Analytics', icon: TrendingUp },

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -9,6 +9,17 @@ const sentryEnabledEnv: string = import.meta.env.VITE_SENTRY_ENABLED ?? '';
 const sentryEnvironment: string = import.meta.env.MODE;
 const isProd = import.meta.env.PROD;
 
+const adsenseClient = import.meta.env.VITE_ADSENSE_CLIENT ?? '';
+
+if (adsenseClient) {
+  const adsScript = document.createElement('script');
+  adsScript.async = true;
+  adsScript.src = `https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${adsenseClient}`;
+  adsScript.crossOrigin = 'anonymous';
+  document.head.appendChild(adsScript);
+}
+
+
 const isValidSentryDsn = (dsn: string): boolean => {
   if (!dsn || /<[^>]+>/.test(dsn)) {
     return false;

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -10,8 +10,22 @@ const sentryEnvironment: string = import.meta.env.MODE;
 const isProd = import.meta.env.PROD;
 
 const adsenseClient = import.meta.env.VITE_ADSENSE_CLIENT ?? '';
+const PUBLIC_ADSENSE_PATHS = new Set(['/']);
 
-if (adsenseClient) {
+const shouldInjectAdsenseScript = (client: string): boolean => {
+  if (!client) {
+    return false;
+  }
+
+  const pathname = window.location.pathname;
+
+  // Only inject AdSense on explicit public marketing routes. Expanding this
+  // allowlist also requires the production CSP to allow the relevant Google
+  // AdSense domains for script/frame/img requests.
+  return PUBLIC_ADSENSE_PATHS.has(pathname);
+};
+
+if (shouldInjectAdsenseScript(adsenseClient)) {
   const adsScript = document.createElement('script');
   adsScript.async = true;
   adsScript.src = `https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${adsenseClient}`;

--- a/apps/web/src/pages/LandingPage.tsx
+++ b/apps/web/src/pages/LandingPage.tsx
@@ -11,6 +11,7 @@ import {
   Truck,
   Users,
 } from 'lucide-react';
+import AdsSlot from '@/components/AdsSlot';
 
 const services = [
   {
@@ -131,6 +132,11 @@ const LandingPage: React.FC = () => {
             </div>
           ))}
         </div>
+      </section>
+
+
+      <section className="mx-auto max-w-7xl px-6 pb-4">
+        <AdsSlot slot={import.meta.env.VITE_ADSENSE_LANDING_SLOT ?? ''} className="mx-auto" />
       </section>
 
       <section className="border-y border-infamous-border bg-[#0f0f0f]">

--- a/apps/web/src/pages/PayrollPage.tsx
+++ b/apps/web/src/pages/PayrollPage.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useMemo, useState } from 'react';
+import { DollarSign, Wallet } from 'lucide-react';
+import api from '@/api-client/client';
+import { useAppStore } from '@/store/app-store';
+
+type Settlement = {
+  id: string;
+  weekStart: string;
+  weekEnd: string;
+  status: string;
+  netPay: number;
+};
+
+const PayrollPage: React.FC = () => {
+  const { user } = useAppStore();
+  const driverId = useMemo(() => user?.id ?? '1', [user?.id]);
+  const [settlements, setSettlements] = useState<Settlement[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function loadPayroll() {
+      try {
+        const response = await api.getDriverSettlements(driverId) as Settlement[];
+        if (mounted) setSettlements(response);
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    }
+
+    void loadPayroll();
+    return () => {
+      mounted = false;
+    };
+  }, [driverId]);
+
+  const totalNet = settlements.reduce((acc, item) => acc + Number(item.netPay ?? 0), 0);
+
+  return (
+    <main className="space-y-4">
+      <section className="card">
+        <h1 className="text-2xl font-bold">Payroll</h1>
+        <p className="mt-1 text-sm text-gray-400">Driver settlements and payout visibility.</p>
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-2">
+        <div className="card">
+          <DollarSign className="text-infamous-orange" />
+          <p className="mt-2 text-sm text-gray-400">Total Net Pay</p>
+          <p className="text-2xl font-black">${totalNet.toFixed(2)}</p>
+        </div>
+        <div className="card">
+          <Wallet className="text-infamous-orange" />
+          <p className="mt-2 text-sm text-gray-400">Settlements</p>
+          <p className="text-2xl font-black">{settlements.length}</p>
+        </div>
+      </section>
+
+      <section className="card overflow-x-auto">
+        {loading ? <p className="text-sm text-gray-400">Loading payroll…</p> : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-gray-400">
+                <th className="pb-2">Week</th><th className="pb-2">Status</th><th className="pb-2">Net</th>
+              </tr>
+            </thead>
+            <tbody>
+              {settlements.map((settlement) => (
+                <tr key={settlement.id} className="border-t border-infamous-border">
+                  <td className="py-3">{new Date(settlement.weekStart).toLocaleDateString()} - {new Date(settlement.weekEnd).toLocaleDateString()}</td>
+                  <td className="py-3 capitalize">{settlement.status}</td>
+                  <td className="py-3">${Number(settlement.netPay ?? 0).toFixed(2)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+    </main>
+  );
+};
+
+export default PayrollPage;

--- a/apps/web/src/pages/PaywallPage.tsx
+++ b/apps/web/src/pages/PaywallPage.tsx
@@ -1,0 +1,41 @@
+import { Link } from 'react-router-dom';
+import { Lock, ShieldCheck, Sparkles } from 'lucide-react';
+
+const tiers = [
+  { name: 'Starter', price: '$99/mo', features: ['Up to 500 loads', 'Core dispatch workflows'] },
+  { name: 'Professional', price: '$499/mo', features: ['Unlimited loads', 'Advanced analytics', 'Priority support'], recommended: true },
+  { name: 'Enterprise', price: 'Custom', features: ['Dedicated support', 'SLA and custom integrations'] },
+];
+
+const PaywallPage: React.FC = () => (
+  <main className="min-h-screen bg-[#090909] px-6 py-10 text-white">
+    <div className="mx-auto max-w-5xl">
+      <div className="mb-8 rounded-2xl border border-infamous-border bg-infamous-card p-6">
+        <div className="inline-flex items-center gap-2 rounded-full bg-infamous-orange/10 px-3 py-1 text-xs text-infamous-orange">
+          <Lock size={14} /> Subscription required
+        </div>
+        <h1 className="mt-3 text-3xl font-black">Paywall & Access Control</h1>
+        <p className="mt-2 text-sm text-gray-400">This feature is available on paid plans. Upgrade in billing settings to unlock protected workflows.</p>
+        <Link to="/settings" className="btn-primary mt-5 inline-flex items-center gap-2">
+          <ShieldCheck size={16} /> Open Billing Settings
+        </Link>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        {tiers.map((tier) => (
+          <div key={tier.name} className={`rounded-2xl border p-5 ${tier.recommended ? 'border-infamous-orange/50 bg-infamous-orange/5' : 'border-infamous-border bg-infamous-card'}`}>
+            <h2 className="text-lg font-bold">{tier.name}</h2>
+            <p className="mt-1 text-xl text-infamous-orange">{tier.price}</p>
+            <ul className="mt-4 space-y-2 text-sm text-gray-300">
+              {tier.features.map((feature) => (
+                <li key={feature} className="flex items-center gap-2"><Sparkles size={14} className="text-infamous-orange" />{feature}</li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </div>
+  </main>
+);
+
+export default PaywallPage;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@resvg/resvg-js':
+        specifier: 2.6.2
+        version: 2.6.2
       concurrently:
         specifier: ^9.0.0
         version: 9.2.1
@@ -75,6 +78,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@paypal/react-paypal-js':
+        specifier: ^9.2.0
+        version: 9.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@sentry/react':
         specifier: ^8.55.1
         version: 8.55.2(react@18.3.1)
@@ -1019,6 +1025,18 @@ packages:
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
 
+  '@paypal/paypal-js@9.7.0':
+    resolution: {integrity: sha512-eUQVZWTEhXhaPsYDmfUaOeV5zfeLUn7kCE7/BXm6uAtMhUoK0S7uPtUzosqfH1vZgjfUSyTzghDJtYxXyRRZig==}
+
+  '@paypal/react-paypal-js@9.2.0':
+    resolution: {integrity: sha512-wckuxilT+fYYwg0TYbEbxkclYeJnhIlThpNtV9RLXQA6uBbt5xPIzGv9wt2ykQTLiNIqhXhw1Hlz5yxUeCteKQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+      react-dom: ^16.8.0 || ^17 || ^18 || ^19
+
+  '@paypal/sdk-constants@1.0.157':
+    resolution: {integrity: sha512-BjxWT9rK6dM1AOffSpvHYY47/8BY775jgEYYiwH6eL4YaqU5Epcw7zOtwQ8L4UaEn4FCAjZ2EWxaS83dCN7SpA==}
+
   '@prisma/client@6.19.3':
     resolution: {integrity: sha512-mKq3jQFhjvko5LTJFHGilsuQs+W+T3Gm451NzuTDGQxwCzwXHYnIu2zGkRoW+Exq3Rob7yp2MfzSrdIiZVhrBg==}
     engines: {node: '>=18.18'}
@@ -1072,6 +1090,82 @@ packages:
   '@remix-run/router@1.23.2':
     resolution: {integrity: sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==}
     engines: {node: '>=14.0.0'}
+
+  '@resvg/resvg-js-android-arm-eabi@2.6.2':
+    resolution: {integrity: sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [android]
+
+  '@resvg/resvg-js-android-arm64@2.6.2':
+    resolution: {integrity: sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@resvg/resvg-js-darwin-arm64@2.6.2':
+    resolution: {integrity: sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@resvg/resvg-js-darwin-x64@2.6.2':
+    resolution: {integrity: sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@resvg/resvg-js-linux-arm-gnueabihf@2.6.2':
+    resolution: {integrity: sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@resvg/resvg-js-linux-arm64-gnu@2.6.2':
+    resolution: {integrity: sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@resvg/resvg-js-linux-arm64-musl@2.6.2':
+    resolution: {integrity: sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@resvg/resvg-js-linux-x64-gnu@2.6.2':
+    resolution: {integrity: sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@resvg/resvg-js-linux-x64-musl@2.6.2':
+    resolution: {integrity: sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@resvg/resvg-js-win32-arm64-msvc@2.6.2':
+    resolution: {integrity: sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@resvg/resvg-js-win32-ia32-msvc@2.6.2':
+    resolution: {integrity: sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@resvg/resvg-js-win32-x64-msvc@2.6.2':
+    resolution: {integrity: sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@resvg/resvg-js@2.6.2':
+    resolution: {integrity: sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==}
+    engines: {node: '>= 10'}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
@@ -2292,6 +2386,9 @@ packages:
     resolution: {integrity: sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==}
     engines: {node: '>=18.0.0'}
 
+  hi-base32@0.5.1:
+    resolution: {integrity: sha512-EmBBpvdYh/4XxsnUybsPag6VikPYnN30td+vQk+GI3qpahVEG9+gTkG0aXVxTjBqQ5T6ijbWIu77O+C5WFWsnA==}
+
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
@@ -3027,6 +3124,9 @@ packages:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
 
+  promise-polyfill@8.3.0:
+    resolution: {integrity: sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg==}
+
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
@@ -3225,6 +3325,9 @@ packages:
   serve-static@1.16.3:
     resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
     engines: {node: '>= 0.8.0'}
+
+  server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -4536,6 +4639,22 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.8.0
 
+  '@paypal/paypal-js@9.7.0':
+    dependencies:
+      promise-polyfill: 8.3.0
+
+  '@paypal/react-paypal-js@9.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@paypal/paypal-js': 9.7.0
+      '@paypal/sdk-constants': 1.0.157
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      server-only: 0.0.1
+
+  '@paypal/sdk-constants@1.0.157':
+    dependencies:
+      hi-base32: 0.5.1
+
   '@prisma/client@6.19.3(prisma@6.19.3(typescript@5.9.3))(typescript@5.9.3)':
     optionalDependencies:
       prisma: 6.19.3(typescript@5.9.3)
@@ -4596,6 +4715,57 @@ snapshots:
       react-redux: 9.2.0(@types/react@18.3.28)(react@18.3.1)(redux@5.0.1)
 
   '@remix-run/router@1.23.2': {}
+
+  '@resvg/resvg-js-android-arm-eabi@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-android-arm64@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-darwin-arm64@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-darwin-x64@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-arm-gnueabihf@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-arm64-gnu@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-arm64-musl@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-x64-gnu@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-x64-musl@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-win32-arm64-msvc@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-win32-ia32-msvc@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-win32-x64-msvc@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js@2.6.2':
+    optionalDependencies:
+      '@resvg/resvg-js-android-arm-eabi': 2.6.2
+      '@resvg/resvg-js-android-arm64': 2.6.2
+      '@resvg/resvg-js-darwin-arm64': 2.6.2
+      '@resvg/resvg-js-darwin-x64': 2.6.2
+      '@resvg/resvg-js-linux-arm-gnueabihf': 2.6.2
+      '@resvg/resvg-js-linux-arm64-gnu': 2.6.2
+      '@resvg/resvg-js-linux-arm64-musl': 2.6.2
+      '@resvg/resvg-js-linux-x64-gnu': 2.6.2
+      '@resvg/resvg-js-linux-x64-musl': 2.6.2
+      '@resvg/resvg-js-win32-arm64-msvc': 2.6.2
+      '@resvg/resvg-js-win32-ia32-msvc': 2.6.2
+      '@resvg/resvg-js-win32-x64-msvc': 2.6.2
 
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     optional: true
@@ -5953,6 +6123,8 @@ snapshots:
 
   helmet@8.1.0: {}
 
+  hi-base32@0.5.1: {}
+
   hoist-non-react-statics@3.3.2:
     dependencies:
       react-is: 16.13.1
@@ -6748,6 +6920,8 @@ snapshots:
 
   progress@2.0.3: {}
 
+  promise-polyfill@8.3.0: {}
+
   prompts@2.4.2:
     dependencies:
       kleur: 3.0.3
@@ -6979,6 +7153,8 @@ snapshots:
       send: 0.19.2
     transitivePeerDependencies:
       - supports-color
+
+  server-only@0.0.1: {}
 
   setprototypeof@1.2.0: {}
 


### PR DESCRIPTION
### Motivation

- Provide a minimal payroll/driver settlement API surface to track weekly settlements and compute driver earnings per tenant. 
- Add a payroll UI and paywall UX so drivers and operators can view settlements and gated functionality. 
- Offer an alternative one-off payment flow (PayPal) and optional AdSense ad slots for the marketing landing page.

### Description

- Added payroll types and an in-memory store to `apps/api/src/app.ts`, plus three endpoints: `GET /api/payroll/settlements/:driverId`, `GET /api/payroll/earnings/:driverId`, and `POST /api/payroll/settlements`, with UUID generation via `crypto.randomUUID()` and basic payload validation. 
- Introduced `apps/api/test/payroll-routes.test.ts` exercising tenant/role enforcement, tenant isolation, settlement creation, listing and earnings summary. 
- Frontend additions: `PayrollPage` and `PaywallPage` pages, new `PayPalCheckoutButton` and `AdsSlot` components, App routes and Sidebar links for `/payroll` and `/paywall`, and automatic AdSense script injection in `main.tsx`. 
- Config and dependency updates: added `VITE_PAYPAL_CLIENT_ID` and `VITE_ADSENSE_*` variables to `apps/web/.env.example`, added `@paypal/react-paypal-js` to `apps/web/package.json`, and updated `pnpm-lock.yaml` accordingly.

### Testing

- Ran the Jest payroll route unit test file `apps/api/test/payroll-routes.test.ts`, and the tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f469522ebc83309491c40075b8a928)