### PR TITLE
Add env aliases and compatibility, improve rate limit/CORS handling, update docs and env checker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,8 @@ REDIS_DB=0
 NODE_ENV=development
 PORT=3001
 JWT_SECRET=your-super-secret-jwt-key-change-this-in-production
+RATE_LIMIT_ENABLED=true
+# Legacy compatibility for older scripts:
 API_RATE_LIMIT_ENABLED=true
 
 # ——— Observability ———
@@ -32,7 +34,11 @@ STRIPE_PUBLISHABLE_KEY=pk_test_...
 # ——— Supabase ———
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_SERVICE_KEY=your-service-key
+# Legacy alias used by some older templates/tooling:
+SUPABASE_SERVICE_ROLE_KEY=your-service-key
 SUPABASE_ANON_KEY=your-anon-key
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_PUBLISHABLE_KEY=sb_publishable_your_key
 
 # ——— Load Board APIs ———
 DAT_API_KEY=your-dat-api-key

--- a/.env.production.example
+++ b/.env.production.example
@@ -5,12 +5,17 @@
 SITE_URL=https://www.infamousfreight.com
 PUBLIC_SITE_URL=https://www.infamousfreight.com
 FRONTEND_URL=https://www.infamousfreight.com
+CORS_ORIGINS=https://www.infamousfreight.com
+# Legacy alias:
 CORS_ORIGIN=https://www.infamousfreight.com
 
 # API
 NODE_ENV=production
 PORT=3000
 API_PUBLIC_URL=https://infamous-freight.fly.dev
+RATE_LIMIT_ENABLED=true
+# Legacy compatibility:
+API_RATE_LIMIT_ENABLED=true
 VITE_API_URL=/api
 VITE_SOCKET_URL=wss://www.infamousfreight.com/socket.io
 
@@ -23,14 +28,18 @@ REDIS_URL=<production-redis-connection-string>
 # Stripe
 STRIPE_SECRET_KEY=<stripe-secret-key>
 STRIPE_WEBHOOK_SECRET=<stripe-webhook-signing-secret>
+STRIPE_PUBLISHABLE_KEY=<stripe-publishable-key>
 VITE_STRIPE_PUBLIC_KEY=<stripe-publishable-key>
 
 # Supabase
 SUPABASE_URL=<supabase-project-url>
 SUPABASE_ANON_KEY=<supabase-anon-key>
-SUPABASE_SERVICE_ROLE_KEY=<supabase-service-role-key>
+SUPABASE_SERVICE_KEY=<supabase-service-key>
+# Legacy alias for older tooling:
+SUPABASE_SERVICE_ROLE_KEY=<supabase-service-key>
 SUPABASE_JWT_SECRET=<supabase-jwt-secret>
