### PR TITLE
Add Netlify production deploy checklist and readiness script

### DIFF
--- a/docs/netlify-deploy-checklist.md
+++ b/docs/netlify-deploy-checklist.md
@@ -1,0 +1,97 @@
+# Netlify Production Deploy Checklist
+
+Use this checklist for every production deploy of `infamousfreight`.
+
+## 1) Confirm Netlify environment variables
+
+In Netlify Dashboard → **Site configuration** → **Environment variables**, confirm these are present:
+
+### Required for web build/runtime
+- `VITE_SUPABASE_URL`
+- `VITE_SUPABASE_PUBLISHABLE_KEY`
+- `VITE_API_URL`
+
+### Required only for CLI-triggered deploys
+- `NETLIFY_AUTH_TOKEN`
+- `NETLIFY_SITE_ID`
+
+### Recommended compatibility fallback
+- `VITE_SUPABASE_ANON_KEY`
+
+### Required for backend/API integrations
+- `DATABASE_URL`
+- `SUPABASE_URL`
+- `SUPABASE_SERVICE_KEY`
+- `STRIPE_SECRET_KEY`
+- `STRIPE_WEBHOOK_SECRET`
+- `CORS_ORIGINS`
+- `WEB_APP_URL`
+- `RATE_LIMIT_ENABLED=true`
+
+## 2) Validate locally (or in CI)
+
+Run the one-command automation (recommended):
+
+```bash
+pnpm netlify:production:readiness
+```
+
+Or run the commands manually:
+
+```bash
+pnpm install --no-frozen-lockfile
+pnpm prisma:generate
+pnpm lint
+pnpm -w test --runInBand
+pnpm env:check:strict
+pnpm -C apps/web run build
+pnpm docker:build
+```
+
+## 3) Keep lockfile stable
+
+```bash
+pnpm install
+git add pnpm-lock.yaml
+git commit -m "Update pnpm lockfile"
+git push
+```
+
+If set previously, remove temporary Netlify workaround:
+
+- `PNPM_FLAGS=--no-frozen-lockfile`
+
+## 4) Trigger production deploy
+
+Netlify UI path:
+
+1. `Netlify`
+2. `infamousfreight`
+3. `Deploys`
+4. `Trigger deploy`
+5. `Deploy site`
+
+## 5) Post-deploy production verification
+
+Run both canonical checks first:
+
+```bash
+curl -I https://infamousfreight.com
+curl -fsS https://www.infamousfreight.com/api/health
+```
+
+Optional direct API domain checks (if `api.infamousfreight.com` is configured to the API origin):
+
+```bash
+curl -fsS https://api.infamousfreight.com/health
+curl -fsS https://api.infamousfreight.com/api/health
+```
+
+If direct API-domain checks return `404`, validate DNS/routing for `api.infamousfreight.com` and keep production smoke checks pointed at `https://www.infamousfreight.com/api/health` until fixed.
+
+Also verify in browser:
+- Homepage loads.
+- No Supabase key error in console.
+- API requests are not blocked by CORS.
+- Forms still work.
+- Billing/auth flows load (if enabled).

--- a/docs/netlify-deploy-checklist.md
+++ b/docs/netlify-deploy-checklist.md
@@ -2,9 +2,9 @@
 
 Use this checklist for every production deploy of `infamousfreight`.
 
-## 1) Confirm Netlify environment variables
+## 1) Confirm web environment variables in Netlify
 
-In Netlify Dashboard → **Site configuration** → **Environment variables**, confirm these are present:
+In Netlify Dashboard → **Site configuration** → **Environment variables**, confirm these are present for the web build/runtime:
 
 ### Required for web build/runtime
 - `VITE_SUPABASE_URL`
@@ -18,7 +18,12 @@ In Netlify Dashboard → **Site configuration** → **Environment variables**, c
 ### Recommended compatibility fallback
 - `VITE_SUPABASE_ANON_KEY`
 
-### Required for backend/API integrations
+Do not add backend-only secrets such as `DATABASE_URL`, `SUPABASE_SERVICE_KEY`, `STRIPE_SECRET_KEY`, or `STRIPE_WEBHOOK_SECRET` to Netlify. Netlify serves the web app and proxies `/api/*` to the Fly API origin, so backend secrets belong in the API runtime.
+
+## 2) Confirm backend/API environment variables in Fly and provider dashboards
+
+In the Fly API app and relevant provider dashboards, confirm these backend variables are configured:
+
 - `DATABASE_URL`
 - `SUPABASE_URL`
 - `SUPABASE_SERVICE_KEY`
