### PR TITLE
Migrate Docker build to pnpm with node:22-bookworm-slim and expose .tools/bin in CLI installer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,36 @@
-FROM node:22-noble AS deps
+FROM node:22-bookworm-slim AS deps
 WORKDIR /app
 
-COPY --chown=1001:1001 package.json package-lock.json ./
+ARG PNPM_VERSION=10.0.0
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
+
+COPY --chown=1001:1001 package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY --chown=1001:1001 apps/api/package.json ./apps/api/package.json
 
-RUN npm ci --omit=dev --workspace apps/api --include-workspace-root=false
+RUN pnpm install --frozen-lockfile --prod --filter @infamous-freight/api...
 
 
-FROM node:22-noble AS build
+FROM node:22-bookworm-slim AS build
 WORKDIR /app
 
-COPY --chown=1001:1001 package.json package-lock.json ./
-COPY apps/api/package.json ./apps/api/package.json
+ARG PNPM_VERSION=10.0.0
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
 
-RUN npm ci --workspace apps/api
+COPY --chown=1001:1001 package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY --chown=1001:1001 apps/api/package.json ./apps/api/package.json
+
+RUN pnpm install --frozen-lockfile --filter @infamous-freight/api...
 
 COPY apps/api ./apps/api
 
 ENV DATABASE_URL="postgresql://user:pass@localhost:5432/db"
 
-RUN npx prisma generate --schema=apps/api/prisma/schema.prisma
+RUN pnpm -C apps/api prisma:generate
 
-RUN npm run build --workspace apps/api
+RUN pnpm -C apps/api build
 
 
-FROM node:22-noble AS runtime
+FROM node:22-bookworm-slim AS runtime
 WORKDIR /app
 
 ENV NODE_ENV=production
@@ -34,7 +40,7 @@ ENV HOST=0.0.0.0
 RUN apt-get update && apt-get install -y --no-install-recommends openssl && rm -rf /var/lib/apt/lists/*
 
 COPY --from=deps --chown=1001:1001 /app/node_modules ./node_modules
-COPY --chown=1001:1001 package.json package-lock.json ./
+COPY --chown=1001:1001 package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY apps/api/package.json ./apps/api/package.json
 
 COPY --from=build --chown=1001:1001 /app/apps/api/dist ./apps/api/dist

--- a/scripts/install-required-clis.sh
+++ b/scripts/install-required-clis.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 TOOLS_DIR="${REPO_ROOT}/.tools/bin"
 mkdir -p "${TOOLS_DIR}"
+export PATH="${TOOLS_DIR}:$PATH"
 
 install_flyctl() {
   if command -v flyctl >/dev/null 2>&1 || [[ -x "${TOOLS_DIR}/flyctl" ]]; then


### PR DESCRIPTION
### Motivation

- Replace the npm-based multi-stage Docker build with pnpm for faster, reproducible workspace installs and to support the monorepo workspace layout. 
- Use the Debian Bookworm slim Node image to standardize the base image and reduce image surface.
- Ensure the local `.tools/bin` directory is available on the `PATH` so installed CLIs in CI/local scripts are discoverable.

### Description

- Swapped all Docker stages from `node:22-noble` to `node:22-bookworm-slim` and preserved runtime configuration and healthcheck. 
- Added `ARG PNPM_VERSION` and enabled `corepack` with `corepack prepare pnpm@${PNPM_VERSION} --activate` to install and use pnpm in `deps` and `build` stages. 
- Replaced `package-lock.json`/`npm ci` usage with `pnpm` files and commands by copying `pnpm-lock.yaml` and `pnpm-workspace.yaml`, and running `pnpm install --frozen-lockfile --prod --filter @infamous-freight/api...` in `deps` and `pnpm install --frozen-lockfile --filter @infamous-freight/api...` in `build`. 
- Switched Prisma generate and build steps to use pnpm invocations: `pnpm -C apps/api prisma:generate` and `pnpm -C apps/api build`. 
- Updated runtime stage to copy `pnpm` lock/workspace files and reuse node_modules produced in `deps` and build artifacts from `build`. 
- Updated `scripts/install-required-clis.sh` to export `PATH="${REPO_ROOT}/.tools/bin:$PATH"` so CLIs installed into `.tools/bin` are immediately executable by the script.

### Testing

- Built the multi-stage image locally using `docker build -t app:local .` to validate the Dockerfile changes and the build completed successfully. 
- Executed `scripts/install-required-clis.sh` in a test environment to confirm the `.tools/bin` path is exported and CLI installers place binaries under `.tools/bin` as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f62003a6f483308d8cfc4a5bc207c1)