### PR TITLE
ops: add production secrets bootstrap workflow

### DIFF
--- a/.env.production.secrets.example
+++ b/.env.production.secrets.example
@@ -1,0 +1,84 @@
+# Infamous Freight production secrets template
+# Copy to .env.production.secrets and fill values locally.
+# Do not commit the real .env.production.secrets file.
+
+# Script options
+# DRY_RUN=true
+# GITHUB_REPOSITORY_OVERRIDE=Infaemous-Freight/Infamous-freight
+# FLY_APP=infamous-freight
+# NETLIFY_SITE_ID=
+
+# GitHub Actions
+FLY_API_TOKEN=
+
+# Core runtime
+NODE_ENV=production
+PORT=3000
+WEB_APP_URL=https://www.infamousfreight.com
+CORS_ORIGINS=https://www.infamousfreight.com,https://app.infamousfreight.com
+CORS_ORIGIN=https://www.infamousfreight.com
+DATABASE_URL=
+RATE_LIMIT_ENABLED=true
+
+# Supabase / database / auth
+SUPABASE_URL=
+SUPABASE_SERVICE_KEY=
+SUPABASE_SERVICE_ROLE_KEY=
+SUPABASE_JWT_SECRET=
+VITE_SUPABASE_URL=
+VITE_SUPABASE_PUBLISHABLE_KEY=
+VITE_SUPABASE_ANON_KEY=
+
+# Stripe
+STRIPE_SECRET_KEY=
+STRIPE_WEBHOOK_SECRET=
+STRIPE_CHECKOUT_SUCCESS_URL=https://www.infamousfreight.com/billing/success
+STRIPE_CHECKOUT_CANCEL_URL=https://www.infamousfreight.com/billing/cancel
+STRIPE_PORTAL_RETURN_URL=https://www.infamousfreight.com/billing
+VITE_STRIPE_PUBLIC_KEY=
+
+# Web / Netlify
+VITE_API_URL=/api
+PUBLIC_SITE_URL=https://www.infamousfreight.com
+VITE_SITE_URL=https://www.infamousfreight.com
+NEXT_PUBLIC_SITE_URL=https://www.infamousfreight.com
+
+# Sentry
+SENTRY_DSN=
+VITE_SENTRY_DSN=
+VITE_SENTRY_ENABLED=true
+SENTRY_AUTH_TOKEN=
+SENTRY_ORG=infmous
+SENTRY_PROJECT=infamous-freight
+SENTRY_SOURCEMAPS=
+
+# Redis / cache
+REDIS_URL=
+REDIS_HOST=
+REDIS_PORT=6379
+REDIS_PASSWORD=
+REDIS_DB=0
+
+# Freight integrations: configure only when enabled
+DAT_API_KEY=
+TRUCKSTOP_API_KEY=
+LOADBOARD_API_KEY=
+SAMSARA_API_TOKEN=
+MOTIVE_CLIENT_ID=
+MOTIVE_CLIENT_SECRET=
+QBO_CLIENT_ID=
+QBO_CLIENT_SECRET=
+XERO_CLIENT_ID=
+XERO_CLIENT_SECRET=
+SENDGRID_API_KEY=
+FROM_EMAIL=support@infamousfreight.com
+RTS_API_KEY=
+OTR_API_KEY=
+APEX_API_KEY=
+
+# Netlify hardening markers
+NETLIFY_SECRET_ROTATION_STATUS=verified
+NETLIFY_SECRET_ROTATION_REQUIRED=false
+NETLIFY_REDEPLOY_REQUIRED_AFTER_SECRET_ROTATION=false
+NETLIFY_TEAM_MFA_ENFORCEMENT_REQUIRED=true
+NETLIFY_PREVIEW_ACCESS_REVIEW_REQUIRED=true

