### PR TITLE
Harden Stripe Checkout and webhook handling

### DIFF
--- a/apps/api/src/billing.ts
+++ b/apps/api/src/billing.ts
@@ -26,6 +26,9 @@ export type StripeEvent = {
   };
 };
 
+const STRIPE_SIGNATURE_TOLERANCE_SECONDS = 300;
+const STRIPE_CHECKOUT_SESSION_TOKEN = '{CHECKOUT_SESSION_ID}';
+
 const PRICE_BY_PLAN_INTERVAL: Record<BillingPlan, Record<BillingInterval, string>> = {
   starter: {
     month: 'price_1TBnZ2KCNuZqDozYEcW5j4xM',
@@ -64,20 +67,41 @@ export function getBillingPortalReturnUrl(): string {
     || 'http://localhost:5173/settings';
 }
 
+function getCheckoutBaseUrl(path: 'success' | 'canceled'): string {
+  const explicitUrl = path === 'success'
+    ? process.env.STRIPE_CHECKOUT_SUCCESS_URL?.trim()
+    : process.env.STRIPE_CHECKOUT_CANCEL_URL?.trim();
+
+  if (explicitUrl) {
+    return explicitUrl;
+  }
+
+  const checkoutStatus = path === 'success' ? 'success' : 'canceled';
+  return `${process.env.WEB_APP_URL?.trim() || 'http://localhost:5173'}/settings?checkout=${checkoutStatus}`;
+}
+
+function appendCheckoutSessionIdToken(url: string): string {
+  if (url.includes(STRIPE_CHECKOUT_SESSION_TOKEN) || url.includes('session_id=')) {
+    return url;
+  }
+
+  const separator = url.includes('?') ? '&' : '?';
+  return `${url}${separator}session_id=${STRIPE_CHECKOUT_SESSION_TOKEN}`;
+}
+
 function getCheckoutSuccessUrl(): string {
-  return process.env.STRIPE_CHECKOUT_SUCCESS_URL?.trim()
-    || `${process.env.WEB_APP_URL?.trim() || 'http://localhost:5173'}/settings?checkout=success`;
+  return appendCheckoutSessionIdToken(getCheckoutBaseUrl('success'));
 }
 
 function getCheckoutCancelUrl(): string {
-  return process.env.STRIPE_CHECKOUT_CANCEL_URL?.trim()
-    || `${process.env.WEB_APP_URL?.trim() || 'http://localhost:5173'}/settings?checkout=canceled`;
+  return getCheckoutBaseUrl('canceled');
 }
 
 export function verifyStripeWebhookSignature(
   rawBody: Buffer,
   signatureHeader: string | undefined,
   webhookSecret: string | null = getStripeWebhookSecret(),
+  nowSeconds: number = Math.floor(Date.now() / 1000),
 ): boolean {
   if (!webhookSecret || !signatureHeader) {
     return false;
@@ -96,6 +120,15 @@ export function verifyStripeWebhookSignature(
   const signatures = parts.v1 ?? [];
 
   if (!timestamp || signatures.length === 0) {
+    return false;
+  }
+
+  const timestampNumber = Number(timestamp);
+  if (!Number.isFinite(timestampNumber)) {
+    return false;
+  }
+
+  if (Math.abs(nowSeconds - timestampNumber) > STRIPE_SIGNATURE_TOLERANCE_SECONDS) {
     return false;
   }
 

--- a/apps/api/test/billing.test.ts
+++ b/apps/api/test/billing.test.ts
@@ -1,9 +1,9 @@
 import crypto from 'crypto';
 import request from 'supertest';
 import { createApp } from '../src/app';
+import { createStripeCheckoutSession, verifyStripeWebhookSignature } from '../src/billing';
 
-function createStripeSignature(payload: string, secret: string): string {
-  const timestamp = Math.floor(Date.now() / 1000);
+function createStripeSignature(payload: string, secret: string, timestamp = Math.floor(Date.now() / 1000)): string {
   const digest = crypto
     .createHmac('sha256', secret)
     .update(`${timestamp}.${payload}`, 'utf8')
@@ -17,6 +17,10 @@ describe('Stripe billing endpoints', () => {
     process.env.NODE_ENV = 'test';
     process.env.STRIPE_WEBHOOK_SECRET = 'whsec_test_secret';
     delete process.env.STRIPE_SECRET_KEY;
+    delete process.env.STRIPE_CHECKOUT_SUCCESS_URL;
+    delete process.env.STRIPE_CHECKOUT_CANCEL_URL;
+    delete process.env.WEB_APP_URL;
+    jest.restoreAllMocks();
   });
 
   it('rejects webhook requests with invalid Stripe signatures', async () => {
@@ -28,6 +32,13 @@ describe('Stripe billing endpoints', () => {
       .set('Content-Type', 'application/json')
       .send(JSON.stringify({ id: 'evt_bad', type: 'invoice.payment_failed', data: { object: {} } }))
       .expect(400);
+  });
+
+  it('rejects otherwise valid Stripe signatures outside the replay tolerance window', () => {
+    const payload = Buffer.from(JSON.stringify({ id: 'evt_old', type: 'invoice.payment_failed', data: { object: {} } }));
+    const signature = createStripeSignature(payload.toString('utf8'), 'whsec_test_secret', 1_000);
+
+    expect(verifyStripeWebhookSignature(payload, signature, 'whsec_test_secret', 1_301)).toBe(false);
   });
 
   it('accepts signed checkout webhook events and syncs billing in memory store', async () => {
@@ -74,6 +85,39 @@ describe('Stripe billing endpoints', () => {
       .expect(500);
 
     expect(response.body.error).toBe('stripe_secret_key_required');
+  });
+
+  it('creates Checkout Sessions with server-side prices, metadata, and session id success redirects', async () => {
+    process.env.STRIPE_SECRET_KEY = 'sk_test_checkout';
+    process.env.WEB_APP_URL = 'https://www.infamousfreight.com';
+
+    const fetchMock = jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ url: 'https://checkout.stripe.com/c/pay/cs_test_123' }),
+    } as Response);
+
+    const url = await createStripeCheckoutSession({
+      carrierId: 'carrier_checkout_123',
+      plan: 'professional',
+      billingInterval: 'month',
+    });
+
+    expect(url).toBe('https://checkout.stripe.com/c/pay/cs_test_123');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [, requestInit] = fetchMock.mock.calls[0];
+    const body = requestInit?.body as URLSearchParams;
+
+    expect(body.get('mode')).toBe('subscription');
+    expect(body.get('line_items[0][price]')).toBe('price_1TBnZ3KCNuZqDozY2FISQT98');
+    expect(body.get('line_items[0][quantity]')).toBe('1');
+    expect(body.get('metadata[carrierId]')).toBe('carrier_checkout_123');
+    expect(body.get('metadata[plan]')).toBe('professional');
+    expect(body.get('metadata[billingInterval]')).toBe('month');
+    expect(body.get('client_reference_id')).toBe('carrier_checkout_123');
+    expect(body.get('success_url')).toBe(
+      'https://www.infamousfreight.com/settings?checkout=success&session_id={CHECKOUT_SESSION_ID}',
+    );
   });
 
   it('blocks duplicate checkout when a carrier already has a Stripe customer', async () => {

--- a/apps/api/test/verify-required-clis-script.test.ts
+++ b/apps/api/test/verify-required-clis-script.test.ts
@@ -6,6 +6,13 @@ import { spawnSync } from 'node:child_process';
 describe('verify-required-clis.sh', () => {
   const sourceScript = path.resolve(__dirname, '..', '..', '..', 'scripts', 'verify-required-clis.sh');
 
+  function createMinimalPath(tmp: string): string {
+    const binDir = path.join(tmp, 'bin');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.symlinkSync('/usr/bin/dirname', path.join(binDir, 'dirname'));
+    return binDir;
+  }
+
   it('fails when required CLIs are missing', () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'verify-clis-missing-'));
     const scriptDir = path.join(tmp, 'scripts');
@@ -18,7 +25,7 @@ describe('verify-required-clis.sh', () => {
     const result = spawnSync('/usr/bin/bash', [scriptPath], {
       cwd: tmp,
       encoding: 'utf8',
-      env: { ...process.env, PATH: '/bin' },
+      env: { ...process.env, PATH: createMinimalPath(tmp) },
     });
 
     expect(result.status).toBe(1);
@@ -27,6 +34,7 @@ describe('verify-required-clis.sh', () => {
     expect(result.stderr).toContain('stripe missing');
     expect(result.stderr).toContain('gh missing');
     expect(result.stderr).toContain('netlify missing');
+    expect(result.stderr).toContain('docker missing');
   });
 
   it('passes when required CLIs exist in .tools/bin', () => {
@@ -49,7 +57,7 @@ describe('verify-required-clis.sh', () => {
     const result = spawnSync('/usr/bin/bash', [scriptPath], {
       cwd: tmp,
       encoding: 'utf8',
-      env: { ...process.env, PATH: '/bin' },
+      env: { ...process.env, PATH: createMinimalPath(tmp) },
     });
 
     expect(result.status).toBe(0);

--- a/docs/STRIPE_BILLING_AUTOMATION.md
+++ b/docs/STRIPE_BILLING_AUTOMATION.md
@@ -1,7 +1,7 @@
 # Stripe Billing Automation
 
-Date: April 27, 2026
-Status: Checkout, webhook sync, customer portal, webhook logging, duplicate checkout guard, and AI usage ledger foundation added
+Date: May 3, 2026
+Status: Checkout, webhook sync, customer portal, webhook logging, duplicate checkout guard, Checkout Session return IDs, webhook replay protection, and AI usage ledger foundation added
 
 ## Purpose
 
@@ -10,10 +10,13 @@ This runbook documents Stripe billing automation for Infamous Freight after cata
 The implementation adds:
 
 - Backend-created Stripe Checkout Sessions
+- Server-side Stripe Price ID selection
 - Stripe webhook verification
+- Stripe webhook replay protection with a 5-minute signature timestamp tolerance
 - Stripe webhook event logging
 - Subscription/customer sync to `Carrier`
 - Duplicate checkout protection
+- Checkout Session ID return in success redirects
 - Owner/admin customer portal endpoint
 - AI usage ledger API and database table
 - Billing UI in Settings
@@ -28,6 +31,12 @@ POST /api/billing/webhook
 ```
 
 This endpoint expects Stripe's raw request body and validates the `stripe-signature` header with `STRIPE_WEBHOOK_SECRET`.
+
+Important implementation details:
+
+- `/api/billing/webhook` is registered before `express.json()` so the raw request body remains available for signature verification.
+- Webhook signatures are rejected when the timestamp is more than 5 minutes outside the server clock to reduce replay risk.
+- The endpoint should be used as the source of truth for fulfillment and billing sync. Do not mark billing state from the success page alone.
 
 Verified events are logged to `StripeWebhookEvent` with status:
 
@@ -74,6 +83,8 @@ Supported billing intervals:
 month
 year
 ```
+
+The frontend sends only `plan` and `billingInterval`; the API maps those values to trusted server-side Stripe Price IDs. Do not accept raw prices or Price IDs from browser input.
 
 If a carrier already has a linked Stripe customer, checkout creation returns a conflict. Use the Customer Portal for billing changes after first checkout.
 
@@ -152,7 +163,7 @@ API:
 STRIPE_SECRET_KEY=sk_live_...
 STRIPE_WEBHOOK_SECRET=whsec_...
 STRIPE_PORTAL_RETURN_URL=https://www.infamousfreight.com/settings
-STRIPE_CHECKOUT_SUCCESS_URL=https://www.infamousfreight.com/settings?checkout=success
+STRIPE_CHECKOUT_SUCCESS_URL=https://www.infamousfreight.com/settings?checkout=success&session_id={CHECKOUT_SESSION_ID}
 STRIPE_CHECKOUT_CANCEL_URL=https://www.infamousfreight.com/settings?checkout=canceled
 ```
 
@@ -161,6 +172,8 @@ Optional fallback:
 ```env
 WEB_APP_URL=https://www.infamousfreight.com
 ```
+
+If `STRIPE_CHECKOUT_SUCCESS_URL` does not include `session_id`, the API automatically appends `session_id={CHECKOUT_SESSION_ID}` before creating the Stripe Checkout Session.
 
 Web:
 
@@ -249,6 +262,14 @@ metadata: {
 
 Subscription metadata also receives the same values so future subscription events can preserve plan mapping.
 
+Checkout Sessions also set:
+
+```ts
+client_reference_id: carrierId
+```
+
+Use `metadata.carrierId` and `client_reference_id` to connect Stripe activity back to the internal carrier/order context.
+
 ## Customer portal setup
 
 In Stripe Dashboard:
@@ -289,13 +310,14 @@ After deployment:
 4. Confirm `/api/billing/webhook` returns `200`.
 5. Start checkout from Settings → Billing & Plans using an internal carrier.
 6. Complete checkout.
-7. Confirm the carrier row has:
+7. Confirm the success redirect includes `session_id`.
+8. Confirm the carrier row has:
    - `stripeCustomerId`
    - correct `subscriptionTier`
    - correct `status`
-8. Confirm `StripeWebhookEvent` logged the webhook as `processed`.
-9. Open customer portal from Settings as owner/admin.
-10. Record one AI usage event and confirm it appears in Settings → Billing & Plans.
+9. Confirm `StripeWebhookEvent` logged the webhook as `processed`.
+10. Open customer portal from Settings as owner/admin.
+11. Record one AI usage event and confirm it appears in Settings → Billing & Plans.
 
 ## Notes
 


### PR DESCRIPTION
## Summary

- Add Stripe webhook timestamp tolerance to reduce replay risk.
- Ensure Checkout success redirects include `session_id={CHECKOUT_SESSION_ID}` automatically.
- Keep trusted server-side Stripe Price ID selection and Checkout metadata/client reference behavior covered by tests.
- Update the Stripe billing runbook with production notes for raw-body webhooks, webhook fulfillment, replay protection, and success redirect validation.

## Validation

- Added/updated API billing tests for webhook replay tolerance and Checkout Session request payloads.
- Not run locally in this environment.