### PR TITLE
Include subscription-status header in tests, harden CLI verification script, and fix checklist formatting

### DIFF
--- a/apps/api/test/billing.test.ts
+++ b/apps/api/test/billing.test.ts
@@ -57,6 +57,7 @@ describe('Stripe billing endpoints', () => {
       .get('/api/billing/status')
       .set('x-tenant-id', 'carrier_billing_123')
       .set('x-user-role', 'owner')
+      .set('x-subscription-status', 'active')
       .expect(200);
 
     expect(statusResponse.body.data).toMatchObject({
@@ -68,6 +69,7 @@ describe('Stripe billing endpoints', () => {
       .post('/api/billing/customer-portal')
       .set('x-tenant-id', 'carrier_billing_123')
       .set('x-user-role', 'owner')
+      .set('x-subscription-status', 'active')
       .send({})
       .expect(500);
 
@@ -101,6 +103,7 @@ describe('Stripe billing endpoints', () => {
       .post('/api/billing/checkout-session')
       .set('x-tenant-id', 'carrier_duplicate_guard')
       .set('x-user-role', 'owner')
+      .set('x-subscription-status', 'active')
       .send({ plan: 'professional', billingInterval: 'month' })
       .expect(409);
 
@@ -114,6 +117,7 @@ describe('Stripe billing endpoints', () => {
       .post('/api/billing/customer-portal')
       .set('x-tenant-id', 'carrier_billing_123')
       .set('x-user-role', 'dispatcher')
+      .set('x-subscription-status', 'active')
       .send({})
       .expect(403);
 
@@ -123,6 +127,7 @@ describe('Stripe billing endpoints', () => {
       .post('/api/billing/checkout-session')
       .set('x-tenant-id', 'carrier_billing_123')
       .set('x-user-role', 'dispatcher')
+      .set('x-subscription-status', 'active')
       .send({ plan: 'professional', billingInterval: 'month' })
       .expect(403);
 
@@ -136,6 +141,7 @@ describe('Stripe billing endpoints', () => {
       .post('/api/billing/checkout-session')
       .set('x-tenant-id', 'carrier_billing_123')
       .set('x-user-role', 'owner')
+      .set('x-subscription-status', 'active')
       .send({ plan: 'free', billingInterval: 'month' })
       .expect(400);
 
@@ -145,6 +151,7 @@ describe('Stripe billing endpoints', () => {
       .post('/api/billing/checkout-session')
       .set('x-tenant-id', 'carrier_billing_123')
       .set('x-user-role', 'owner')
+      .set('x-subscription-status', 'active')
       .send({ plan: 'professional', billingInterval: 'weekly' })
       .expect(400);
 
@@ -158,6 +165,7 @@ describe('Stripe billing endpoints', () => {
       .post('/api/billing/customer-portal')
       .set('x-tenant-id', 'carrier_without_customer')
       .set('x-user-role', 'admin')
+      .set('x-subscription-status', 'active')
       .send({})
       .expect(404);
 
@@ -171,6 +179,7 @@ describe('Stripe billing endpoints', () => {
       .post('/api/ai-usage/events')
       .set('x-tenant-id', 'carrier_ai_123')
       .set('x-user-role', 'dispatcher')
+      .set('x-subscription-status', 'active')
       .send({
         feature: 'dispatch-assistant',
         actionCount: 2,
@@ -186,6 +195,7 @@ describe('Stripe billing endpoints', () => {
       .post('/api/ai-usage/events')
       .set('x-tenant-id', 'carrier_ai_123')
       .set('x-user-role', 'dispatcher')
+      .set('x-subscription-status', 'active')
       .send({
         feature: 'dispatch-assistant',
         actionCount: 2,
@@ -201,6 +211,7 @@ describe('Stripe billing endpoints', () => {
       .get('/api/ai-usage/summary')
       .set('x-tenant-id', 'carrier_ai_123')
       .set('x-user-role', 'owner')
+      .set('x-subscription-status', 'active')
       .expect(200);
 
     expect(summary.body.data).toMatchObject({
@@ -220,6 +231,7 @@ describe('Stripe billing endpoints', () => {
       .post('/api/ai-usage/events')
       .set('x-tenant-id', 'carrier_ai_123')
       .set('x-user-role', 'dispatcher')
+      .set('x-subscription-status', 'active')
       .send({ actionCount: 1 })
       .expect(400);
 

--- a/apps/api/test/freight-operations.test.ts
+++ b/apps/api/test/freight-operations.test.ts
@@ -4,6 +4,7 @@ import { createApp } from '../src/app';
 const headers = {
   'x-tenant-id': 'carrier_123',
   'x-user-role': 'dispatcher',
+  'x-subscription-status': 'active',
 };
 
 describe('freight operations API', () => {

--- a/apps/api/test/freight-workflows.test.ts
+++ b/apps/api/test/freight-workflows.test.ts
@@ -4,6 +4,7 @@ import { createApp } from '../src/app';
 const headers = {
   'x-tenant-id': 'carrier_phase4',
   'x-user-role': 'dispatcher',
+  'x-subscription-status': 'active',
 };
 
 const loadPayload = {

--- a/apps/api/test/health.test.ts
+++ b/apps/api/test/health.test.ts
@@ -62,7 +62,8 @@ describe('tenant-protected resource routes', () => {
   it('rejects /api/loads without tenant id', async () => {
     const response = await request(createApp())
       .get('/api/loads')
-      .set('x-user-role', 'dispatcher');
+      .set('x-user-role', 'dispatcher')
+      .set('x-subscription-status', 'active');
 
     expect(response.status).toBe(400);
     expect(response.body.error).toBe('tenant_id_required');
@@ -100,6 +101,7 @@ describe('tenant-protected resource routes', () => {
       .post('/api/shipments')
       .set('x-tenant-id', 'tenant-1')
       .set('x-user-role', 'dispatcher')
+      .set('x-subscription-status', 'active')
       .send(shipmentForTenant1);
 
     expect(createForT1.status).toBe(201);
@@ -109,6 +111,7 @@ describe('tenant-protected resource routes', () => {
       .post('/api/shipments')
       .set('x-tenant-id', 'tenant-2')
       .set('x-user-role', 'dispatcher')
+      .set('x-subscription-status', 'active')
       .send(shipmentForTenant2);
 
     expect(createForT2.status).toBe(201);
@@ -116,7 +119,8 @@ describe('tenant-protected resource routes', () => {
     const listT1 = await request(app)
       .get('/api/shipments')
       .set('x-tenant-id', 'tenant-1')
-      .set('x-user-role', 'dispatcher');
+      .set('x-user-role', 'dispatcher')
+      .set('x-subscription-status', 'active');
 
     expect(listT1.status).toBe(200);
     expect(listT1.body.count).toBe(1);

--- a/apps/api/test/mvp-quote-to-load.test.ts
+++ b/apps/api/test/mvp-quote-to-load.test.ts
@@ -6,6 +6,7 @@ describe('MVP quote-to-load workflow', () => {
   const headers = {
     'x-tenant-id': tenantId,
     'x-user-role': 'dispatcher',
+    'x-subscription-status': 'active',
   };
 
   beforeAll(() => {

--- a/apps/api/test/verify-required-clis-script.test.ts
+++ b/apps/api/test/verify-required-clis-script.test.ts
@@ -15,10 +15,10 @@ describe('verify-required-clis.sh', () => {
     fs.copyFileSync(sourceScript, scriptPath);
     fs.chmodSync(scriptPath, 0o755);
 
-    const result = spawnSync('bash', [scriptPath], {
+    const result = spawnSync('/usr/bin/bash', [scriptPath], {
       cwd: tmp,
       encoding: 'utf8',
-      env: { ...process.env, PATH: '/usr/bin:/bin' },
+      env: { ...process.env, PATH: '/bin' },
     });
 
     expect(result.status).toBe(1);
@@ -34,7 +34,7 @@ describe('verify-required-clis.sh', () => {
     fs.mkdirSync(toolsDir, { recursive: true });
     fs.mkdirSync(scriptDir, { recursive: true });
 
-    for (const tool of ['flyctl', 'supabase', 'stripe']) {
+    for (const tool of ['flyctl', 'supabase', 'stripe', 'docker']) {
       const toolPath = path.join(toolsDir, tool);
       fs.writeFileSync(toolPath, '#!/usr/bin/env bash\nexit 0\n');
       fs.chmodSync(toolPath, 0o755);
@@ -44,7 +44,7 @@ describe('verify-required-clis.sh', () => {
     fs.copyFileSync(sourceScript, scriptPath);
     fs.chmodSync(scriptPath, 0o755);
 
-    const result = spawnSync('bash', [scriptPath], {
+    const result = spawnSync('/usr/bin/bash', [scriptPath], {
       cwd: tmp,
       encoding: 'utf8',
       env: { ...process.env, PATH: '/usr/bin:/bin' },

--- a/docs/production-operations/COMPLIANCE_CHECKLIST.md
+++ b/docs/production-operations/COMPLIANCE_CHECKLIST.md
@@ -111,8 +111,8 @@ The compliance owner is responsible for confirming, maintaining, and updating al
 
 If any regulatory requirement changes (new bond minimum, new filing process, authority lapse, or bond cancellation):
 
-1. Update this checklist immediately.
-2. Update `PRODUCTION_READINESS_EVIDENCE.md` with new status.
-3. Update `LAUNCH_CHECKLIST.md` if the change affects launch gate criteria.
-4. Notify the compliance owner and document the change with a date.
-5. Do not resume brokerage activity until the updated requirement is re-validated.
+- [ ] Update this checklist immediately.
+- [ ] Update `PRODUCTION_READINESS_EVIDENCE.md` with new status.
+- [ ] Update `LAUNCH_CHECKLIST.md` if the change affects launch gate criteria.
+- [ ] Notify the compliance owner and document the change with a date.
+- [ ] Do not resume brokerage activity until the updated requirement is re-validated.


### PR DESCRIPTION
### Motivation
- Ensure tests simulate requests from tenants with active subscriptions by adding the subscription status header to API tests.
- Make the CLI verification integration tests more reliable across environments by invoking an absolute shell path and tightening `PATH` handling, and to reflect an additional required tool (`docker`).
- Fix formatting in the compliance checklist to use task-style checkboxes for clarity.

### Description
- Added the `x-subscription-status: active` header to multiple test files and common `headers` objects so requests emulate an active subscription context for billing, AI usage, freight, and health/tenant routes.  
- Updated shell invocation in `verify-required-clis-script.test.ts` to call `/usr/bin/bash` explicitly and adjusted `env.PATH` used in the spawn to control which tools are discovered.  
- Extended the test that simulates required CLIs to include `docker` in the fake `.tools/bin` directory and adjusted the expected `PATH` values in each scenario.  
- Converted a numbered list to checklist-style items in `docs/production-operations/COMPLIANCE_CHECKLIST.md` to restore consistent checkbox formatting.

### Testing
- Ran the project's automated test suite via `npm test` and verified the modified API and script tests executed successfully.  
- Confirmed the CLI verification tests produce the expected exit codes and output with the updated shell and `PATH` handling.  
- All tests passed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f487187ab08330aa58a128f4f720de)