### PR TITLE
Switch to Debian-based Node images, add unified bootstrap, and enhance Docker CLI installer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-FROM node:22-alpine AS deps
+FROM node:22-noble AS deps
 WORKDIR /app
 
-COPY package.json package-lock.json ./
-COPY apps/api/package.json ./apps/api/package.json
+COPY --chown=1001:1001 package.json package-lock.json ./
+COPY --chown=1001:1001 apps/api/package.json ./apps/api/package.json
 
 RUN npm ci --omit=dev --workspace apps/api --include-workspace-root=false
 
 
-FROM node:22-alpine AS build
+FROM node:22-noble AS build
 WORKDIR /app
 
-COPY package.json package-lock.json ./
+COPY --chown=1001:1001 package.json package-lock.json ./
 COPY apps/api/package.json ./apps/api/package.json
 
 RUN npm ci --workspace apps/api
@@ -24,23 +24,23 @@ RUN npx prisma generate --schema=apps/api/prisma/schema.prisma
 RUN npm run build --workspace apps/api
 
 
-FROM node:22-alpine AS runtime
+FROM node:22-noble AS runtime
 WORKDIR /app
 
 ENV NODE_ENV=production
 ENV PORT=3000
 ENV HOST=0.0.0.0
 
-RUN apk add --no-cache openssl
+RUN apt-get update && apt-get install -y --no-install-recommends openssl && rm -rf /var/lib/apt/lists/*
 
-COPY --from=deps /app/node_modules ./node_modules
-COPY package.json package-lock.json ./
+COPY --from=deps --chown=1001:1001 /app/node_modules ./node_modules
+COPY --chown=1001:1001 package.json package-lock.json ./
 COPY apps/api/package.json ./apps/api/package.json
 
-COPY --from=build /app/apps/api/dist ./apps/api/dist
-COPY --from=build /app/apps/api/prisma ./apps/api/prisma
+COPY --from=build --chown=1001:1001 /app/apps/api/dist ./apps/api/dist
+COPY --from=build --chown=1001:1001 /app/apps/api/prisma ./apps/api/prisma
 
-RUN addgroup -S nodejs && adduser -S nodejs -G nodejs
+RUN groupadd --system --gid 1001 nodejs && useradd --system --uid 1001 --gid 1001 nodejs
 USER nodejs
 
 WORKDIR /app/apps/api

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS build
+FROM node:20-noble AS build
 
 WORKDIR /app/apps/api
 
@@ -8,7 +8,7 @@ RUN npm install
 COPY apps/api ./
 RUN npx tsc -p tsconfig.build.json
 
-FROM node:20-alpine AS runtime
+FROM node:20-noble AS runtime
 
 WORKDIR /app/apps/api
 ENV NODE_ENV=production
@@ -19,8 +19,8 @@ RUN npm install --omit=dev
 
 COPY --from=build /app/apps/api/dist ./dist
 
-RUN addgroup -g 1001 -S nodejs
-RUN adduser -S nodejs -u 1001
+RUN groupadd --system --gid 1001 nodejs
+RUN useradd --system --uid 1001 --gid 1001 nodejs
 USER nodejs
 
 EXPOSE 3000

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "smoke:api:health": "bash scripts/smoke-api-health.sh",
     "snapshot:prod": "bash scripts/production-snapshot.sh",
     "setup:deps-docker": "bash scripts/bootstrap-deps-docker.sh",
-    "social-preview:generate": "node scripts/generate-social-preview.mjs"
+    "social-preview:generate": "node scripts/generate-social-preview.mjs",
+    "bootstrap": "bash scripts/bootstrap.sh"
   },
   "devDependencies": {
     "@resvg/resvg-js": "2.6.2",

--- a/scripts/bootstrap-deps-docker.sh
+++ b/scripts/bootstrap-deps-docker.sh
@@ -6,8 +6,8 @@ pnpm install --frozen-lockfile
 # Ensure prisma client is generated even when package-manager build scripts are disabled.
 pnpm run prisma:generate
 
-# Validate Docker CLI availability (non-mutating by default).
-if bash scripts/install-docker-cli.sh; then
+# Ensure Docker CLI is installed, then validate daemon availability.
+if INSTALL_DOCKER=true bash scripts/install-docker-cli.sh; then
   echo "Docker CLI/daemon check: PASS"
 else
   echo "Docker CLI/daemon check: WARN (not available in this environment)"

--- a/scripts/bootstrap-environment.sh
+++ b/scripts/bootstrap-environment.sh
@@ -12,15 +12,12 @@ if should_install_workspace_dependencies "$PACKAGE_MANAGER"; then
   install_workspace_dependencies "$PACKAGE_MANAGER"
 fi
 
-echo "==> Ensuring deployment CLIs (Docker, flyctl, jq)"
-if [[ "${EUID}" -eq 0 ]]; then
-  bash scripts/install-dev-clis.sh
-else
-  bash scripts/install-docker-cli.sh || true
-  if ! command -v flyctl >/dev/null 2>&1; then
-    echo "flyctl is not installed. Run with sudo/root:"
-    echo "  sudo bash scripts/install-dev-clis.sh"
-  fi
+echo "==> Ensuring required CLIs (flyctl, supabase, stripe, docker)"
+bash scripts/install-required-clis.sh
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker is not installed. Install with sudo/root:"
+  echo "  sudo INSTALL_DOCKER=true bash scripts/install-docker-cli.sh"
 fi
 
 echo "==> Ensuring AI SDK runtime"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Unified bootstrap entrypoint for local and CI-like environments.
+bash scripts/bootstrap-environment.sh
+bash scripts/bootstrap-deps-docker.sh

--- a/scripts/install-docker-cli.sh
+++ b/scripts/install-docker-cli.sh
@@ -17,7 +17,6 @@ install_via_static_binary() {
   docker --version
 }
 
-
 install_buildx_plugin() {
   if docker buildx version >/dev/null 2>&1; then
     return 0
@@ -73,8 +72,32 @@ ensure_docker_daemon() {
   fi
 
   echo "Docker daemon is still not reachable."
-  echo "If this is a restricted container, daemon access may be unavailable." 
+  echo "If this is a restricted container, daemon access may be unavailable."
   return 1
+}
+
+install_via_docker_apt_repo() {
+  local arch codename
+  arch="$(dpkg --print-architecture)"
+  codename="$(. /etc/os-release && echo "${VERSION_CODENAME:-}")"
+
+  if [ -z "$codename" ]; then
+    echo "Unable to detect Ubuntu/Debian codename; skipping Docker apt repo setup." >&2
+    return 1
+  fi
+
+  apt-get update
+  apt-get install -y --no-install-recommends ca-certificates curl gnupg
+  install -m 0755 -d /etc/apt/keyrings
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+  chmod a+r /etc/apt/keyrings/docker.gpg
+
+  cat >/etc/apt/sources.list.d/docker.list <<APT
+ deb [arch=${arch} signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu ${codename} stable
+APT
+
+  apt-get update
+  apt-get install -y --no-install-recommends docker-ce-cli docker-buildx-plugin docker-compose-plugin
 }
 
 if command -v docker >/dev/null 2>&1; then
@@ -104,14 +127,10 @@ fi
 
 if command -v apt-get >/dev/null 2>&1; then
   echo "Installing Docker CLI packages..."
-  if apt-get update && {
-    if apt-cache show docker-buildx-plugin >/dev/null 2>&1; then
-      apt-get install -y docker.io docker-buildx-plugin
-    else
-      apt-get install -y docker.io
-    fi
-  }; then
+  if install_via_docker_apt_repo; then
     :
+  elif apt-get update && apt-get install -y --no-install-recommends docker.io; then
+    echo "Installed Docker via distro packages."
   else
     echo "APT install failed, falling back to static Docker CLI binary install..."
     install_via_static_binary
@@ -128,11 +147,15 @@ fi
 
 docker --version
 
-install_buildx_plugin
 if docker buildx version >/dev/null 2>&1; then
   docker buildx version
 else
-  echo "Docker Buildx is not available from installed packages."
+  install_buildx_plugin
+  if docker buildx version >/dev/null 2>&1; then
+    docker buildx version
+  else
+    echo "Docker Buildx is not available from installed packages."
+  fi
 fi
 
 if ! ensure_docker_daemon; then

--- a/scripts/install-required-clis.sh
+++ b/scripts/install-required-clis.sh
@@ -53,9 +53,32 @@ install_stripe() {
   rm -f "$tmp"
 }
 
+install_docker() {
+  if command -v docker >/dev/null 2>&1; then
+    echo "docker already installed"
+    return
+  fi
+
+  if [[ "$(id -u)" -eq 0 ]]; then
+    INSTALL_DOCKER=true bash "${SCRIPT_DIR}/install-docker-cli.sh"
+    return
+  fi
+
+  if command -v sudo >/dev/null 2>&1; then
+    sudo INSTALL_DOCKER=true bash "${SCRIPT_DIR}/install-docker-cli.sh"
+    return
+  fi
+
+  echo "Docker CLI requires root privileges to install. Re-run with sudo or as root:" >&2
+  echo "  sudo INSTALL_DOCKER=true bash ${SCRIPT_DIR}/install-docker-cli.sh" >&2
+  return 1
+}
+
+
 install_flyctl
 install_supabase
 install_stripe
+install_docker
 
 echo "Required CLIs are available in ${TOOLS_DIR}."
 echo "Add to PATH: export PATH=\"${TOOLS_DIR}:\$PATH\""

--- a/scripts/validate-ops-scripts.sh
+++ b/scripts/validate-ops-scripts.sh
@@ -5,6 +5,7 @@ scripts=(
   scripts/install-docker-cli.sh
   scripts/install-required-clis.sh
   scripts/bootstrap-deps-docker.sh
+  scripts/bootstrap.sh
   scripts/smoke-api-health.sh
   scripts/production-snapshot.sh
 )

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -53,6 +53,14 @@ echo "==> Building API + Web"
 run_workspace_script "$PACKAGE_MANAGER" build
 record_pass "API and web build"
 
+echo "==> Verifying required CLIs"
+if bash scripts/verify-required-clis.sh; then
+  record_pass "Required CLIs available"
+else
+  record_fail "Required CLIs missing"
+  exit 1
+fi
+
 echo "==> Checking Docker CLI"
 if command -v docker >/dev/null 2>&1; then
   docker --version

--- a/scripts/verify-required-clis.sh
+++ b/scripts/verify-required-clis.sh
@@ -19,6 +19,7 @@ check_cli() {
 check_cli flyctl
 check_cli supabase
 check_cli stripe
+check_cli docker
 
 if [[ "$missing" -ne 0 ]]; then
   exit 1


### PR DESCRIPTION
### Motivation
- Move Docker images off Alpine to Debian-based Node variants for broader compatibility with system packages and to enable non-root image file ownership; unify and simplify repository bootstrapping and ensure required CLIs are available.

### Description
- Replace `node:*alpine` images with `node:*noble` in `Dockerfile` and `Dockerfile.api`, add `--chown=1001:1001` to `COPY` operations, create system `nodejs` user/group with UID/GID 1001, and install `openssl` via `apt-get` in the runtime stage.
- Add `scripts/bootstrap.sh` as a unified bootstrap entrypoint and add a `bootstrap` npm script, while updating `scripts/bootstrap-environment.sh` to call `install-required-clis.sh` and to prompt for Docker when not present.
- Rework `scripts/install-docker-cli.sh` to support installing Docker via the official apt repo, fall back to distro packages or a static binary, install the Buildx plugin if missing, and robustly attempt to ensure the Docker daemon is available; make the installer respect `INSTALL_DOCKER=true` to allow non-mutating checks.
- Enhance `scripts/install-required-clis.sh` to install Docker when run as root/sudo and update `scripts/verify-required-clis.sh`, `scripts/validate-ops-scripts.sh`, and `scripts/validate-repo.sh` to include and validate the new bootstrapping and Docker checks.

### Testing
- Validated modified ops scripts with `scripts/validate-ops-scripts.sh` (syntax checks via `bash -n`), which completed without syntax errors.
- Ran `scripts/verify-required-clis.sh` to confirm required CLIs (including `docker`) are detected in the environment and it returned success.
- Executed the repository validation via `scripts/validate-repo.sh`, which performed workspace `pnpm` test/build/lint steps and CLI checks and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4547747988330adc72d7987a08fb6)