### PR TITLE
Clarify direct npm invocations in scripts/workspace-pm.sh

### DIFF
--- a/scripts/workspace-pm.sh
+++ b/scripts/workspace-pm.sh
@@ -48,6 +48,8 @@ install_workspace_dependencies() {
     return
   fi
 
+  # Keep npm invocation direct here. Proxy-related npm warnings should be fixed
+  # by correcting user/CI npm env configuration rather than mutating runtime env.
   npm ci || npm install
 }
 
@@ -61,5 +63,6 @@ run_workspace_script() {
     return
   fi
 
+  # Keep npm invocation direct for parity with local shells and CI behavior.
   npm run "$script_name" "$@"
 }

--- a/scripts/workspace-pm.sh
+++ b/scripts/workspace-pm.sh
@@ -48,8 +48,9 @@ install_workspace_dependencies() {
     return
   fi
 
-  # Keep npm invocation direct here. Proxy-related npm warnings should be fixed
-  # by correcting user/CI npm env configuration rather than mutating runtime env.
+  # Keep npm invocation direct in this helper. Proxy-related npm warnings are
+  # normally handled by user/CI npm configuration; other repository scripts may
+  # still sanitize env explicitly before calling this helper.
   npm ci || npm install
 }
 


### PR DESCRIPTION
### Motivation
- Document why `npm` is invoked directly in the workspace helper to avoid masking proxy-related warnings by mutating runtime environment and to keep parity with local shells and CI.

### Description
- Added explanatory comments above the `npm ci || npm install` and `npm run` calls in `scripts/workspace-pm.sh` to state the intent of keeping `npm` invocation direct and not adjusting env at runtime.

### Testing
- No automated tests were executed for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5e96360f48330811eb44f538e9f89)