### PR TITLE
docs: overhaul environment variables guide (identify 27 vars, clarify names & templates)

### DIFF
--- a/docs/environment/ENVIRONMENT_VARIABLES_COMPLETE.md
+++ b/docs/environment/ENVIRONMENT_VARIABLES_COMPLETE.md
@@ -1,53 +1,112 @@
-# Infamous Freight Environment Variables (Complete)
+# How to Get All 27 Environment Variables (Infamous Freight)
 
-## Backend (apps/api)
+_Last updated: May 1, 2026._
 
-| Variable | Required | Description |
-|---|---:|---|
-| NODE_ENV | Yes | Runtime mode (`production` in deploy). |
-| PORT | Yes | API bind port (`3000` in production, `3001` local default). |
-| DATABASE_URL | Yes | PostgreSQL connection string for Prisma. |
-| CORS_ORIGINS | Yes | Comma-separated allowed origins. |
-| WEB_APP_URL | Yes | Canonical frontend URL used by API flows. |
-| STRIPE_SECRET_KEY | Yes | Stripe server-side secret key. |
-| STRIPE_WEBHOOK_SECRET | Yes | Stripe webhook signing secret. |
-| STRIPE_CHECKOUT_SUCCESS_URL | Yes | Success redirect URL for checkout. |
-| STRIPE_CHECKOUT_CANCEL_URL | Yes | Cancel redirect URL for checkout. |
-| STRIPE_PORTAL_RETURN_URL | Yes | Return URL for Stripe customer portal. |
-| SUPABASE_URL | Yes | Supabase project URL. |
-| SUPABASE_SERVICE_KEY | Yes | Supabase service role key (server only). |
-| REDIS_HOST | Yes | Redis host. |
-| REDIS_PORT | Yes | Redis port (typically `6379`). |
-| REDIS_PASSWORD | Yes | Redis password. |
-| REDIS_DB | Yes | Redis DB index (typically `0`). |
-| DAT_API_KEY | Yes | DAT loadboard API key. |
-| TRUCKSTOP_API_KEY | Yes | Truckstop API key. |
-| LOADBOARD_API_KEY | Yes | Alternate/general loadboard API key. |
-| SAMSARA_API_TOKEN | Yes | Samsara API token. |
-| SENTRY_DSN | Optional | Backend Sentry DSN. |
-| API_RATE_LIMIT_ENABLED | Yes | Enables API rate limiting (`true`/`false`). |
+This is the production-oriented setup guide for every environment variable currently expected across `apps/api` and `apps/web`.
 
-## Frontend (apps/web)
+## Variable inventory (27 total)
 
-| Variable | Required | Description |
-|---|---:|---|
-| VITE_API_URL | Yes | Public API base URL. |
-| VITE_SUPABASE_URL | Yes | Supabase project URL for client SDK. |
-| VITE_SUPABASE_PUBLISHABLE_KEY | Yes | Supabase publishable key for frontend. |
-| VITE_SUPABASE_ANON_KEY | Optional | Backward-compatible anon key for older frontend setups. |
-| VITE_SENTRY_DSN | Optional | Frontend Sentry DSN. |
+### Core (5)
+1. `NODE_ENV`
+2. `PORT`
+3. `DATABASE_URL`
+4. `CORS_ORIGINS`
+5. `WEB_APP_URL`
 
-## Secrets (do not commit)
+### Stripe (5)
+6. `STRIPE_SECRET_KEY`
+7. `STRIPE_WEBHOOK_SECRET`
+8. `STRIPE_CHECKOUT_SUCCESS_URL`
+9. `STRIPE_CHECKOUT_CANCEL_URL`
+10. `STRIPE_PORTAL_RETURN_URL`
 
-Set these in secret stores (CI/Fly/Codex secrets), not tracked files:
+### Supabase (5)
+11. `SUPABASE_URL`
+12. `SUPABASE_SERVICE_KEY`
+13. `VITE_SUPABASE_URL`
+14. `VITE_SUPABASE_PUBLISHABLE_KEY`
+15. `VITE_SUPABASE_ANON_KEY` (legacy-compatible fallback)
 
