### PR TITLE
Add codex env-check improvements, tests, docs, and CI diagnostic step

### DIFF
--- a/.github/workflows/full-validation.yml
+++ b/.github/workflows/full-validation.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Test API workspace
         run: pnpm -C apps/api run test -- --runInBand
 
+      - name: Environment diagnostics (non-strict)
+        run: pnpm run codex:env-check
+
       - name: Write validation summary
         if: always()
         run: |
@@ -56,6 +59,7 @@ jobs:
             echo "- pnpm run lint"
             echo "- pnpm run build"
             echo "- pnpm -C apps/api run test -- --runInBand"
+            echo "- pnpm run codex:env-check"
             echo ""
             echo "Ref: ${{ github.ref }}"
             echo "SHA: ${{ github.sha }}"

--- a/apps/api/test/codex-env-check-script.test.ts
+++ b/apps/api/test/codex-env-check-script.test.ts
@@ -1,0 +1,48 @@
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+describe('codex-env-check.sh', () => {
+  const scriptPath = path.resolve(__dirname, '..', '..', '..', 'scripts', 'codex-env-check.sh');
+
+  it('fails in strict mode when placeholders are configured', () => {
+    const result = spawnSync('/usr/bin/bash', [scriptPath, '--strict'], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        NODE_ENV: 'production',
+        DATABASE_URL: 'postgresql://user:password@host:5432/db',
+        STRIPE_SECRET_KEY: 'sk_live_placeholder',
+        STRIPE_WEBHOOK_SECRET: 'whsec_real_secret',
+        STRIPE_PUBLISHABLE_KEY: 'pk_live_real',
+        VITE_STRIPE_PUBLIC_KEY: 'pk_live_real',
+        SUPABASE_URL: 'https://placeholder.supabase.co',
+        SUPABASE_SERVICE_KEY: 'service_role_real',
+        SUPABASE_ANON_KEY: 'anon_real',
+        SUPABASE_SERVICE_ROLE_KEY: 'service_role_real',
+        SUPABASE_JWT_SECRET: 'jwt_real',
+        VITE_SUPABASE_URL: 'https://placeholder.supabase.co',
+        VITE_SUPABASE_DATABASE_URL: 'https://placeholder.supabase.co',
+        VITE_SUPABASE_PUBLISHABLE_KEY: 'sb_publishable_real',
+        VITE_SUPABASE_ANON_KEY: 'anon_real',
+        NEXT_PUBLIC_SUPABASE_URL: 'https://placeholder.supabase.co',
+      },
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('appears to still use a placeholder value');
+    expect(result.stdout).toContain('Placeholder-looking values:');
+  });
+
+  it('warns when REDIS_HOST is localhost', () => {
+    const result = spawnSync('/usr/bin/bash', [scriptPath], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        REDIS_HOST: 'localhost',
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('REDIS_HOST is localhost');
+  });
+});

--- a/docs/PRODUCTION-SECRETS-CHECKLIST.md
+++ b/docs/PRODUCTION-SECRETS-CHECKLIST.md
@@ -22,17 +22,52 @@ Required:
 
 ```text
 FLY_API_TOKEN=<rotated Fly deploy token>
+DATABASE_URL=<production postgres connection string>
 ```
 
 Recommended repository variables or secrets where needed by builds:
 
 ```text
+NODE_ENV=production
+PORT=3000
 SITE_URL=https://www.infamousfreight.com
 PUBLIC_SITE_URL=https://www.infamousfreight.com
+FRONTEND_URL=https://www.infamousfreight.com
+WEB_APP_URL=https://www.infamousfreight.com
+CORS_ORIGIN=https://www.infamousfreight.com
+CORS_ORIGINS=https://www.infamousfreight.com,https://app.infamousfreight.com
 VITE_SITE_URL=https://www.infamousfreight.com
 NEXT_PUBLIC_SITE_URL=https://www.infamousfreight.com
+API_PUBLIC_URL=https://api.infamousfreight.com
 VITE_API_URL=/api
 NEXT_PUBLIC_API_URL=/api
+VITE_SOCKET_URL=wss://www.infamousfreight.com/socket.io
+REDIS_URL=<managed redis url>
+REDIS_HOST=<managed redis host>
+REDIS_PORT=6379
+REDIS_PASSWORD=<managed redis password>
+REDIS_DB=0
+SUPABASE_URL=https://<project>.supabase.co
+SUPABASE_SERVICE_KEY=<supabase service key>
+SUPABASE_SERVICE_ROLE_KEY=<supabase service role key>
+SUPABASE_ANON_KEY=<supabase anon key>
+SUPABASE_JWT_SECRET=<supabase jwt secret>
+VITE_SUPABASE_URL=https://<project>.supabase.co
+VITE_SUPABASE_DATABASE_URL=https://<project>.supabase.co
+VITE_SUPABASE_PUBLISHABLE_KEY=<supabase publishable key>
+VITE_SUPABASE_ANON_KEY=<supabase anon key>
+NEXT_PUBLIC_SUPABASE_URL=https://<project>.supabase.co
+SENTRY_DSN=<backend sentry dsn>
+VITE_SENTRY_DSN=<frontend sentry dsn>
+NEXT_PUBLIC_SENTRY_DSN=<frontend sentry dsn>
+STRIPE_SECRET_KEY=<stripe secret key>
+STRIPE_WEBHOOK_SECRET=<stripe webhook signing secret>
+STRIPE_PUBLISHABLE_KEY=<stripe publishable key>
+VITE_STRIPE_PUBLIC_KEY=<stripe publishable key>
+DAT_API_KEY=<dat api key>
+TRUCKSTOP_API_KEY=<truckstop api key>
+LOADBOARD_API_KEY=<loadboard api key>
+SAMSARA_API_TOKEN=<samsara api token>
 ```
 
 ## Netlify production environment

--- a/docs/SECRETS-GUIDE.md
+++ b/docs/SECRETS-GUIDE.md
@@ -53,6 +53,16 @@ fly apps list
 |-------------|-------|------------|
 | `SUPABASE_URL` | `https://your-project.supabase.co` | Supabase Project Settings > API |
 | `SUPABASE_SERVICE_KEY` | `your-service-key` | Supabase Project Settings > API > service_role key |
+| `SUPABASE_SERVICE_ROLE_KEY` | `your-service-role-key` | Supabase Project Settings > API > service_role key |
+| `SUPABASE_JWT_SECRET` | `your-jwt-secret` | Supabase Project Settings > API |
+| `SUPABASE_ANON_KEY` | `your-anon-key` | Supabase Project Settings > API |
+
+### Sentry (Recommended for production)
+| Secret Name | Value | How to Get |
+|-------------|-------|------------|
+| `SENTRY_DSN` | `https://...` | Sentry project settings |
+| `VITE_SENTRY_DSN` | `https://...` | Sentry project settings |
+| `NEXT_PUBLIC_SENTRY_DSN` | `https://...` | Sentry project settings |
 
 ### Load Board APIs (Optional — enables live load data)
 | Secret Name | Value | How to Get |
@@ -90,14 +100,29 @@ After adding all secrets, your GitHub Actions page should show:
 ```
 Repository secrets:
 - FLY_API_TOKEN
+- DATABASE_URL
 - NETLIFY_AUTH_TOKEN
 - NETLIFY_SITE_ID
 - STRIPE_SECRET_KEY
 - STRIPE_WEBHOOK_SECRET
 - SUPABASE_URL
 - SUPABASE_SERVICE_KEY
+- SUPABASE_SERVICE_ROLE_KEY
+- SUPABASE_JWT_SECRET
+- SUPABASE_ANON_KEY
 - VITE_API_URL
 - VITE_STRIPE_PUBLIC_KEY
+```
+
+Repository variables/secrets should also include runtime values documented in:
+
+- `docs/PRODUCTION-SECRETS-CHECKLIST.md`
+- `scripts/codex-env-check.sh` required and optional lists
+
+Use this for a quick CI validation pass after saving values:
+
+```bash
+pnpm run codex:env-check:strict
 ```
 
 ---

--- a/docs/environment/ENVIRONMENT_CONFIGURATION_27.md
+++ b/docs/environment/ENVIRONMENT_CONFIGURATION_27.md
@@ -1,0 +1,72 @@
+# 27 Environment Variables - Configuration Snapshot
+
+_Last updated: May 1, 2026._
+
+This snapshot reflects the 27 configured variables currently tracked for Infamous Freight and highlights where placeholder values still block production readiness.
+
+## Important status clarification
+
+Even though all 27 variable **names** are configured, the environment is **not production-ready** while placeholder values remain (for example `placeholder_*`, sample Supabase values, and sample Sentry DSNs).
+
+## Backend variables (22)
+
+1. `NODE_ENV`
+2. `PORT`
+3. `DATABASE_URL`
+4. `CORS_ORIGINS`
+5. `WEB_APP_URL`
+6. `STRIPE_SECRET_KEY`
+7. `STRIPE_WEBHOOK_SECRET`
+8. `STRIPE_CHECKOUT_SUCCESS_URL`
+9. `STRIPE_CHECKOUT_CANCEL_URL`
+10. `STRIPE_PORTAL_RETURN_URL`
+11. `SUPABASE_URL`
+12. `SUPABASE_SERVICE_KEY`
+13. `REDIS_HOST`
+14. `REDIS_PORT`
+15. `REDIS_PASSWORD`
+16. `REDIS_DB`
+17. `DAT_API_KEY`
+18. `TRUCKSTOP_API_KEY`
+19. `LOADBOARD_API_KEY`
+20. `SAMSARA_API_TOKEN`
+21. `SENTRY_DSN`
+22. `RATE_LIMIT_ENABLED`
+
+## Frontend variables (5)
+
+23. `VITE_API_URL`
+24. `VITE_SUPABASE_URL`
+25. `VITE_SUPABASE_PUBLISHABLE_KEY`
+26. `VITE_SUPABASE_ANON_KEY`
+27. `VITE_SENTRY_DSN`
+
+## Required replacements before production
+
+Replace placeholders with real credentials for:
+
+- `REDIS_PASSWORD`
+- `DAT_API_KEY`
+- `TRUCKSTOP_API_KEY`
+- `LOADBOARD_API_KEY`
+- `SAMSARA_API_TOKEN`
+- `SENTRY_DSN`
+- `VITE_SUPABASE_URL`
+- `VITE_SUPABASE_PUBLISHABLE_KEY`
+- `VITE_SUPABASE_ANON_KEY`
+- `VITE_SENTRY_DSN`
+
+## Redis production recommendation
+
+Avoid `REDIS_HOST=localhost` in production unless Redis runs in the same container/runtime.
+Prefer managed Redis with explicit host/password and connectivity checks.
+
+## Validation commands
+
+```bash
+pnpm run codex:env-check
+pnpm run codex:env-check:strict
+pnpm -C apps/api run test
+```
+
+Use strict mode as a release gate: any missing required values or placeholder-like values should block promotion.

--- a/scripts/codex-env-check.sh
+++ b/scripts/codex-env-check.sh
@@ -25,17 +25,26 @@ required_vars=(
   SUPABASE_URL
   SUPABASE_SERVICE_KEY
   SUPABASE_ANON_KEY
+  SUPABASE_SERVICE_ROLE_KEY
+  SUPABASE_JWT_SECRET
   VITE_SUPABASE_URL
+  VITE_SUPABASE_DATABASE_URL
   VITE_SUPABASE_PUBLISHABLE_KEY
+  VITE_SUPABASE_ANON_KEY
+  NEXT_PUBLIC_SUPABASE_URL
 )
 
 optional_vars=(
   PORT
   CORS_ORIGINS
+  SITE_URL
+  PUBLIC_SITE_URL
+  FRONTEND_URL
   WEB_APP_URL
   STRIPE_CHECKOUT_SUCCESS_URL
   STRIPE_CHECKOUT_CANCEL_URL
   STRIPE_PORTAL_RETURN_URL
+  REDIS_URL
   REDIS_HOST
   REDIS_PORT
   REDIS_PASSWORD
@@ -44,8 +53,10 @@ optional_vars=(
   API_RATE_LIMIT_ENABLED
   SENTRY_DSN
   VITE_API_URL
+  API_PUBLIC_URL
   VITE_SOCKET_URL
   VITE_SENTRY_DSN
+  NEXT_PUBLIC_SENTRY_DSN
   VITE_SENTRY_ENABLED
   SENTRY_ORG
   SENTRY_PROJECT
@@ -60,6 +71,7 @@ optional_vars=(
   QBO_CLIENT_SECRET
   XERO_CLIENT_ID
   XERO_CLIENT_SECRET
+  FLY_API_TOKEN
   SENDGRID_API_KEY
   FROM_EMAIL
   RTS_API_KEY
@@ -69,6 +81,50 @@ optional_vars=(
 
 missing_required=0
 missing_optional=0
+placeholder_values=0
+
+placeholder_patterns=(
+  "placeholder"
+  "changeme"
+  "your-"
+  "your_"
+  "example"
+  "<"
+)
+
+placeholder_overrides=(
+  "NODE_ENV"
+  "PORT"
+  "REDIS_PORT"
+  "REDIS_DB"
+  "API_RATE_LIMIT_ENABLED"
+  "VITE_SENTRY_ENABLED"
+  "FROM_EMAIL"
+)
+
+contains_placeholder() {
+  local value="$1"
+  local lowered
+  lowered="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')"
+
+  for pattern in "${placeholder_patterns[@]}"; do
+    if [[ "$lowered" == *"$pattern"* ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+is_placeholder_override() {
+  local name="$1"
+  for allowed_name in "${placeholder_overrides[@]}"; do
+    if [[ "$allowed_name" == "$name" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
 
 check_var() {
   local name="$1"
@@ -76,6 +132,16 @@ check_var() {
 
   if [[ -n "${!name:-}" ]]; then
     echo "✅ ${name} is set"
+
+    if ! is_placeholder_override "$name" && contains_placeholder "${!name}"; then
+      echo "❌ ${name} appears to still use a placeholder value"
+      placeholder_values=$((placeholder_values + 1))
+    fi
+
+    if [[ "$name" == "REDIS_HOST" && "${!name}" == "localhost" ]]; then
+      echo "⚠️  REDIS_HOST is localhost. This only works when Redis runs in the same runtime/container."
+    fi
+
     return 0
   fi
 
@@ -104,9 +170,17 @@ printenv | cut -d= -f1 | sort
 printf '\nSummary:\n'
 echo "Required missing: ${missing_required}"
 echo "Optional missing: ${missing_optional}"
+echo "Placeholder-looking values: ${placeholder_values}"
 
 if [[ "${missing_required}" -gt 0 ]]; then
   echo "Required variables are missing. Add them to Codex Environment variables, save the environment, then rerun this check."
+  if [[ "${strict}" == "1" ]]; then
+    exit 1
+  fi
+fi
+
+if [[ "${placeholder_values}" -gt 0 ]]; then
+  echo "One or more configured values still look like placeholders. Replace them with real production values."
   if [[ "${strict}" == "1" ]]; then
     exit 1
   fi


### PR DESCRIPTION
### Motivation

- Ensure runtime environment variables are validated for missing values and placeholder-like values before promoting to production.
- Surface common misconfigurations such as `REDIS_HOST=localhost` and fail fast in strict release gating mode.
- Document required production secrets and provide a snapshot of the current environment configuration for easier ops handoff.

### Description

- Enhanced `scripts/codex-env-check.sh` to include additional required/optional variables, placeholder detection, a list of placeholder patterns, and a strict-mode exit when placeholders or required values are present, plus a `REDIS_HOST=localhost` warning.
- Added unit tests at `apps/api/test/codex-env-check-script.test.ts` covering strict-mode failure on placeholder values and a warning for `REDIS_HOST=localhost`.
- Updated CI workflow `.github/workflows/full-validation.yml` to run the environment diagnostics step `pnpm run codex:env-check` and to include it in the validation summary.
- Expanded documentation in `docs/PRODUCTION-SECRETS-CHECKLIST.md` and `docs/SECRETS-GUIDE.md`, and added `docs/environment/ENVIRONMENT_CONFIGURATION_27.md` to record a snapshot of tracked variables.

### Testing

- Ran the API test suite with `pnpm -C apps/api run test -- --runInBand`, which executed `codex-env-check-script.test.ts` and the new tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4b349d5c483309e7a52b1685d9f22)