### PR TITLE
Cache PrismaClient on globalThis in non-production and handle Prisma Accelerate extension

### DIFF
--- a/apps/api/src/prisma-client.ts
+++ b/apps/api/src/prisma-client.ts
@@ -4,6 +4,10 @@ type AccelerateExtension = Parameters<PrismaClient['$extends']>[0];
 
 let client: PrismaClient | null = null;
 
+const globalForPrisma = globalThis as unknown as {
+  __infamousPrismaClient?: PrismaClient;
+};
+
 function loadAccelerateExtension(): (() => AccelerateExtension) | null {
   try {
     const accelerateModule = require('@prisma/extension-accelerate') as {
@@ -19,6 +23,14 @@ function loadAccelerateExtension(): (() => AccelerateExtension) | null {
 
 export function createPrismaClient(): PrismaClient {
   if (client) return client;
+
+  const shouldUseGlobalCache =
+    process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test';
+
+  if (shouldUseGlobalCache && globalForPrisma.__infamousPrismaClient) {
+    client = globalForPrisma.__infamousPrismaClient;
+    return client;
+  }
 
   const databaseUrl = process.env.DATABASE_URL;
 
@@ -42,9 +54,19 @@ export function createPrismaClient(): PrismaClient {
     } as ConstructorParameters<typeof PrismaClient>[0]);
 
     client = accelerateBase.$extends(withAccelerate()) as unknown as PrismaClient;
+
+    if (shouldUseGlobalCache) {
+      globalForPrisma.__infamousPrismaClient = client;
+    }
+
     return client;
   }
 
   client = new PrismaClient();
+
+  if (shouldUseGlobalCache) {
+    globalForPrisma.__infamousPrismaClient = client;
+  }
+
   return client;
 }


### PR DESCRIPTION
### Motivation

- Prevent creating multiple `PrismaClient` instances during development by reusing a single client across module reloads. 
- Ensure correct error handling and initialization when `DATABASE_URL` is configured for Prisma Accelerate. 

### Description

- Introduce a `globalForPrisma` wrapper on `globalThis` and a `__infamousPrismaClient` slot to cache a `PrismaClient` instance. 
- Add `shouldUseGlobalCache` (true when `NODE_ENV` is not `production` or `test`) and reuse the cached client when available. 
- Persist the instantiated client into `globalForPrisma.__infamousPrismaClient` for both normal and Prisma Accelerate (`accelerateUrl`) client flows. 
- Keep existing logic to load `@prisma/extension-accelerate`, validate `DATABASE_URL`, and extend the client when required. 

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f62445d5d88330a739f93838291f9e)