-VITE_SUPABASE_DATABASE_URL=<supabase-project-url>
+VITE_SUPABASE_URL=<supabase-project-url>
+VITE_SUPABASE_PUBLISHABLE_KEY=<supabase-publishable-key>
 VITE_SUPABASE_ANON_KEY=<supabase-anon-key>
 NEXT_PUBLIC_SUPABASE_URL=<supabase-project-url>
 

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -154,7 +154,7 @@ function initializeSentry() {
 }
 
 function getAllowedCorsOrigins(): string[] {
-  return (process.env.CORS_ORIGINS ?? '')
+  return (process.env.CORS_ORIGINS ?? process.env.CORS_ORIGIN ?? '')
     .split(',')
     .map((origin) => origin.trim())
     .filter(Boolean);

--- a/apps/api/src/rate-limit.ts
+++ b/apps/api/src/rate-limit.ts
@@ -45,7 +45,8 @@ export function createRateLimitMiddleware(keyPrefix = 'api') {
   const options = getRateLimitOptions(keyPrefix);
 
   return (req: Request, res: Response, next: NextFunction) => {
-    if (process.env.RATE_LIMIT_ENABLED === 'false') {
+    const rateLimitEnabled = process.env.RATE_LIMIT_ENABLED ?? process.env.API_RATE_LIMIT_ENABLED;
+    if (rateLimitEnabled === 'false') {
       next();
       return;
     }

--- a/apps/api/src/uploads/upload.service.ts
+++ b/apps/api/src/uploads/upload.service.ts
@@ -14,7 +14,7 @@ export class UploadService {
   constructor() {
     this.supabase = createClient(
       process.env.SUPABASE_URL || '',
-      process.env.SUPABASE_SERVICE_KEY || ''
+      process.env.SUPABASE_SERVICE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY || ''
     );
   }
 

--- a/docs/environment/ENVIRONMENT_VARIABLES_COMPLETE.md
+++ b/docs/environment/ENVIRONMENT_VARIABLES_COMPLETE.md
@@ -1,53 +1,112 @@
-# Infamous Freight Environment Variables (Complete)
+# How to Get All 27 Environment Variables (Infamous Freight)
 
-## Backend (apps/api)
+_Last updated: May 1, 2026._
 
-| Variable | Required | Description |
-|---|---:|---|
-| NODE_ENV | Yes | Runtime mode (`production` in deploy). |
-| PORT | Yes | API bind port (`3000` in production, `3001` local default). |
-| DATABASE_URL | Yes | PostgreSQL connection string for Prisma. |
-| CORS_ORIGINS | Yes | Comma-separated allowed origins. |
-| WEB_APP_URL | Yes | Canonical frontend URL used by API flows. |
-| STRIPE_SECRET_KEY | Yes | Stripe server-side secret key. |
-| STRIPE_WEBHOOK_SECRET | Yes | Stripe webhook signing secret. |
-| STRIPE_CHECKOUT_SUCCESS_URL | Yes | Success redirect URL for checkout. |
-| STRIPE_CHECKOUT_CANCEL_URL | Yes | Cancel redirect URL for checkout. |
-| STRIPE_PORTAL_RETURN_URL | Yes | Return URL for Stripe customer portal. |
-| SUPABASE_URL | Yes | Supabase project URL. |
-| SUPABASE_SERVICE_KEY | Yes | Supabase service role key (server only). |
-| REDIS_HOST | Yes | Redis host. |
-| REDIS_PORT | Yes | Redis port (typically `6379`). |
-| REDIS_PASSWORD | Yes | Redis password. |
-| REDIS_DB | Yes | Redis DB index (typically `0`). |
-| DAT_API_KEY | Yes | DAT loadboard API key. |
-| TRUCKSTOP_API_KEY | Yes | Truckstop API key. |
-| LOADBOARD_API_KEY | Yes | Alternate/general loadboard API key. |
-| SAMSARA_API_TOKEN | Yes | Samsara API token. |
-| SENTRY_DSN | Optional | Backend Sentry DSN. |
-| API_RATE_LIMIT_ENABLED | Yes | Enables API rate limiting (`true`/`false`). |
+This is the production-oriented setup guide for every environment variable currently expected across `apps/api` and `apps/web`.
 
-## Frontend (apps/web)
+## Variable inventory (27 total)
 
-| Variable | Required | Description |
-|---|---:|---|
-| VITE_API_URL | Yes | Public API base URL. |
-| VITE_SUPABASE_URL | Yes | Supabase project URL for client SDK. |
-| VITE_SUPABASE_PUBLISHABLE_KEY | Yes | Supabase publishable key for frontend. |
-| VITE_SUPABASE_ANON_KEY | Optional | Backward-compatible anon key for older frontend setups. |
-| VITE_SENTRY_DSN | Optional | Frontend Sentry DSN. |
+### Core (5)
+1. `NODE_ENV`
+2. `PORT`
+3. `DATABASE_URL`
+4. `CORS_ORIGINS`
+5. `WEB_APP_URL`
 
-## Secrets (do not commit)
+### Stripe (5)
+6. `STRIPE_SECRET_KEY`
+7. `STRIPE_WEBHOOK_SECRET`
+8. `STRIPE_CHECKOUT_SUCCESS_URL`
+9. `STRIPE_CHECKOUT_CANCEL_URL`
+10. `STRIPE_PORTAL_RETURN_URL`
 
-Set these in secret stores (CI/Fly/Codex secrets), not tracked files:
+### Supabase (5)
+11. `SUPABASE_URL`
+12. `SUPABASE_SERVICE_KEY`
+13. `VITE_SUPABASE_URL`
+14. `VITE_SUPABASE_PUBLISHABLE_KEY`
+15. `VITE_SUPABASE_ANON_KEY` (legacy-compatible fallback)
 
-- `NPM_TOKEN`
-- `GITHUB_TOKEN`
-- `PRIVATE_REGISTRY_TOKEN`
+### Redis (4)
+16. `REDIS_HOST`
+17. `REDIS_PORT`
+18. `REDIS_PASSWORD`
+19. `REDIS_DB`
 
-Use `PORT=3001` locally only if your development setup runs the API on 3001.
+### Load boards (3)
+20. `DAT_API_KEY`
+21. `TRUCKSTOP_API_KEY`
+22. `LOADBOARD_API_KEY`
 
-## Example values template
+### ELD (1)
+23. `SAMSARA_API_TOKEN`
+
+### Observability + protection (2)
+24. `SENTRY_DSN`
+25. `RATE_LIMIT_ENABLED` (runtime flag used by API code)
+
+### Frontend connectivity (2)
+26. `VITE_API_URL`
+27. `VITE_SENTRY_DSN`
+
+> Note: Runtime checks use `RATE_LIMIT_ENABLED`. Template files now include both `RATE_LIMIT_ENABLED` and legacy aliases where needed for compatibility.
+
+---
+
+## Step-by-step: where to get each value
+
+### 1) Core values
+- `NODE_ENV=production`
+- `PORT=3000` (Fly/host may inject this automatically)
+- `DATABASE_URL`: PostgreSQL connection URI (Supabase/AWS RDS/DigitalOcean)
+- `CORS_ORIGINS`: comma-separated frontend origins, no spaces
+- `WEB_APP_URL`: canonical frontend URL, no trailing slash
+
+### 2) Stripe (billing)
+From Stripe Dashboard (`Developers`):
+- `STRIPE_SECRET_KEY`: use `sk_test_...` for staging, `sk_live_...` for production
+- `STRIPE_WEBHOOK_SECRET`: `whsec_...` from your webhook endpoint
+- Redirects:
+  - `STRIPE_CHECKOUT_SUCCESS_URL=https://www.infamousfreight.com/billing/success`
+  - `STRIPE_CHECKOUT_CANCEL_URL=https://www.infamousfreight.com/billing/cancel`
+  - `STRIPE_PORTAL_RETURN_URL=https://www.infamousfreight.com/billing`
+
+### 3) Supabase (auth/data)
+From Supabase Project Settings → API:
+- `SUPABASE_URL`
+- `SUPABASE_SERVICE_KEY` (server-only secret)
+- `VITE_SUPABASE_URL`
+- `VITE_SUPABASE_PUBLISHABLE_KEY` (preferred frontend key)
+- `VITE_SUPABASE_ANON_KEY` (compatibility fallback)
+
+### 4) Redis (cache/queues)
+From Redis Cloud / AWS ElastiCache / DigitalOcean Managed Redis:
+- `REDIS_HOST`
+- `REDIS_PORT`
+- `REDIS_PASSWORD`
+- `REDIS_DB=0` (default)
+
+### 5) Load board integrations
+Collect from each vendor portal:
+- `DAT_API_KEY`
+- `TRUCKSTOP_API_KEY`
+- `LOADBOARD_API_KEY`
+
+### 6) ELD integration
+From Samsara API tokens page:
+- `SAMSARA_API_TOKEN`
+
+### 7) Observability and abuse protection
+- `SENTRY_DSN` (backend DSN)
+- `RATE_LIMIT_ENABLED=true`
+
+### 8) Frontend runtime
+- `VITE_API_URL` (use `/api` behind reverse proxy, or absolute URL for direct API)
+- `VITE_SENTRY_DSN` (frontend DSN)
+
+---
+
+## Production template
 
 ```env
 NODE_ENV=production
@@ -55,43 +114,122 @@ PORT=3000
 DATABASE_URL=postgresql://user:password@host:5432/infamous_freight
 CORS_ORIGINS=https://www.infamousfreight.com,https://app.infamousfreight.com
 WEB_APP_URL=https://www.infamousfreight.com
+
 STRIPE_SECRET_KEY=sk_live_YOUR_KEY
 STRIPE_WEBHOOK_SECRET=whsec_YOUR_SECRET
 STRIPE_CHECKOUT_SUCCESS_URL=https://www.infamousfreight.com/billing/success
 STRIPE_CHECKOUT_CANCEL_URL=https://www.infamousfreight.com/billing/cancel
 STRIPE_PORTAL_RETURN_URL=https://www.infamousfreight.com/billing
+
 SUPABASE_URL=https://YOUR_PROJECT.supabase.co
 SUPABASE_SERVICE_KEY=YOUR_SERVICE_KEY
-REDIS_HOST=redis.infamousfreight.com
-REDIS_PORT=6379
-REDIS_PASSWORD=YOUR_PASSWORD
-REDIS_DB=0
-DAT_API_KEY=YOUR_KEY
-TRUCKSTOP_API_KEY=YOUR_KEY
-LOADBOARD_API_KEY=YOUR_KEY
-SAMSARA_API_TOKEN=YOUR_TOKEN
-SENTRY_DSN=https://YOUR_KEY@sentry.io/ID
-API_RATE_LIMIT_ENABLED=true
-VITE_API_URL=https://api.infamousfreight.com
 VITE_SUPABASE_URL=https://YOUR_PROJECT.supabase.co
 VITE_SUPABASE_PUBLISHABLE_KEY=YOUR_PUBLISHABLE_KEY
 VITE_SUPABASE_ANON_KEY=YOUR_ANON_KEY
-VITE_SENTRY_DSN=https://YOUR_KEY@sentry.io/ID
+
+REDIS_HOST=redis.example.com
+REDIS_PORT=6379
+REDIS_PASSWORD=YOUR_REDIS_PASSWORD
+REDIS_DB=0
+
+DAT_API_KEY=YOUR_DAT_KEY
+TRUCKSTOP_API_KEY=YOUR_TRUCKSTOP_KEY
+LOADBOARD_API_KEY=YOUR_LOADBOARD_KEY
+SAMSARA_API_TOKEN=YOUR_SAMSARA_TOKEN
+
+SENTRY_DSN=https://YOUR_KEY@sentry.io/PROJECT_ID
+RATE_LIMIT_ENABLED=true
+
+VITE_API_URL=/api
+VITE_SENTRY_DSN=https://YOUR_KEY@sentry.io/PROJECT_ID
 ```
 
-## Verification commands
+## Quick verification
 
 ```bash
-test -n "$NODE_ENV" && echo "✓ NODE_ENV is set"
-test -n "$DATABASE_URL" && echo "✓ DATABASE_URL is set"
-test -n "$STRIPE_SECRET_KEY" && echo "✓ STRIPE_SECRET_KEY is set"
-printenv | sort
+test -n "$DATABASE_URL" && echo "✓ DATABASE_URL set"
+test -n "$STRIPE_SECRET_KEY" && echo "✓ STRIPE_SECRET_KEY set"
+test -n "$SUPABASE_URL" && echo "✓ SUPABASE_URL set"
+test -n "$RATE_LIMIT_ENABLED" && echo "✓ RATE_LIMIT_ENABLED set"
 ```
 
-
-## Source of truth templates
-
-For exact local/dev defaults and additional optional integrations, reference:
-
-- Root API template: `.env.example`
+## Source-of-truth templates
+- Root backend template: `.env.example`
 - Web template: `apps/web/.env.example`
+- Deployment baseline: `.env.production.example`
+
+
+---
+
+## What is currently present vs missing/needed
+
+Based on current runtime references in `apps/api/src`, `apps/web/src`, and local env templates:
+
+### Present in runtime code (actively referenced)
+- Backend/runtime: `NODE_ENV`, `PORT`, `DATABASE_URL`, `CORS_ORIGINS`, `WEB_APP_URL`, `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_CHECKOUT_SUCCESS_URL`, `STRIPE_CHECKOUT_CANCEL_URL`, `STRIPE_PORTAL_RETURN_URL`, `SUPABASE_URL`, `SUPABASE_SERVICE_KEY`, `REDIS_HOST`, `REDIS_PORT`, `REDIS_PASSWORD`, `REDIS_DB`, `DAT_API_KEY`, `TRUCKSTOP_API_KEY`, `LOADBOARD_API_KEY`, `SAMSARA_API_TOKEN`, `SENTRY_DSN`, `RATE_LIMIT_ENABLED`.
+- Frontend/runtime: `VITE_API_URL`, `VITE_SUPABASE_URL`, `VITE_SUPABASE_PUBLISHABLE_KEY` (preferred), `VITE_SUPABASE_ANON_KEY` (fallback), `VITE_SENTRY_DSN`.
+
+### Present in env templates but not currently required by runtime code
+These are optional/integration/deployment convenience variables and can be set only when needed:
+- Auth/integration legacy: `JWT_SECRET`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_JWT_SECRET`
+- Frontend/deploy extras: `VITE_SOCKET_URL`, `VITE_STRIPE_PUBLIC_KEY`, `VITE_SENTRY_ENABLED`, `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SENTRY_DSN`
+- Platform/deploy metadata: `SITE_URL`, `PUBLIC_SITE_URL`, `FRONTEND_URL`, `API_PUBLIC_URL`, `FLY_API_TOKEN`
+- Sentry CI/source map upload: `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT`
+- Additional vendor integrations: `MOTIVE_CLIENT_ID`, `MOTIVE_CLIENT_SECRET`, `QBO_CLIENT_ID`, `QBO_CLIENT_SECRET`, `XERO_CLIENT_ID`, `XERO_CLIENT_SECRET`, `SENDGRID_API_KEY`, `FROM_EMAIL`, `RTS_API_KEY`, `OTR_API_KEY`, `APEX_API_KEY`
+
+### Missing/needed for a production deployment
+Set all 27 runtime variables listed in this document. At minimum, production is blocked without:
+- `DATABASE_URL`
+- `STRIPE_SECRET_KEY` + `STRIPE_WEBHOOK_SECRET`
+- `SUPABASE_URL` + `SUPABASE_SERVICE_KEY`
+- `VITE_API_URL` + `VITE_SUPABASE_URL` + one frontend Supabase key (`VITE_SUPABASE_PUBLISHABLE_KEY` recommended)
+- `CORS_ORIGINS` + `WEB_APP_URL`
+- `RATE_LIMIT_ENABLED=true`
+
+### Naming mismatches to resolve in your secret manager
+- Prefer `RATE_LIMIT_ENABLED` (runtime). Keep `API_RATE_LIMIT_ENABLED` only as a temporary compatibility value if older tooling still reads it.
+- Prefer `SUPABASE_SERVICE_KEY` for API runtime. Templates include `SUPABASE_SERVICE_ROLE_KEY` as a legacy alias; map both to the same secret value during transition.
+
+## Recommended add-ons (set when feature is enabled)
+
+To “add all recommended above,” configure these in the same secret manager when the related integration is turned on:
+
+- Payments/frontend UX: `VITE_STRIPE_PUBLIC_KEY`
+- Socket routing: `VITE_SOCKET_URL`
+- Sentry release automation: `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT`, `VITE_SENTRY_ENABLED`
+- Alternate ELD provider: `MOTIVE_CLIENT_ID`, `MOTIVE_CLIENT_SECRET`
+- Accounting: `QBO_CLIENT_ID`, `QBO_CLIENT_SECRET`, `XERO_CLIENT_ID`, `XERO_CLIENT_SECRET`
+- Email delivery: `SENDGRID_API_KEY`, `FROM_EMAIL`
+- Factoring providers: `RTS_API_KEY`, `OTR_API_KEY`, `APEX_API_KEY`
+
+## Deployment-ready checklist (copy/paste)
+
+```bash
+# Required runtime set (27 vars)
+printenv | rg '^(NODE_ENV|PORT|DATABASE_URL|CORS_ORIGINS|WEB_APP_URL|STRIPE_SECRET_KEY|STRIPE_WEBHOOK_SECRET|STRIPE_CHECKOUT_SUCCESS_URL|STRIPE_CHECKOUT_CANCEL_URL|STRIPE_PORTAL_RETURN_URL|SUPABASE_URL|SUPABASE_SERVICE_KEY|REDIS_HOST|REDIS_PORT|REDIS_PASSWORD|REDIS_DB|DAT_API_KEY|TRUCKSTOP_API_KEY|LOADBOARD_API_KEY|SAMSARA_API_TOKEN|SENTRY_DSN|RATE_LIMIT_ENABLED|VITE_API_URL|VITE_SUPABASE_URL|VITE_SUPABASE_PUBLISHABLE_KEY|VITE_SUPABASE_ANON_KEY|VITE_SENTRY_DSN)='
+
+# Health expectation after deploy
+curl -fsS https://api.infamousfreight.com/health
+```
+
+Expected:
+- Health endpoint returns HTTP 200.
+- `RATE_LIMIT_ENABLED=true` in production.
+- App binds to `PORT=3000` (or host-injected `PORT`).
+
+## CI validation commands (run before merge/deploy)
+
+```bash
+pnpm lint
+pnpm -w test --runInBand
+pnpm env:check:strict
+```
+
+## Docker setup commands
+
+```bash
+pnpm docker:install-cli
+pnpm setup:deps-docker
+pnpm docker:build
+pnpm docker:up
+```

--- a/docs/environment/ENVIRONMENT_VARIABLES_COMPLETE.md
+++ b/docs/environment/ENVIRONMENT_VARIABLES_COMPLETE.md
@@ -1,223 +1,41 @@
-# How to Get All 27 Environment Variables (Infamous Freight)
+# Infamous Freight environment variables
 
-_Last updated: May 1, 2026._
+_Last updated: May 2, 2026._
 
-This is the production-oriented setup guide for every environment variable currently expected across `apps/api` and `apps/web`.
+This document is the production environment-variable guide for the API and web app. Exact variable names are maintained in the source templates and validation script:
 
-## Variable inventory (27 total)
+- `.env.example`
+- `.env.production.example`
+- `apps/web/.env.example`
+- `scripts/codex-env-check.sh`
 
-### Core (5)
-1. `NODE_ENV`
-2. `PORT`
-3. `DATABASE_URL`
-4. `CORS_ORIGINS`
-5. `WEB_APP_URL`
+## Validation rules
 
-### Stripe (5)
-6. `STRIPE_SECRET_KEY`
-7. `STRIPE_WEBHOOK_SECRET`
-8. `STRIPE_CHECKOUT_SUCCESS_URL`
-9. `STRIPE_CHECKOUT_CANCEL_URL`
-10. `STRIPE_PORTAL_RETURN_URL`
+The strict environment check must match runtime behavior.
 
-### Supabase (5)
-11. `SUPABASE_URL`
-12. `SUPABASE_SERVICE_KEY`
-13. `VITE_SUPABASE_URL`
-14. `VITE_SUPABASE_PUBLISHABLE_KEY`
-15. `VITE_SUPABASE_ANON_KEY` (legacy-compatible fallback)
+### Frontend Supabase rule
 
-### Redis (4)
-16. `REDIS_HOST`
-17. `REDIS_PORT`
-18. `REDIS_PASSWORD`
-19. `REDIS_DB`
+The web app requires one frontend Supabase credential. The preferred frontend publishable value and the legacy frontend anon value are alternatives. Do not require both. A backend-only anon value is not enough for the web runtime.
 
-### Load boards (3)
-20. `DAT_API_KEY`
-21. `TRUCKSTOP_API_KEY`
-22. `LOADBOARD_API_KEY`
+### Server Supabase rule
 
-### ELD (1)
-23. `SAMSARA_API_TOKEN`
+The API requires one server-side Supabase credential. The canonical server value should be preferred. The legacy service-role value remains supported as a migration fallback.
 
-### Observability + protection (2)
-24. `SENTRY_DSN`
-25. `RATE_LIMIT_ENABLED` (runtime flag used by API code)
+### CORS rule
 
-### Frontend connectivity (2)
-26. `VITE_API_URL`
-27. `VITE_SENTRY_DSN`
+Production and strict validation require one CORS origin configuration. The canonical plural form should be preferred. The legacy singular form remains supported as a fallback.
 
-> Note: Runtime checks use `RATE_LIMIT_ENABLED`. Template files now include both `RATE_LIMIT_ENABLED` and legacy aliases where needed for compatibility.
+### Stripe frontend rule
 
----
+The frontend Stripe public value is optional unless the frontend billing flow is enabled. Do not make it a strict production requirement for deployments that do not enable frontend billing.
 
-## Step-by-step: where to get each value
+### Rate-limit rule
 
-### 1) Core values
-- `NODE_ENV=production`
-- `PORT=3000` (Fly/host may inject this automatically)
-- `DATABASE_URL`: PostgreSQL connection URI (Supabase/AWS RDS/DigitalOcean)
-- `CORS_ORIGINS`: comma-separated frontend origins, no spaces
-- `WEB_APP_URL`: canonical frontend URL, no trailing slash
+Rate limiting defaults to enabled unless explicitly disabled. The runtime toggle should be set in production for clarity, but missing the toggle does not mean the API starts with rate limiting disabled.
 
-### 2) Stripe (billing)
-From Stripe Dashboard (`Developers`):
-- `STRIPE_SECRET_KEY`: use `sk_test_...` for staging, `sk_live_...` for production
-- `STRIPE_WEBHOOK_SECRET`: `whsec_...` from your webhook endpoint
-- Redirects:
-  - `STRIPE_CHECKOUT_SUCCESS_URL=https://www.infamousfreight.com/billing/success`
-  - `STRIPE_CHECKOUT_CANCEL_URL=https://www.infamousfreight.com/billing/cancel`
-  - `STRIPE_PORTAL_RETURN_URL=https://www.infamousfreight.com/billing`
+## Deployment checklist
 
-### 3) Supabase (auth/data)
-From Supabase Project Settings → API:
-- `SUPABASE_URL`
-- `SUPABASE_SERVICE_KEY` (server-only secret)
-- `VITE_SUPABASE_URL`
-- `VITE_SUPABASE_PUBLISHABLE_KEY` (preferred frontend key)
-- `VITE_SUPABASE_ANON_KEY` (compatibility fallback)
-
-### 4) Redis (cache/queues)
-From Redis Cloud / AWS ElastiCache / DigitalOcean Managed Redis:
-- `REDIS_HOST`
-- `REDIS_PORT`
-- `REDIS_PASSWORD`
-- `REDIS_DB=0` (default)
-
-### 5) Load board integrations
-Collect from each vendor portal:
-- `DAT_API_KEY`
-- `TRUCKSTOP_API_KEY`
-- `LOADBOARD_API_KEY`
-
-### 6) ELD integration
-From Samsara API tokens page:
-- `SAMSARA_API_TOKEN`
-
-### 7) Observability and abuse protection
-- `SENTRY_DSN` (backend DSN)
-- `RATE_LIMIT_ENABLED=true`
-
-### 8) Frontend runtime
-- `VITE_API_URL` (use `/api` behind reverse proxy, or absolute URL for direct API)
-- `VITE_SENTRY_DSN` (frontend DSN)
-
----
-
-## Production template
-
-```env
-NODE_ENV=production
-PORT=3000
-DATABASE_URL=postgresql://user:password@host:5432/infamous_freight
-CORS_ORIGINS=https://www.infamousfreight.com,https://app.infamousfreight.com
-WEB_APP_URL=https://www.infamousfreight.com
-
-STRIPE_SECRET_KEY=sk_live_YOUR_KEY
-STRIPE_WEBHOOK_SECRET=whsec_YOUR_SECRET
-STRIPE_CHECKOUT_SUCCESS_URL=https://www.infamousfreight.com/billing/success
-STRIPE_CHECKOUT_CANCEL_URL=https://www.infamousfreight.com/billing/cancel
-STRIPE_PORTAL_RETURN_URL=https://www.infamousfreight.com/billing
-
-SUPABASE_URL=https://YOUR_PROJECT.supabase.co
-SUPABASE_SERVICE_KEY=YOUR_SERVICE_KEY
-VITE_SUPABASE_URL=https://YOUR_PROJECT.supabase.co
-VITE_SUPABASE_PUBLISHABLE_KEY=YOUR_PUBLISHABLE_KEY
-VITE_SUPABASE_ANON_KEY=YOUR_ANON_KEY
-
-REDIS_HOST=redis.example.com
-REDIS_PORT=6379
-REDIS_PASSWORD=YOUR_REDIS_PASSWORD
-REDIS_DB=0
-
-DAT_API_KEY=YOUR_DAT_KEY
-TRUCKSTOP_API_KEY=YOUR_TRUCKSTOP_KEY
-LOADBOARD_API_KEY=YOUR_LOADBOARD_KEY
-SAMSARA_API_TOKEN=YOUR_SAMSARA_TOKEN
-
-SENTRY_DSN=https://YOUR_KEY@sentry.io/PROJECT_ID
-RATE_LIMIT_ENABLED=true
-
-VITE_API_URL=/api
-VITE_SENTRY_DSN=https://YOUR_KEY@sentry.io/PROJECT_ID
-```
-
-## Quick verification
-
-```bash
-test -n "$DATABASE_URL" && echo "✓ DATABASE_URL set"
-test -n "$STRIPE_SECRET_KEY" && echo "✓ STRIPE_SECRET_KEY set"
-test -n "$SUPABASE_URL" && echo "✓ SUPABASE_URL set"
-test -n "$RATE_LIMIT_ENABLED" && echo "✓ RATE_LIMIT_ENABLED set"
-```
-
-## Source-of-truth templates
-- Root backend template: `.env.example`
-- Web template: `apps/web/.env.example`
-- Deployment baseline: `.env.production.example`
-
-
----
-
-## What is currently present vs missing/needed
-
-Based on current runtime references in `apps/api/src`, `apps/web/src`, and local env templates:
-
-### Present in runtime code (actively referenced)
-- Backend/runtime: `NODE_ENV`, `PORT`, `DATABASE_URL`, `CORS_ORIGINS`, `WEB_APP_URL`, `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_CHECKOUT_SUCCESS_URL`, `STRIPE_CHECKOUT_CANCEL_URL`, `STRIPE_PORTAL_RETURN_URL`, `SUPABASE_URL`, `SUPABASE_SERVICE_KEY`, `REDIS_HOST`, `REDIS_PORT`, `REDIS_PASSWORD`, `REDIS_DB`, `DAT_API_KEY`, `TRUCKSTOP_API_KEY`, `LOADBOARD_API_KEY`, `SAMSARA_API_TOKEN`, `SENTRY_DSN`, `RATE_LIMIT_ENABLED`.
-- Frontend/runtime: `VITE_API_URL`, `VITE_SUPABASE_URL`, `VITE_SUPABASE_PUBLISHABLE_KEY` (preferred), `VITE_SUPABASE_ANON_KEY` (fallback), `VITE_SENTRY_DSN`.
-
-### Present in env templates but not currently required by runtime code
-These are optional/integration/deployment convenience variables and can be set only when needed:
-- Auth/integration legacy: `JWT_SECRET`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_JWT_SECRET`
-- Frontend/deploy extras: `VITE_SOCKET_URL`, `VITE_STRIPE_PUBLIC_KEY`, `VITE_SENTRY_ENABLED`, `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SENTRY_DSN`
-- Platform/deploy metadata: `SITE_URL`, `PUBLIC_SITE_URL`, `FRONTEND_URL`, `API_PUBLIC_URL`, `FLY_API_TOKEN`
-- Sentry CI/source map upload: `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT`
-- Additional vendor integrations: `MOTIVE_CLIENT_ID`, `MOTIVE_CLIENT_SECRET`, `QBO_CLIENT_ID`, `QBO_CLIENT_SECRET`, `XERO_CLIENT_ID`, `XERO_CLIENT_SECRET`, `SENDGRID_API_KEY`, `FROM_EMAIL`, `RTS_API_KEY`, `OTR_API_KEY`, `APEX_API_KEY`
-
-### Missing/needed for a production deployment
-Set all 27 runtime variables listed in this document. At minimum, production is blocked without:
-- `DATABASE_URL`
-- `STRIPE_SECRET_KEY` + `STRIPE_WEBHOOK_SECRET`
-- `SUPABASE_URL` + `SUPABASE_SERVICE_KEY`
-- `VITE_API_URL` + `VITE_SUPABASE_URL` + one frontend Supabase key (`VITE_SUPABASE_PUBLISHABLE_KEY` recommended)
-- `CORS_ORIGINS` + `WEB_APP_URL`
-- `RATE_LIMIT_ENABLED=true`
-
-### Naming mismatches to resolve in your secret manager
-- Prefer `RATE_LIMIT_ENABLED` (runtime). Keep `API_RATE_LIMIT_ENABLED` only as a temporary compatibility value if older tooling still reads it.
-- Prefer `SUPABASE_SERVICE_KEY` for API runtime. Templates include `SUPABASE_SERVICE_ROLE_KEY` as a legacy alias; map both to the same secret value during transition.
-
-## Recommended add-ons (set when feature is enabled)
-
-To “add all recommended above,” configure these in the same secret manager when the related integration is turned on:
-
-- Payments/frontend UX: `VITE_STRIPE_PUBLIC_KEY`
-- Socket routing: `VITE_SOCKET_URL`
-- Sentry release automation: `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT`, `VITE_SENTRY_ENABLED`
-- Alternate ELD provider: `MOTIVE_CLIENT_ID`, `MOTIVE_CLIENT_SECRET`
-- Accounting: `QBO_CLIENT_ID`, `QBO_CLIENT_SECRET`, `XERO_CLIENT_ID`, `XERO_CLIENT_SECRET`
-- Email delivery: `SENDGRID_API_KEY`, `FROM_EMAIL`
-- Factoring providers: `RTS_API_KEY`, `OTR_API_KEY`, `APEX_API_KEY`
-
-## Deployment-ready checklist (copy/paste)
-
-```bash
-# Required runtime set (27 vars)
-printenv | rg '^(NODE_ENV|PORT|DATABASE_URL|CORS_ORIGINS|WEB_APP_URL|STRIPE_SECRET_KEY|STRIPE_WEBHOOK_SECRET|STRIPE_CHECKOUT_SUCCESS_URL|STRIPE_CHECKOUT_CANCEL_URL|STRIPE_PORTAL_RETURN_URL|SUPABASE_URL|SUPABASE_SERVICE_KEY|REDIS_HOST|REDIS_PORT|REDIS_PASSWORD|REDIS_DB|DAT_API_KEY|TRUCKSTOP_API_KEY|LOADBOARD_API_KEY|SAMSARA_API_TOKEN|SENTRY_DSN|RATE_LIMIT_ENABLED|VITE_API_URL|VITE_SUPABASE_URL|VITE_SUPABASE_PUBLISHABLE_KEY|VITE_SUPABASE_ANON_KEY|VITE_SENTRY_DSN)='
-
-# Health expectation after deploy
-curl -fsS https://api.infamousfreight.com/health
-```
-
-Expected:
-- Health endpoint returns HTTP 200.
-- `RATE_LIMIT_ENABLED=true` in production.
-- App binds to `PORT=3000` (or host-injected `PORT`).
-
-## CI validation commands (run before merge/deploy)
+Before production deploy:
 
 ```bash
 pnpm lint
@@ -225,11 +43,24 @@ pnpm -w test --runInBand
 pnpm env:check:strict
 ```
 
-## Docker setup commands
+After production deploy:
 
-```bash
-pnpm docker:install-cli
-pnpm setup:deps-docker
-pnpm docker:build
-pnpm docker:up
-```
+- Verify the API health endpoint returns HTTP 200.
+- Verify the frontend starts without a missing Supabase frontend credential error.
+- Verify browser requests are allowed by the configured CORS origins.
+
+## Recommended integrations
+
+Configure optional integration variables only when those integrations are enabled:
+
+- frontend billing
+- socket routing
+- Sentry release automation
+- alternate ELD providers
+- accounting providers
+- email delivery
+- factoring providers
+
+## Operational rule
+
+Do not commit real production values. Store production values in the target platform secret manager.

--- a/scripts/codex-env-check.sh
+++ b/scripts/codex-env-check.sh
@@ -20,13 +20,8 @@ required_vars=(
   DATABASE_URL
   STRIPE_SECRET_KEY
   STRIPE_WEBHOOK_SECRET
-  STRIPE_PUBLISHABLE_KEY
-  VITE_STRIPE_PUBLIC_KEY
   SUPABASE_URL
-  SUPABASE_SERVICE_KEY
-  SUPABASE_ANON_KEY
   VITE_SUPABASE_URL
-  VITE_SUPABASE_PUBLISHABLE_KEY
 )
 
 optional_vars=(
@@ -41,6 +36,7 @@ optional_vars=(
   REDIS_PASSWORD
   REDIS_DB
   JWT_SECRET
+  RATE_LIMIT_ENABLED
   API_RATE_LIMIT_ENABLED
   SENTRY_DSN
   VITE_API_URL
@@ -88,15 +84,45 @@ check_var() {
   fi
 }
 
+check_one_of() {
+  local required="$1"
+  shift
+  local names=("$@")
+  local found=()
+
+  for name in "${names[@]}"; do
+    if [[ -n "${!name:-}" ]]; then
+      found+=("${name}")
+    fi
+  done
+
+  if [[ "${#found[@]}" -gt 0 ]]; then
+    echo "✅ one-of [${names[*]}] is set (${found[*]})"
+    return 0
+  fi
+
+  if [[ "${required}" == "true" ]]; then
+    echo "❌ one-of [${names[*]}] is NOT set"
+    missing_required=$((missing_required + 1))
+  else
+    echo "⚠️  one-of [${names[*]}] is not set"
+    missing_optional=$((missing_optional + 1))
+  fi
+}
+
 echo "Required / core variables:"
 for var in "${required_vars[@]}"; do
   check_var "$var" "true"
 done
+check_one_of "true" STRIPE_PUBLISHABLE_KEY VITE_STRIPE_PUBLIC_KEY
+check_one_of "true" SUPABASE_SERVICE_KEY SUPABASE_SERVICE_ROLE_KEY
+check_one_of "true" SUPABASE_ANON_KEY VITE_SUPABASE_ANON_KEY VITE_SUPABASE_PUBLISHABLE_KEY
 
 printf '\nOptional integration variables:\n'
 for var in "${optional_vars[@]}"; do
   check_var "$var" "false"
 done
+check_one_of "false" CORS_ORIGINS CORS_ORIGIN
 
 printf '\nSafe environment inventory — names only, no values:\n'
 printenv | cut -d= -f1 | sort

--- a/scripts/codex-env-check.sh
+++ b/scripts/codex-env-check.sh
@@ -26,11 +26,12 @@ required_vars=(
 
 optional_vars=(
   PORT
-  CORS_ORIGINS
-  WEB_APP_URL
   STRIPE_CHECKOUT_SUCCESS_URL
   STRIPE_CHECKOUT_CANCEL_URL
   STRIPE_PORTAL_RETURN_URL
+  STRIPE_PUBLISHABLE_KEY
+  VITE_STRIPE_PUBLIC_KEY
+  SUPABASE_ANON_KEY
   REDIS_HOST
   REDIS_PORT
   REDIS_PASSWORD
@@ -110,19 +111,25 @@ check_one_of() {
   fi
 }
 
+production_required="false"
+if [[ "${strict}" == "1" || "${NODE_ENV:-}" == "production" ]]; then
+  production_required="true"
+fi
+
 echo "Required / core variables:"
 for var in "${required_vars[@]}"; do
   check_var "$var" "true"
 done
-check_one_of "true" STRIPE_PUBLISHABLE_KEY VITE_STRIPE_PUBLIC_KEY
+check_var "WEB_APP_URL" "${production_required}"
+check_one_of "${production_required}" CORS_ORIGINS CORS_ORIGIN
 check_one_of "true" SUPABASE_SERVICE_KEY SUPABASE_SERVICE_ROLE_KEY
-check_one_of "true" SUPABASE_ANON_KEY VITE_SUPABASE_ANON_KEY VITE_SUPABASE_PUBLISHABLE_KEY
+check_one_of "true" VITE_SUPABASE_PUBLISHABLE_KEY VITE_SUPABASE_ANON_KEY
 
 printf '\nOptional integration variables:\n'
 for var in "${optional_vars[@]}"; do
   check_var "$var" "false"
 done
-check_one_of "false" CORS_ORIGINS CORS_ORIGIN
+check_one_of "false" STRIPE_PUBLISHABLE_KEY VITE_STRIPE_PUBLIC_KEY
 
 printf '\nSafe environment inventory — names only, no values:\n'
 printenv | cut -d= -f1 | sort


### PR DESCRIPTION
### Motivation

- Provide backward-compatible environment variable names so older scripts and tooling continue to work without secret renames. 
- Make runtime feature toggles (rate limiting) and CORS configuration more robust to multiple env naming conventions. 
- Allow the backend upload service to accept either Supabase service key alias for smoother migrations. 
- Centralize and document the canonical environment variables and provide a better diagnostic script for CI/ops.

### Status

This PR was closed after its merge became blocked by conflicts. Key changes were applied directly to `main` in follow-up commits, including env template alias compatibility, CORS alias support, rate-limit alias support, and docs cleanup.

### Follow-up

`apps/api/src/uploads/upload.service.ts` still needs the Supabase service-key fallback applied separately if desired.