-- `NPM_TOKEN`
-- `GITHUB_TOKEN`
-- `PRIVATE_REGISTRY_TOKEN`
+### Redis (4)
+16. `REDIS_HOST`
+17. `REDIS_PORT`
+18. `REDIS_PASSWORD`
+19. `REDIS_DB`
 
-Use `PORT=3001` locally only if your development setup runs the API on 3001.
+### Load boards (3)
+20. `DAT_API_KEY`
+21. `TRUCKSTOP_API_KEY`
+22. `LOADBOARD_API_KEY`
 
-## Example values template
+### ELD (1)
+23. `SAMSARA_API_TOKEN`
+
+### Observability + protection (2)
+24. `SENTRY_DSN`
+25. `RATE_LIMIT_ENABLED` (runtime flag used by API code)
+
+### Frontend connectivity (2)
+26. `VITE_API_URL`
+27. `VITE_SENTRY_DSN`
+
+> Note: Some templates still show `API_RATE_LIMIT_ENABLED`; runtime checks currently reference `RATE_LIMIT_ENABLED`. Set `RATE_LIMIT_ENABLED=true` in production to avoid ambiguity.
+
+---
+
+## Step-by-step: where to get each value
+
+### 1) Core values
+- `NODE_ENV=production`
+- `PORT=3000` (Fly/host may inject this automatically)
+- `DATABASE_URL`: PostgreSQL connection URI (Supabase/AWS RDS/DigitalOcean)
+- `CORS_ORIGINS`: comma-separated frontend origins, no spaces
+- `WEB_APP_URL`: canonical frontend URL, no trailing slash
+
+### 2) Stripe (billing)
+From Stripe Dashboard (`Developers`):
+- `STRIPE_SECRET_KEY`: use `sk_test_...` for staging, `sk_live_...` for production
+- `STRIPE_WEBHOOK_SECRET`: `whsec_...` from your webhook endpoint
+- Redirects:
+  - `STRIPE_CHECKOUT_SUCCESS_URL=https://www.infamousfreight.com/billing/success`
+  - `STRIPE_CHECKOUT_CANCEL_URL=https://www.infamousfreight.com/billing/cancel`
+  - `STRIPE_PORTAL_RETURN_URL=https://www.infamousfreight.com/billing`
+
+### 3) Supabase (auth/data)
+From Supabase Project Settings → API:
+- `SUPABASE_URL`
+- `SUPABASE_SERVICE_KEY` (server-only secret)
+- `VITE_SUPABASE_URL`
+- `VITE_SUPABASE_PUBLISHABLE_KEY` (preferred frontend key)
+- `VITE_SUPABASE_ANON_KEY` (compatibility fallback)
+
+### 4) Redis (cache/queues)
+From Redis Cloud / AWS ElastiCache / DigitalOcean Managed Redis:
+- `REDIS_HOST`
+- `REDIS_PORT`
+- `REDIS_PASSWORD`
+- `REDIS_DB=0` (default)
+
+### 5) Load board integrations
+Collect from each vendor portal:
+- `DAT_API_KEY`
+- `TRUCKSTOP_API_KEY`
+- `LOADBOARD_API_KEY`
+
+### 6) ELD integration
+From Samsara API tokens page:
+- `SAMSARA_API_TOKEN`
+
+### 7) Observability and abuse protection
+- `SENTRY_DSN` (backend DSN)
+- `RATE_LIMIT_ENABLED=true`
+
+### 8) Frontend runtime
+- `VITE_API_URL` (use `/api` behind reverse proxy, or absolute URL for direct API)
+- `VITE_SENTRY_DSN` (frontend DSN)
+
+---
+
+## Production template
 
 ```env
 NODE_ENV=production
@@ -55,43 +114,78 @@ PORT=3000
 DATABASE_URL=postgresql://user:password@host:5432/infamous_freight
 CORS_ORIGINS=https://www.infamousfreight.com,https://app.infamousfreight.com
 WEB_APP_URL=https://www.infamousfreight.com
+
 STRIPE_SECRET_KEY=sk_live_YOUR_KEY
 STRIPE_WEBHOOK_SECRET=whsec_YOUR_SECRET
 STRIPE_CHECKOUT_SUCCESS_URL=https://www.infamousfreight.com/billing/success
 STRIPE_CHECKOUT_CANCEL_URL=https://www.infamousfreight.com/billing/cancel
 STRIPE_PORTAL_RETURN_URL=https://www.infamousfreight.com/billing
+
 SUPABASE_URL=https://YOUR_PROJECT.supabase.co
 SUPABASE_SERVICE_KEY=YOUR_SERVICE_KEY
-REDIS_HOST=redis.infamousfreight.com
-REDIS_PORT=6379
-REDIS_PASSWORD=YOUR_PASSWORD
-REDIS_DB=0
-DAT_API_KEY=YOUR_KEY
-TRUCKSTOP_API_KEY=YOUR_KEY
-LOADBOARD_API_KEY=YOUR_KEY
-SAMSARA_API_TOKEN=YOUR_TOKEN
-SENTRY_DSN=https://YOUR_KEY@sentry.io/ID
-API_RATE_LIMIT_ENABLED=true
-VITE_API_URL=https://api.infamousfreight.com
 VITE_SUPABASE_URL=https://YOUR_PROJECT.supabase.co
 VITE_SUPABASE_PUBLISHABLE_KEY=YOUR_PUBLISHABLE_KEY
 VITE_SUPABASE_ANON_KEY=YOUR_ANON_KEY
-VITE_SENTRY_DSN=https://YOUR_KEY@sentry.io/ID
+
+REDIS_HOST=redis.example.com
+REDIS_PORT=6379
+REDIS_PASSWORD=YOUR_REDIS_PASSWORD
+REDIS_DB=0
+
+DAT_API_KEY=YOUR_DAT_KEY
+TRUCKSTOP_API_KEY=YOUR_TRUCKSTOP_KEY
+LOADBOARD_API_KEY=YOUR_LOADBOARD_KEY
+SAMSARA_API_TOKEN=YOUR_SAMSARA_TOKEN
+
+SENTRY_DSN=https://YOUR_KEY@sentry.io/PROJECT_ID
+RATE_LIMIT_ENABLED=true
+
+VITE_API_URL=/api
+VITE_SENTRY_DSN=https://YOUR_KEY@sentry.io/PROJECT_ID
 ```
 
