### PR TITLE
docs: add MVP launch readiness GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/launch_blocker.md
+++ b/.github/ISSUE_TEMPLATE/launch_blocker.md
@@ -1,0 +1,57 @@
+---
+name: Launch blocker
+description: Track a launch-blocking issue before private beta, paid beta, or public launch
+title: "[Launch Blocker]: "
+labels: [production, operations]
+assignees: ""
+---
+
+## Summary
+Describe the launch-blocking issue in one or two sentences.
+
+## Launch gate impacted
+- [ ] Private beta
+- [ ] Paid beta
+- [ ] Public launch
+
+## Severity
+- [ ] Critical — blocks launch
+- [ ] High — blocks paid/public launch unless workaround is documented
+- [ ] Medium — launch may proceed if assigned and documented
+- [ ] Low — launch may proceed
+- [ ] Unknown — treat as failed until verified
+
+## Evidence
+Paste command output, screenshots, dashboard links, logs, or reproduction notes.
+
+```text
+Evidence goes here.
+```
+
+## Expected result
+What should have happened?
+
+## Actual result
+What happened instead?
+
+## Root cause
+Known, suspected, or unknown.
+
+## Workaround
+Document any safe temporary workaround. Write `None` if no workaround exists.
+
+## Fix plan
+- [ ] Owner assigned
+- [ ] Fix identified
+- [ ] Fix implemented
+- [ ] Fix reviewed
+- [ ] Fix deployed
+
+## Retest proof
+Paste evidence that the blocker was retested after the fix.
+
+## Launch decision
+- [ ] Still blocked
+- [ ] Cleared for private beta
+- [ ] Cleared for paid beta
+- [ ] Cleared for public launch

--- a/.github/ISSUE_TEMPLATE/operations_task.md
+++ b/.github/ISSUE_TEMPLATE/operations_task.md
@@ -1,0 +1,36 @@
+---
+name: Operations task
+description: Track freight operations, compliance, launch, or support work
+title: "[Ops]: "
+labels: [operations]
+assignees: ""
+---
+
+## Task
+State the operational task clearly.
+
+## Area
+- [ ] Quote intake
+- [ ] Lead follow-up
+- [ ] Shipment tracking
+- [ ] Carrier onboarding
+- [ ] Dispatch workflow
+- [ ] Billing or Stripe
+- [ ] Notifications
+- [ ] Compliance
+- [ ] Admin recovery
+- [ ] Monitoring or support
+- [ ] Other
+
+## Definition of done
+- [ ] Owner assigned
+- [ ] Required evidence identified
+- [ ] Work completed
+- [ ] Evidence attached
+- [ ] Documentation updated if needed
+
+## Evidence required
+List the proof needed to close this task.
+
+## Notes
+Add links, screenshots, command output, or related issues.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,52 @@
+## Summary
+Explain what changed and why.
+
+## Launch impact
+- [ ] No launch impact
+- [ ] Private beta readiness
+- [ ] Paid beta readiness
+- [ ] Public launch readiness
+- [ ] Production hotfix
+
+## Area changed
+- [ ] Web app
+- [ ] API
+- [ ] Database or Prisma
+- [ ] Auth or roles
+- [ ] Billing or Stripe
+- [ ] Notifications
+- [ ] Freight workflow
+- [ ] Deployment or CI/CD
+- [ ] Documentation only
+
+## Verification
+Paste the commands or checks run.
+
+```bash
+# Example
+pnpm run build
+pnpm run test
+pnpm run validate
+```
+
+## Evidence
+Add screenshots, logs, links, or notes that prove the change works.
+
+## Risk checklist
+- [ ] No secrets committed
+- [ ] No production data included
+- [ ] Role/access behavior considered
+- [ ] Billing/payment behavior considered
+- [ ] Rollback path identified
+- [ ] Docs updated where needed
+
+## Launch gate checklist
+- [ ] API health remains valid
+- [ ] Web app still loads
+- [ ] Quote intake still works or was not touched
+- [ ] Tracking flow still works or was not touched
+- [ ] Admin/operator flow still works or was not touched
+- [ ] Notifications still work or were not touched
+
+## Follow-up issues
+Link any blockers, deferred tasks, or evidence gaps.


### PR DESCRIPTION
## Summary
Adds GitHub templates that make the Infamous Freight MVP launch process evidence-based and repeatable.

## Changes
- Adds a launch blocker issue template.
- Adds an operations task issue template.
- Adds a launch-ready pull request checklist.

## Why
The repository already has launch-readiness docs, but GitHub workflow templates were missing. These templates make blockers, operations tasks, verification evidence, and launch-risk checks easier to capture before private beta, paid beta, or public launch.

## Verification
Documentation-only change. No runtime code changed.

## Related work
- Launch control issue: #1781

## Risk
Low. This only adds GitHub metadata/checklist files.