@@ -26,9 +31,9 @@ In Netlify Dashboard → **Site configuration** → **Environment variables**, c
 - `STRIPE_WEBHOOK_SECRET`
 - `CORS_ORIGINS`
 - `WEB_APP_URL`
-- `RATE_LIMIT_ENABLED=true`
+- `RATE_LIMIT_ENABLED` with value `true`
 
-## 2) Validate locally (or in CI)
+## 3) Validate locally (or in CI)
 
 Run the one-command automation (recommended):
 
@@ -39,7 +44,7 @@ pnpm netlify:production:readiness
 Or run the commands manually:
 
 ```bash
-pnpm install --no-frozen-lockfile
+pnpm install --frozen-lockfile
 pnpm prisma:generate
 pnpm lint
 pnpm -w test --runInBand
@@ -48,7 +53,13 @@ pnpm -C apps/web run build
 pnpm docker:build
 ```
 
-## 3) Keep lockfile stable
+If you intentionally need to refresh the lockfile during readiness validation, opt in explicitly:
+
+```bash
+ALLOW_LOCKFILE_UPDATE=true pnpm netlify:production:readiness
+```
+
+## 4) Keep lockfile stable
 
 ```bash
 pnpm install
@@ -59,9 +70,11 @@ git push
 
 If set previously, remove temporary Netlify workaround:
 
-- `PNPM_FLAGS=--no-frozen-lockfile`
+- `NPM_FLAGS=--no-frozen-lockfile`
 
-## 4) Trigger production deploy
+The committed Netlify config currently uses `NPM_FLAGS=--legacy-peer-deps` for npm-based builds.
+
+## 5) Trigger production deploy
 
 Netlify UI path:
 
@@ -71,20 +84,33 @@ Netlify UI path:
 4. `Trigger deploy`
 5. `Deploy site`
 
-## 5) Post-deploy production verification
-
-Run both canonical checks first:
+CLI deploys should rely on the `NETLIFY_AUTH_TOKEN` environment variable instead of passing secrets through command-line flags:
 
 ```bash