-## Verification commands
+## Quick verification
 
 ```bash
-test -n "$NODE_ENV" && echo "✓ NODE_ENV is set"
-test -n "$DATABASE_URL" && echo "✓ DATABASE_URL is set"
-test -n "$STRIPE_SECRET_KEY" && echo "✓ STRIPE_SECRET_KEY is set"
-printenv | sort
+test -n "$DATABASE_URL" && echo "✓ DATABASE_URL set"
+test -n "$STRIPE_SECRET_KEY" && echo "✓ STRIPE_SECRET_KEY set"
+test -n "$SUPABASE_URL" && echo "✓ SUPABASE_URL set"
+test -n "$RATE_LIMIT_ENABLED" && echo "✓ RATE_LIMIT_ENABLED set"
 ```
 
-
-## Source of truth templates
-
-For exact local/dev defaults and additional optional integrations, reference:
-
-- Root API template: `.env.example`
+## Source-of-truth templates
+- Root backend template: `.env.example`
 - Web template: `apps/web/.env.example`
+- Deployment baseline: `.env.production.example`
+
+
+---
+
+## What is currently present vs missing/needed
+
+Based on current runtime references in `apps/api/src`, `apps/web/src`, and local env templates:
+
+### Present in runtime code (actively referenced)
+- Backend/runtime: `NODE_ENV`, `PORT`, `DATABASE_URL`, `CORS_ORIGINS`, `WEB_APP_URL`, `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_CHECKOUT_SUCCESS_URL`, `STRIPE_CHECKOUT_CANCEL_URL`, `STRIPE_PORTAL_RETURN_URL`, `SUPABASE_URL`, `SUPABASE_SERVICE_KEY`, `REDIS_HOST`, `REDIS_PORT`, `REDIS_PASSWORD`, `REDIS_DB`, `DAT_API_KEY`, `TRUCKSTOP_API_KEY`, `LOADBOARD_API_KEY`, `SAMSARA_API_TOKEN`, `SENTRY_DSN`, `RATE_LIMIT_ENABLED`.
+- Frontend/runtime: `VITE_API_URL`, `VITE_SUPABASE_URL`, `VITE_SUPABASE_PUBLISHABLE_KEY` (preferred), `VITE_SUPABASE_ANON_KEY` (fallback), `VITE_SENTRY_DSN`.
+
+### Present in env templates but not currently required by runtime code
+These are optional/integration/deployment convenience variables and can be set only when needed:
+- Auth/integration legacy: `JWT_SECRET`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_JWT_SECRET`
+- Frontend/deploy extras: `VITE_SOCKET_URL`, `VITE_STRIPE_PUBLIC_KEY`, `VITE_SENTRY_ENABLED`, `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SENTRY_DSN`
+- Platform/deploy metadata: `SITE_URL`, `PUBLIC_SITE_URL`, `FRONTEND_URL`, `API_PUBLIC_URL`, `FLY_API_TOKEN`
+- Sentry CI/source map upload: `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT`
+- Additional vendor integrations: `MOTIVE_CLIENT_ID`, `MOTIVE_CLIENT_SECRET`, `QBO_CLIENT_ID`, `QBO_CLIENT_SECRET`, `XERO_CLIENT_ID`, `XERO_CLIENT_SECRET`, `SENDGRID_API_KEY`, `FROM_EMAIL`, `RTS_API_KEY`, `OTR_API_KEY`, `APEX_API_KEY`
+
+### Missing/needed for a production deployment
+Set all 27 runtime variables listed in this document. At minimum, production is blocked without:
+- `DATABASE_URL`
+- `STRIPE_SECRET_KEY` + `STRIPE_WEBHOOK_SECRET`
+- `SUPABASE_URL` + `SUPABASE_SERVICE_KEY`
+- `VITE_API_URL` + `VITE_SUPABASE_URL` + one frontend Supabase key (`VITE_SUPABASE_PUBLISHABLE_KEY` recommended)
+- `CORS_ORIGINS` + `WEB_APP_URL`
+- `RATE_LIMIT_ENABLED=true`
+
+### Naming mismatches to resolve in your secret manager
+- Prefer `RATE_LIMIT_ENABLED` (runtime). Keep `API_RATE_LIMIT_ENABLED` only as a temporary compatibility value if older tooling still reads it.
+- Prefer `SUPABASE_SERVICE_KEY` for API runtime. Some templates still mention `SUPABASE_SERVICE_ROLE_KEY`; map both to the same secret value if needed during transition.


### PR DESCRIPTION
### Motivation
- Consolidate and modernize the environment variables reference into a single production-oriented document for `apps/api` and `apps/web`. 
- Resolve naming ambiguity between `API_RATE_LIMIT_ENABLED` and the runtime-checked `RATE_LIMIT_ENABLED`, and make required production variables explicit. 
- Provide clear source-of-truth references and a usable production `.env` template to reduce deployment mistakes.

### Description
- Replaced the previous table-style file with a comprehensive inventory and step-by-step guide in `docs/environment/ENVIRONMENT_VARIABLES_COMPLETE.md` that enumerates all 27 runtime variables. 
- Normalized naming and guidance for rate-limiting (`RATE_LIMIT_ENABLED`) and Supabase service keys, and documented mismatches that may exist in older templates. 
- Updated the production example template values and swapped several placeholders to clearer examples, moved Redis and third-party keys into the template, and standardized `VITE_API_URL` to `/api` in the example. 
- Added quick verification commands, links to source-of-truth env templates (`.env.example`, `apps/web/.env.example`, `.env.production.example`), and sections listing which vars are present in runtime code, which are optional in templates, and which are required for production.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4be6c63688330b3fd90652e6be739)