--- a/docs/production-operations/PRODUCTION_SECRETS_SETUP.md
+++ b/docs/production-operations/PRODUCTION_SECRETS_SETUP.md
@@ -1,0 +1,154 @@
+# Production Secrets Setup Runbook
+
+Use this runbook to configure Infamous Freight production secrets without committing or exposing real credentials.
+
+## Hard rules
+
+- Do not paste real secrets into GitHub issues, pull requests, chat, screenshots, or logs.
+- Do not commit `.env.production.secrets`.
+- Add secret values directly through each platform secret manager or through the local bootstrap script.
+- Rotate any secret that was exposed outside its owning platform.
+
+## Platforms configured by the bootstrap script
+
+The script `scripts/setup-production-secrets.sh` can write values to:
+
+- GitHub Actions repository secrets
+- Fly.io app secrets
+- Netlify production environment variables
+
+The script does **not** configure Stripe Dashboard URLs, Supabase Auth URLs, Sentry project settings, MFA policies, or provider-side webhooks. Those still require dashboard verification.
+
+## Prerequisites
+
+Install and authenticate the CLIs on a trusted local machine:
+
+```bash
+gh auth login
+flyctl auth login
+netlify login
+```
+
+Verify access:
+
+```bash
+gh repo view Infaemous-Freight/Infamous-freight
+flyctl status --app infamous-freight
+netlify status
+```
+
+## Create the local secrets file
+
+```bash
+cp .env.production.secrets.example .env.production.secrets
+chmod 600 .env.production.secrets
+```
+
+Fill `.env.production.secrets` locally with production values from Fly.io, Netlify, Stripe, Supabase, Sentry, and provider dashboards.
+
+## Dry run first
+
+```bash
+DRY_RUN=true bash scripts/setup-production-secrets.sh .env.production.secrets
+```
+
+The dry run must show the correct platforms and variable names without printing secret values.
+
+## Apply secrets
+
+```bash
+bash scripts/setup-production-secrets.sh .env.production.secrets
+```
+
+If Netlify needs a site ID, set it explicitly:
+
+```bash
+NETLIFY_SITE_ID=<site-id> bash scripts/setup-production-secrets.sh .env.production.secrets
+```
+
+## Required dashboard checks
+
+### Stripe
+
+Confirm:
+
+```text
+Business website: https://www.infamousfreight.com
+Webhook endpoint: https://www.infamousfreight.com/api/stripe/webhook
+Checkout success URL: https://www.infamousfreight.com/billing/success
+Checkout cancel URL: https://www.infamousfreight.com/billing/cancel
+Customer portal return URL: https://www.infamousfreight.com/billing
+```
+
+### Supabase
+
+Confirm:
+
+```text
+Site URL: https://www.infamousfreight.com
+Redirect URLs:
+https://www.infamousfreight.com
+https://www.infamousfreight.com/*
+```
+
+Confirm the service role key is server-side only and the frontend uses only the publishable or anon key.
+
+### Sentry
+
+Confirm:
+
+```text
+SENTRY_ORG=infmous
+SENTRY_PROJECT=infamous-freight
+Frontend DSN is set in Netlify
+Backend DSN is set in Fly.io if backend monitoring is enabled
+Source map token is set in Netlify only
+```
+
+### Netlify security
+
+Confirm:
+
+- Team MFA is enforced.
+- Preview deploy access is reviewed.
+- Backend-sensitive values are hidden/secret where the platform supports it.
+
+## Redeploy after secret changes
+
+After applying secrets, redeploy both sides:
+
+```bash
+flyctl deploy --app infamous-freight
+```
+
+Trigger a fresh Netlify production deploy from the dashboard or via Netlify CLI.
+
+## Verification
+
+Run:
+
+```bash
+pnpm env:check:strict
+pnpm run production:preflight
+pnpm run production:smoke-test
+curl -i https://www.infamousfreight.com
+curl -i https://www.infamousfreight.com/api/health
+curl -i https://infamous-freight.fly.dev/health
+curl -i https://infamous-freight.fly.dev/api/health
+```
+
+Record evidence in:
+
+- GitHub issue `#1781`
+- GitHub issue `#1788`
+- `docs/LAUNCH_EVIDENCE_LOG.md`
+
+## Done means
+
+- GitHub Actions `FLY_API_TOKEN` exists and deploy workflow authenticates.
+- Fly.io app secrets are present and API health passes.
+- Netlify production env vars are present and frontend builds from latest `main`.
+- Stripe mode and webhook are verified.
+- Supabase auth/database configuration is verified.
+- Sentry receives a test frontend event if enabled.
+- Production smoke test passes with evidence.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "infamous-freight",
   "version": "1.0.0",
   "private": true,