-curl -I https://infamousfreight.com
-curl -fsS https://www.infamousfreight.com/api/health
+NETLIFY_AUTH_TOKEN=... NETLIFY_SITE_ID=... pnpm netlify:production:readiness
+```
+
+## 6) Post-deploy production verification
+
+Run the canonical checks first:
+
+```bash
+curl --fail --show-error --location --head --retry 5 --retry-delay 10 --retry-connrefused https://www.infamousfreight.com
+curl --fail --show-error --silent --location --retry 5 --retry-delay 10 --retry-connrefused https://www.infamousfreight.com/api/health
+```
+
+Then confirm the bare domain redirects to the canonical www host:
+
+```bash
+final_url=$(curl --silent --location --head --retry 5 --retry-delay 10 --retry-connrefused --output /dev/null --write-out '%{url_effective}' https://infamousfreight.com)
+test "$final_url" = "https://www.infamousfreight.com/"
 ```
 
 Optional direct API domain checks (if `api.infamousfreight.com` is configured to the API origin):
 
 ```bash
-curl -fsS https://api.infamousfreight.com/health
-curl -fsS https://api.infamousfreight.com/api/health
+curl --fail --show-error --silent --location --retry 5 --retry-delay 10 --retry-connrefused https://api.infamousfreight.com/health
+curl --fail --show-error --silent --location --retry 5 --retry-delay 10 --retry-connrefused https://api.infamousfreight.com/api/health
 ```
 
 If direct API-domain checks return `404`, validate DNS/routing for `api.infamousfreight.com` and keep production smoke checks pointed at `https://www.infamousfreight.com/api/health` until fixed.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "infamous-freight",
   "version": "1.0.0",
   "private": true,
-  "description": "Infamous Freight — The freight dispatch platform built by truckers, for truckers",
+  "description": "Infamous Freight \u2014 The freight dispatch platform built by truckers, for truckers",
   "packageManager": "pnpm@10.0.0",
   "repository": {
     "type": "git",
@@ -48,7 +48,8 @@
     "snapshot:prod": "bash scripts/production-snapshot.sh",
     "setup:deps-docker": "bash scripts/bootstrap-deps-docker.sh",
     "social-preview:generate": "node scripts/generate-social-preview.mjs",
-    "bootstrap": "bash scripts/bootstrap.sh"
+    "bootstrap": "bash scripts/bootstrap.sh",
+    "netlify:production:readiness": "bash scripts/netlify-production-readiness.sh"
   },
   "devDependencies": {
     "@resvg/resvg-js": "2.6.2",

--- a/scripts/netlify-production-readiness.sh
+++ b/scripts/netlify-production-readiness.sh
@@ -5,7 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
 WEB_HEALTH_URL="${WEB_HEALTH_URL:-https://www.infamousfreight.com/api/health}"
-SITE_URL="${SITE_URL:-https://infamousfreight.com}"
+SITE_URL="${SITE_URL:-https://www.infamousfreight.com}"
 API_HEALTH_URL="${API_HEALTH_URL:-https://api.infamousfreight.com/health}"
 API_HEALTH_FALLBACK_URL="${API_HEALTH_FALLBACK_URL:-https://api.infamousfreight.com/api/health}"
 
@@ -17,7 +17,20 @@ run_step() {
   "$@"
 }
 
-run_step "Install workspace deps (no frozen lockfile)" pnpm install --no-frozen-lockfile
+curl_head() {
+  curl --fail --show-error --location --head --retry 5 --retry-delay 10 --retry-connrefused --max-time 30 "$@"
+}
+
+curl_get() {
+  curl --fail --show-error --silent --location --retry 5 --retry-delay 10 --retry-connrefused --max-time 30 "$@"
+}
+
+if [[ "${ALLOW_LOCKFILE_UPDATE:-false}" == "true" ]]; then
+  run_step "Install workspace deps (lockfile updates allowed)" pnpm install --no-frozen-lockfile
+else
+  run_step "Install workspace deps (frozen lockfile)" pnpm install --frozen-lockfile
+fi
+
 run_step "Prisma client generation" pnpm prisma:generate
 run_step "Type/lint checks" pnpm lint
 run_step "API tests (runInBand)" pnpm -w test --runInBand
@@ -25,14 +38,14 @@ run_step "Strict environment checks" pnpm env:check:strict
 run_step "Web production build" pnpm -C apps/web run build
 run_step "Docker build validation" pnpm docker:build
 
-run_step "Site HEAD check" curl -I "$SITE_URL"
-run_step "Canonical API health check" curl -fsS "$WEB_HEALTH_URL"
+run_step "Site HEAD check" curl_head "$SITE_URL"
+run_step "Canonical API health check" curl_get "$WEB_HEALTH_URL"
 
 echo ""
 echo "==> Optional direct API domain checks"
-if curl -fsS "$API_HEALTH_URL"; then
+if curl_get "$API_HEALTH_URL"; then
   echo "Direct API health URL succeeded: $API_HEALTH_URL"
-elif curl -fsS "$API_HEALTH_FALLBACK_URL"; then
+elif curl_get "$API_HEALTH_FALLBACK_URL"; then
   echo "Direct API fallback health URL succeeded: $API_HEALTH_FALLBACK_URL"
 else
   echo "WARNING: Direct API domain health checks failed (both endpoints)." >&2
@@ -43,7 +56,7 @@ echo ""
 echo "==> Optional Netlify production deploy trigger"
 if [[ -n "${NETLIFY_AUTH_TOKEN:-}" && -n "${NETLIFY_SITE_ID:-}" ]]; then
   echo "Triggering deploy for site ${NETLIFY_SITE_ID} via Netlify CLI..."
-  pnpm dlx netlify-cli deploy --prod --dir apps/web/dist --site "$NETLIFY_SITE_ID" --auth "$NETLIFY_AUTH_TOKEN"
+  pnpm dlx netlify-cli deploy --prod --dir apps/web/dist --site "$NETLIFY_SITE_ID"
 else
   echo "Skipped: set NETLIFY_AUTH_TOKEN and NETLIFY_SITE_ID to trigger deploy from CLI."
 fi

--- a/scripts/netlify-production-readiness.sh
+++ b/scripts/netlify-production-readiness.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+WEB_HEALTH_URL="${WEB_HEALTH_URL:-https://www.infamousfreight.com/api/health}"
+SITE_URL="${SITE_URL:-https://infamousfreight.com}"
+API_HEALTH_URL="${API_HEALTH_URL:-https://api.infamousfreight.com/health}"
+API_HEALTH_FALLBACK_URL="${API_HEALTH_FALLBACK_URL:-https://api.infamousfreight.com/api/health}"
+
+run_step() {
+  local title="$1"
+  shift
+  echo ""
+  echo "==> ${title}"
+  "$@"
+}
+
+run_step "Install workspace deps (no frozen lockfile)" pnpm install --no-frozen-lockfile
+run_step "Prisma client generation" pnpm prisma:generate
+run_step "Type/lint checks" pnpm lint
+run_step "API tests (runInBand)" pnpm -w test --runInBand
+run_step "Strict environment checks" pnpm env:check:strict
+run_step "Web production build" pnpm -C apps/web run build
+run_step "Docker build validation" pnpm docker:build
+
+run_step "Site HEAD check" curl -I "$SITE_URL"
+run_step "Canonical API health check" curl -fsS "$WEB_HEALTH_URL"
+
+echo ""
+echo "==> Optional direct API domain checks"
+if curl -fsS "$API_HEALTH_URL"; then
+  echo "Direct API health URL succeeded: $API_HEALTH_URL"
+elif curl -fsS "$API_HEALTH_FALLBACK_URL"; then
+  echo "Direct API fallback health URL succeeded: $API_HEALTH_FALLBACK_URL"
+else
+  echo "WARNING: Direct API domain health checks failed (both endpoints)." >&2
+  echo "Keep smoke checks pointed at ${WEB_HEALTH_URL} and verify DNS/origin routing for api.infamousfreight.com." >&2
+fi
+
+echo ""
+echo "==> Optional Netlify production deploy trigger"
+if [[ -n "${NETLIFY_AUTH_TOKEN:-}" && -n "${NETLIFY_SITE_ID:-}" ]]; then
+  echo "Triggering deploy for site ${NETLIFY_SITE_ID} via Netlify CLI..."
+  pnpm dlx netlify-cli deploy --prod --dir apps/web/dist --site "$NETLIFY_SITE_ID" --auth "$NETLIFY_AUTH_TOKEN"
+else
+  echo "Skipped: set NETLIFY_AUTH_TOKEN and NETLIFY_SITE_ID to trigger deploy from CLI."
+fi


### PR DESCRIPTION
### Motivation
- Provide a repeatable checklist and automation for Netlify production deploys to reduce manual errors and missed environment variables.
- Consolidate pre-deploy validations (build, tests, lint, health checks, Docker) into a single script that can be run locally or in CI.
- Offer an optional CLI-triggered Netlify deploy to allow safe programmatic releases when credentials are provided.

### Description
- Add `docs/netlify-deploy-checklist.md` with step-by-step guidance for environment variables, local/CI validation, deploy triggers, and post-deploy verification.
- Add `scripts/netlify-production-readiness.sh` which runs workspace install, `pnpm prisma:generate`, `pnpm lint`, `pnpm -w test --runInBand`, `pnpm env:check:strict`, web build, Docker build, and health checks, and optionally triggers a Netlify deploy when `NETLIFY_AUTH_TOKEN` and `NETLIFY_SITE_ID` are set.
- Add a new npm script `netlify:production:readiness` to `package.json` that invokes `bash scripts/netlify-production-readiness.sh` and adjust the package `description` encoding.
- Ensure the readiness script exits on failure with `set -euo pipefail` and prints clear step headers for easier debugging.

### Testing
- No automated CI tests were executed as part of this PR; the change introduces a convenience script rather than modifying core logic.
- The readiness automation will run the following automated checks when invoked: `pnpm install --no-frozen-lockfile`, `pnpm prisma:generate`, `pnpm lint`, `pnpm -w test --runInBand`, `pnpm env:check:strict`, `pnpm -C apps/web run build`, and `pnpm docker:build`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5e8f6c1d48330943f58fbdf039f2c)