-  "description": "Infamous Freight \u2014 The freight dispatch platform built by truckers, for truckers",
+  "description": "Infamous Freight — The freight dispatch platform built by truckers, for truckers",
   "packageManager": "pnpm@10.0.0",
   "repository": {
     "type": "git",
@@ -49,7 +49,9 @@
     "setup:deps-docker": "bash scripts/bootstrap-deps-docker.sh",
     "social-preview:generate": "node scripts/generate-social-preview.mjs",
     "bootstrap": "bash scripts/bootstrap.sh",
-    "netlify:production:readiness": "bash scripts/netlify-production-readiness.sh"
+    "netlify:production:readiness": "bash scripts/netlify-production-readiness.sh",
+    "production:secrets:setup": "bash scripts/setup-production-secrets.sh",
+    "production:secrets:dry-run": "DRY_RUN=true bash scripts/setup-production-secrets.sh"
   },
   "devDependencies": {
     "@resvg/resvg-js": "2.6.2",

--- a/scripts/setup-production-secrets.sh
+++ b/scripts/setup-production-secrets.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="${1:-${ROOT_DIR}/.env.production.secrets}"
+REPO="${GITHUB_REPOSITORY_OVERRIDE:-Infaemous-Freight/Infamous-freight}"
+FLY_APP="${FLY_APP:-infamous-freight}"
+NETLIFY_SITE_ID="${NETLIFY_SITE_ID:-}"
+DRY_RUN="${DRY_RUN:-false}"
+
+cat <<'BANNER'
+Infamous Freight production secrets bootstrap
+
+This script reads secrets from a local, gitignored file and writes them to the
+platforms that use them:
+- GitHub Actions repository secrets
+- Fly.io app secrets
+- Netlify site environment variables
+
+It does not print secret values. Do not commit the local secrets file.
+BANNER
+
+if [[ ! -f "${ENV_FILE}" ]]; then
+  cat >&2 <<EOF
+ERROR: Secrets file not found: ${ENV_FILE}
+
+Create it from the template:
+  cp .env.production.secrets.example .env.production.secrets
+
+Then fill values locally. The real .env.production.secrets file is ignored by git.
+EOF
+  exit 1
+fi
+
+set -a
+# shellcheck source=/dev/null
+source "${ENV_FILE}"
+set +a
+
+mask() {
+  local value="${1:-}"
+  if [[ -n "${value}" ]]; then
+    printf '***'
+  else
+    printf '<unset>'
+  fi
+}
+
+need_cmd() {
+  local cmd="$1"
+  if ! command -v "${cmd}" >/dev/null 2>&1; then
+    echo "ERROR: Required CLI missing: ${cmd}" >&2
+    return 1
+  fi
+}
+
+run_or_echo() {
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    echo "DRY RUN: $*"
+  else
+    "$@"
+  fi
+}
+
+set_github_secret() {
+  local name="$1"
+  local value="${!name:-}"
+  if [[ -z "${value}" ]]; then
+    echo "skip GitHub ${name}: unset"
+    return 0
+  fi
+  echo "set GitHub ${name}: $(mask "${value}")"
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    echo "DRY RUN: gh secret set ${name} -R ${REPO}"
+  else
+    gh secret set "${name}" -R "${REPO}" --body "${value}"
+  fi
+}
+
+set_fly_secret_args=()
+add_fly_secret() {
+  local name="$1"
+  local value="${!name:-}"
+  if [[ -z "${value}" ]]; then
+    echo "skip Fly ${name}: unset"
+    return 0
+  fi
+  echo "queue Fly ${name}: $(mask "${value}")"
+  set_fly_secret_args+=("${name}=${value}")
+}
+
+set_netlify_env() {
+  local name="$1"
+  local value="${!name:-}"
+  if [[ -z "${value}" ]]; then
+    echo "skip Netlify ${name}: unset"
+    return 0
+  fi
+  echo "set Netlify ${name}: $(mask "${value}")"
+  if [[ -n "${NETLIFY_SITE_ID}" ]]; then
+    if [[ "${DRY_RUN}" == "true" ]]; then
+      echo "DRY RUN: netlify env:set ${name} [value] --context production --site ${NETLIFY_SITE_ID}"
+    else
+      netlify env:set "${name}" "${value}" --context production --site "${NETLIFY_SITE_ID}"
+    fi
+  else
+    if [[ "${DRY_RUN}" == "true" ]]; then
+      echo "DRY RUN: netlify env:set ${name} [value] --context production"
+    else
+      netlify env:set "${name}" "${value}" --context production
+    fi
+  fi
+}
+
+validate_not_placeholder() {
+  local name="$1"
+  local value="${!name:-}"
+  if [[ "${value}" == *YOUR_* || "${value}" == *"<"* || "${value}" == *">"* ]]; then
+    echo "ERROR: ${name} still looks like a placeholder." >&2
+    exit 1
+  fi
+}
+
+# Validate core non-placeholder values only when present.
+for key in \
+  FLY_API_TOKEN DATABASE_URL SUPABASE_URL SUPABASE_SERVICE_KEY \
+  VITE_SUPABASE_URL VITE_SUPABASE_PUBLISHABLE_KEY \
+  STRIPE_SECRET_KEY STRIPE_WEBHOOK_SECRET VITE_STRIPE_PUBLIC_KEY; do
+  if [[ -n "${!key:-}" ]]; then
+    validate_not_placeholder "${key}"
+  fi
+done
+
+# GitHub Actions secrets
+need_cmd gh
+set_github_secret FLY_API_TOKEN
+set_github_secret DATABASE_URL
+
+# Fly.io runtime secrets
+need_cmd flyctl
+add_fly_secret NODE_ENV
+add_fly_secret PORT
+add_fly_secret WEB_APP_URL
+add_fly_secret CORS_ORIGINS
+add_fly_secret CORS_ORIGIN
+add_fly_secret DATABASE_URL
+add_fly_secret SUPABASE_URL
+add_fly_secret SUPABASE_SERVICE_KEY
+add_fly_secret SUPABASE_SERVICE_ROLE_KEY
+add_fly_secret SUPABASE_JWT_SECRET
+add_fly_secret STRIPE_SECRET_KEY
+add_fly_secret STRIPE_WEBHOOK_SECRET
+add_fly_secret STRIPE_CHECKOUT_SUCCESS_URL
+add_fly_secret STRIPE_CHECKOUT_CANCEL_URL
+add_fly_secret STRIPE_PORTAL_RETURN_URL
+add_fly_secret RATE_LIMIT_ENABLED
+add_fly_secret SENTRY_DSN
+add_fly_secret REDIS_URL
+add_fly_secret REDIS_HOST
+add_fly_secret REDIS_PORT
+add_fly_secret REDIS_PASSWORD
+add_fly_secret REDIS_DB
+add_fly_secret DAT_API_KEY
+add_fly_secret TRUCKSTOP_API_KEY
+add_fly_secret LOADBOARD_API_KEY
+add_fly_secret SAMSARA_API_TOKEN
+add_fly_secret MOTIVE_CLIENT_ID
+add_fly_secret MOTIVE_CLIENT_SECRET
+add_fly_secret QBO_CLIENT_ID
+add_fly_secret QBO_CLIENT_SECRET
+add_fly_secret XERO_CLIENT_ID
+add_fly_secret XERO_CLIENT_SECRET
+add_fly_secret SENDGRID_API_KEY
+add_fly_secret FROM_EMAIL
+add_fly_secret RTS_API_KEY
+add_fly_secret OTR_API_KEY
+add_fly_secret APEX_API_KEY
+
+if [[ "${#set_fly_secret_args[@]}" -gt 0 ]]; then
+  echo "apply Fly secrets to app ${FLY_APP}"
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    echo "DRY RUN: flyctl secrets set [${#set_fly_secret_args[@]} values] --app ${FLY_APP}"
+  else
+    flyctl secrets set "${set_fly_secret_args[@]}" --app "${FLY_APP}"
+  fi
+else
+  echo "No Fly secrets queued."
+fi
+
+# Netlify production environment variables.
+need_cmd netlify
+set_netlify_env VITE_API_URL
+set_netlify_env VITE_SUPABASE_URL
+set_netlify_env VITE_SUPABASE_PUBLISHABLE_KEY
+set_netlify_env VITE_SUPABASE_ANON_KEY
+set_netlify_env VITE_STRIPE_PUBLIC_KEY
+set_netlify_env VITE_SENTRY_DSN
+set_netlify_env VITE_SENTRY_ENABLED
+set_netlify_env SENTRY_AUTH_TOKEN
+set_netlify_env SENTRY_ORG
+set_netlify_env SENTRY_PROJECT
+set_netlify_env SENTRY_SOURCEMAPS
+set_netlify_env PUBLIC_SITE_URL
+set_netlify_env VITE_SITE_URL
+set_netlify_env NEXT_PUBLIC_SITE_URL
+set_netlify_env NETLIFY_SECRET_ROTATION_STATUS
+set_netlify_env NETLIFY_SECRET_ROTATION_REQUIRED
+set_netlify_env NETLIFY_REDEPLOY_REQUIRED_AFTER_SECRET_ROTATION
+set_netlify_env NETLIFY_TEAM_MFA_ENFORCEMENT_REQUIRED
+set_netlify_env NETLIFY_PREVIEW_ACCESS_REVIEW_REQUIRED
+
+cat <<'DONE'
+
+Secret bootstrap finished.
+
+Required follow-up:
+1. Trigger a fresh Fly/API deployment.
+2. Trigger a fresh Netlify production deploy.
+3. Run: pnpm env:check:strict
+4. Run: pnpm run production:preflight
+5. Run: pnpm run production:smoke-test
+6. Paste evidence into issue #1781 or docs/LAUNCH_EVIDENCE_LOG.md.
+DONE


### PR DESCRIPTION
## Summary
Adds a safe, local-first workflow for configuring production secrets across GitHub Actions, Fly.io, and Netlify without committing real credentials.

## Changes
- Adds `scripts/setup-production-secrets.sh`
- Adds `.env.production.secrets.example`
- Adds `docs/production-operations/PRODUCTION_SECRETS_SETUP.md`
- Adds npm scripts:
  - `production:secrets:dry-run`
  - `production:secrets:setup`

## Why
The project needs production secrets configured across multiple platforms. This PR gives operators a repeatable path that keeps real secret values out of GitHub, chat, logs, and committed files.

## Verification
Documentation/script-only change. The script supports `DRY_RUN=true` and masks secret values in output.

## Related
- #1781
- #1788

## Risk
Low. No production values are included. The real `.env.production.secrets` file remains ignored by existing `.gitignore` rules.