### PR TITLE
Add Stripe one-time payment checkout pack

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,40 +1,40 @@
-# Dependency/Build Directories
+# Dependencies
 node_modules
-npm-debug.log
-.npm
+**/node_modules
 
-# TypeScript source files (we only need compiled JS in production)
-src
-*.ts
-!*.d.ts
+# Build outputs
+dist
+**/dist
+build
+**/build
+coverage
+**/coverage
+*.tsbuildinfo
 
-# Project Files
+# Logs and temp files
+*.log
+npm-debug.log*
+pnpm-debug.log*
+.tmp
+tmp
+.cache
+
+# VCS and editor files
 .git
 .gitignore
-.dockerignore
-Dockerfile
-fly.toml # Fly.io configuration file
-tsconfig.json
-tslint.json
-.eslintrc*
-
-# Environment/Configuration Files
-.env
-.DS_Store
-*.log
-
-# Development/Testing files and directories
-test
-tests
-__tests__
-docs
-coverage
-.nyc_output
-tmp
-*~
-
-# IDE files
 .vscode
 .idea
 *.swp
 *.swo
+.DS_Store
+
+# Environment files
+.env
+.env.*
+!.env.example
+
+# Large/generated artifacts
+sbom
+.netlify
+.tools
+reports

--- a/.env.example
+++ b/.env.example
@@ -18,18 +18,25 @@ REDIS_DB=0
 # ——— API ———
 NODE_ENV=development
 PORT=3001
-JWT_SECRET=your-super-secret-jwt-key-change-this-in-production
+JWT_SECRET=replace-this-in-production
 RATE_LIMIT_ENABLED=true
 # Legacy compatibility for older scripts:
 API_RATE_LIMIT_ENABLED=true
 
 # ——— Observability ———
-SENTRY_DSN=https://<public-key>@o<org>.ingest.us.sentry.io/<project-id>
+SENTRY_DSN=https://example.invalid/sentry-dsn
 
 # ——— Stripe ———
-STRIPE_SECRET_KEY=sk_test_...
-STRIPE_WEBHOOK_SECRET=whsec_...
-STRIPE_PUBLISHABLE_KEY=pk_test_...
+STRIPE_SECRET_KEY=replace-with-stripe-secret-key
+STRIPE_WEBHOOK_SECRET=replace-with-stripe-webhook-signing-secret
+STRIPE_PUBLISHABLE_KEY=replace-with-stripe-publishable-key
+STRIPE_PRICE_ONE_TIME=replace-with-one-time-price-id
+# Legacy alias supported by the API for the same one-time add-on price:
+STRIPE_PRICE_AI_ADDON_PACK=replace-with-one-time-price-id
+STRIPE_PORTAL_RETURN_URL=http://localhost:5173/settings
+STRIPE_CHECKOUT_SUCCESS_URL=http://localhost:5173/settings?checkout=success&session_id={CHECKOUT_SESSION_ID}
+STRIPE_CHECKOUT_CANCEL_URL=http://localhost:5173/settings?checkout=canceled
+WEB_APP_URL=http://localhost:5173
 
 # ——— Supabase ———
 SUPABASE_URL=https://your-project.supabase.co
@@ -59,7 +66,7 @@ XERO_CLIENT_ID=your-xero-client-id
 XERO_CLIENT_SECRET=your-xero-secret
 
 # ——— SendGrid ———
-SENDGRID_API_KEY=SG.your-sendgrid-key
+SENDGRID_API_KEY=your-sendgrid-key
 FROM_EMAIL=noreply@infamousfreight.com
 
 # ——— Factoring ———
@@ -69,5 +76,5 @@ APEX_API_KEY=your-apex-key
 
 # ——— Web Frontend ———
 VITE_API_URL=http://localhost:3001
-VITE_STRIPE_PUBLIC_KEY=pk_test_...
+VITE_STRIPE_PUBLIC_KEY=replace-with-stripe-publishable-key
 VITE_SOCKET_URL=ws://localhost:3001

--- a/.github/workflows/full-validation.yml
+++ b/.github/workflows/full-validation.yml
@@ -80,7 +80,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@5b527519f648035f8be57f79b1a08876fa6a6e64 # v3.11.1
+        uses: docker/setup-buildx-action@v3
 
       - name: Build runtime image
         run: docker build --pull -t "$IMAGE_NAME" .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,45 +1,35 @@
-# Stage 1: Build the Application
-# We use node:22 as the base for building and installing dependencies.
 FROM node:22 AS build
 
-# Set the working directory inside the container
 WORKDIR /usr/src/app
 
-# Copy package.json and package-lock.json first to leverage Docker caching.
-# If these files don't change, subsequent builds can skip 'npm install'.
-COPY package*.json ./
-COPY tsconfig.json ./
+RUN corepack enable
 
-# Install dependencies including TypeScript
-RUN npm install
-RUN npm install --save-dev typescript @types/node
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/api/package.json apps/api/package.json
+COPY apps/web/package.json apps/web/package.json
 
-# Copy the rest of the application source code
-COPY . .
+RUN pnpm install --frozen-lockfile
 
-# Build TypeScript
-RUN npm run build || npx tsc
+COPY scripts scripts
+COPY apps/api apps/api
 
-# Stage 2: Create the Final Production Image
-# We use node:22-slim as a minimal runtime image.
+RUN pnpm run build:api
+
 FROM node:22-slim
 
-# Set the working directory
 WORKDIR /usr/src/app
 
-# Copy only production dependencies
-COPY --from=build /usr/src/app/package*.json ./
-RUN npm install --only=production
-
-# Copy the built application files from the 'build' stage
-COPY --from=build /usr/src/app/dist ./dist
-
-# Expose the port your app runs on
+ENV NODE_ENV=production
 ENV PORT=8080
-EXPOSE $PORT
 
-# Run the application using the non-root user (recommended for security)
+COPY --from=build /usr/src/app/package.json ./package.json
+COPY --from=build /usr/src/app/pnpm-lock.yaml ./pnpm-lock.yaml
+COPY --from=build /usr/src/app/pnpm-workspace.yaml ./pnpm-workspace.yaml
+COPY --from=build /usr/src/app/node_modules ./node_modules
+COPY --from=build /usr/src/app/apps/api ./apps/api
+
+EXPOSE 8080
+
 USER node
 
-# Define the command to start your application
-CMD [ "node", "dist/index.js" ]
+CMD ["node", "apps/api/dist/src/server.js"]

--- a/apps/api/prisma/migrations/20260503083000_add_stripe_one_time_payments/migration.sql
+++ b/apps/api/prisma/migrations/20260503083000_add_stripe_one_time_payments/migration.sql
@@ -1,0 +1,25 @@
+CREATE TABLE "StripeOneTimePayment" (
+    "id" TEXT NOT NULL,
+    "eventId" TEXT NOT NULL,
+    "carrierId" TEXT NOT NULL,
+    "stripeCustomerId" TEXT,
+    "stripeCheckoutSessionId" TEXT NOT NULL,
+    "stripePaymentIntentId" TEXT,
+    "amountTotal" INTEGER NOT NULL,
+    "currency" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "purchaseType" TEXT NOT NULL,
+    "priceId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "StripeOneTimePayment_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "StripeOneTimePayment_stripeCheckoutSessionId_key" ON "StripeOneTimePayment"("stripeCheckoutSessionId");
+CREATE INDEX "StripeOneTimePayment_carrierId_createdAt_idx" ON "StripeOneTimePayment"("carrierId", "createdAt");
+CREATE INDEX "StripeOneTimePayment_purchaseType_idx" ON "StripeOneTimePayment"("purchaseType");
+CREATE INDEX "StripeOneTimePayment_status_idx" ON "StripeOneTimePayment"("status");
+CREATE INDEX "StripeOneTimePayment_eventId_idx" ON "StripeOneTimePayment"("eventId");
+
+ALTER TABLE "StripeOneTimePayment" ADD CONSTRAINT "StripeOneTimePayment_carrierId_fkey" FOREIGN KEY ("carrierId") REFERENCES "Carrier"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -21,17 +21,18 @@ model Carrier {
   createdAt        DateTime @default(now())
   updatedAt        DateTime @updatedAt
 
-  drivers         Driver[]
-  loads           Load[]
-  invoices        Invoice[]
-  documents       Document[]
-  teamMembers     TeamMember[]
-  quoteRequests   QuoteRequest[]
-  loadAssignments LoadAssignment[]
-  loadDispatches  LoadDispatch[]
-  carrierPayments CarrierPayment[]
-  aiUsageEvents   AiUsageEvent[]
-  rateAgreement   RateAgreement?
+  drivers               Driver[]
+  loads                 Load[]
+  invoices              Invoice[]
+  documents             Document[]
+  teamMembers           TeamMember[]
+  quoteRequests         QuoteRequest[]
+  loadAssignments       LoadAssignment[]
+  loadDispatches        LoadDispatch[]
+  carrierPayments       CarrierPayment[]
+  aiUsageEvents         AiUsageEvent[]
+  stripeOneTimePayments StripeOneTimePayment[]
+  rateAgreement         RateAgreement?
 }
 
 model Driver {
@@ -337,6 +338,29 @@ model StripeWebhookEvent {
   @@index([status])
   @@index([carrierId])
   @@index([receivedAt])
+}
+
+model StripeOneTimePayment {
+  id                      String   @id @default(cuid())
+  eventId                 String
+  carrierId               String
+  stripeCustomerId        String?
+  stripeCheckoutSessionId String   @unique
+  stripePaymentIntentId   String?
+  amountTotal             Int
+  currency                String
+  status                  String
+  purchaseType            String
+  priceId                 String?
+  createdAt               DateTime @default(now())
+  updatedAt               DateTime @updatedAt
+
+  carrier Carrier @relation(fields: [carrierId], references: [id])
+
+  @@index([carrierId, createdAt])
+  @@index([purchaseType])
+  @@index([status])
+  @@index([eventId])
 }
 
 model AuditLog {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -12,7 +12,9 @@ import {
   BillingPlan,
   createStripeBillingPortalSession,
   createStripeCheckoutSession,
+  createStripeOneTimeCheckoutSession,
   getBillingSyncFromStripeEvent,
+  getStripeOneTimePaymentFromStripeEvent,
   getStripeWebhookSecret,
   StripeEvent,
   verifyStripeWebhookSignature,
@@ -20,6 +22,7 @@ import {
 import { createAiUsageStore } from './ai-usage';
 import { createRateLimitMiddleware } from './rate-limit';
 import { createStripeWebhookEventStore } from './stripe-webhook-events';
+import { createStripeOneTimePaymentStore } from './stripe-one-time-payments';
 import { createFreightWorkflowRouter } from './freight-workflow-routes';
 
 type Role = 'owner' | 'admin' | 'dispatcher';
@@ -218,12 +221,18 @@ function getCheckoutInterval(req: Request): BillingInterval {
   return billingInterval;
 }
 
+function getOneTimePurchaseType(req: Request): string | undefined {
+  const purchaseType = req.body?.purchaseType;
+  return typeof purchaseType === 'string' && purchaseType.trim() ? purchaseType.trim() : undefined;
+}
+
 function getCarrierIdFromBillingSync(billingSync: ReturnType<typeof getBillingSyncFromStripeEvent>): string | null {
   return billingSync?.carrierId ?? null;
 }
 
 function registerWebhookRoute(app: express.Express, dataStore: DataStore) {
   const webhookEvents = createStripeWebhookEventStore();
+  const oneTimePayments = createStripeOneTimePaymentStore();
 
   app.post('/api/billing/webhook', express.raw({ type: 'application/json' }), wrapAsync(async (req, res) => {
     const rawBody = Buffer.isBuffer(req.body) ? req.body : Buffer.from(JSON.stringify(req.body ?? {}));
@@ -236,7 +245,8 @@ function registerWebhookRoute(app: express.Express, dataStore: DataStore) {
 
     const event = JSON.parse(rawBody.toString('utf8')) as StripeEvent;
     const billingSync = getBillingSyncFromStripeEvent(event);
-    const carrierId = getCarrierIdFromBillingSync(billingSync);
+    const oneTimePayment = getStripeOneTimePaymentFromStripeEvent(event);
+    const carrierId = getCarrierIdFromBillingSync(billingSync) ?? oneTimePayment?.carrierId ?? null;
 
     await webhookEvents.upsert({
       eventId: event.id,
@@ -246,6 +256,10 @@ function registerWebhookRoute(app: express.Express, dataStore: DataStore) {
     });
 
     try {
+      if (oneTimePayment) {
+        await oneTimePayments.upsert(oneTimePayment);
+      }
+
       if (billingSync) {
         const synced = await dataStore.syncCarrierBilling(billingSync);
         await webhookEvents.upsert({
@@ -253,6 +267,14 @@ function registerWebhookRoute(app: express.Express, dataStore: DataStore) {
           eventType: event.type,
           carrierId,
           status: synced ? 'processed' : 'ignored',
+          processedAt: new Date(),
+        });
+      } else if (oneTimePayment) {
+        await webhookEvents.upsert({
+          eventId: event.id,
+          eventType: event.type,
+          carrierId,
+          status: 'processed',
           processedAt: new Date(),
         });
       } else {
@@ -375,6 +397,27 @@ function registerRoutes(app: express.Express, dataStore: DataStore) {
       stripeCustomerId,
       plan: getCheckoutPlan(req),
       billingInterval: getCheckoutInterval(req),
+    });
+
+    res.status(200).json({ data: { url } });
+  }));
+
+  app.post('/api/billing/one-time-checkout-session', requireTenant, requireRole, requireBillingRole, wrapAsync(async (req, res) => {
+    const carrierId = getRequiredTenantId(req);
+    const stripeCustomerId = await dataStore.getCarrierStripeCustomerId(carrierId);
+
+    if (!stripeCustomerId) {
+      throw new HttpError(
+        404,
+        'stripe_customer_not_found',
+        'A linked Stripe customer is required before purchasing one-time add-ons.',
+      );
+    }
+
+    const url = await createStripeOneTimeCheckoutSession({
+      carrierId,
+      stripeCustomerId,
+      purchaseType: getOneTimePurchaseType(req),
     });
 
     res.status(200).json({ data: { url } });
@@ -556,6 +599,13 @@ export function createApp() {
       return res.status(500).json({
         error: 'stripe_secret_key_required',
         message: 'STRIPE_SECRET_KEY is required for billing actions.',
+      });
+    }
+
+    if (err.message === 'stripe_one_time_price_required') {
+      return res.status(500).json({
+        error: 'stripe_one_time_price_required',
+        message: 'STRIPE_PRICE_ONE_TIME or STRIPE_PRICE_AI_ADDON_PACK is required for one-time purchases.',
       });
     }
 

--- a/apps/api/src/billing.ts
+++ b/apps/api/src/billing.ts
@@ -18,6 +18,25 @@ export type CheckoutSessionInput = {
   stripeCustomerId?: string | null;
 };
 
+export type OneTimeCheckoutSessionInput = {
+  carrierId: string;
+  stripeCustomerId?: string | null;
+  purchaseType?: string;
+};
+
+export type StripeOneTimePaymentPayload = {
+  eventId: string;
+  carrierId: string;
+  stripeCustomerId?: string | null;
+  stripeCheckoutSessionId: string;
+  stripePaymentIntentId?: string | null;
+  amountTotal: number;
+  currency: string;
+  status: string;
+  purchaseType: string;
+  priceId?: string | null;
+};
+
 export type StripeEvent = {
   id: string;
   type: string;
@@ -28,6 +47,7 @@ export type StripeEvent = {
 
 const STRIPE_SIGNATURE_TOLERANCE_SECONDS = 300;
 const STRIPE_CHECKOUT_SESSION_TOKEN = '{CHECKOUT_SESSION_ID}';
+const DEFAULT_ONE_TIME_PURCHASE_TYPE = 'ai_addon_pack';
 
 const PRICE_BY_PLAN_INTERVAL: Record<BillingPlan, Record<BillingInterval, string>> = {
   starter: {
@@ -59,6 +79,12 @@ export function getStripeSecretKey(): string | null {
 
 export function getStripeWebhookSecret(): string | null {
   return process.env.STRIPE_WEBHOOK_SECRET?.trim() || null;
+}
+
+export function getStripeOneTimePriceId(): string | null {
+  return process.env.STRIPE_PRICE_ONE_TIME?.trim()
+    || process.env.STRIPE_PRICE_AI_ADDON_PACK?.trim()
+    || null;
 }
 
 export function getBillingPortalReturnUrl(): string {
@@ -151,6 +177,10 @@ function getString(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim() ? value : undefined;
 }
 
+function getNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
 function getRecord(value: unknown): Record<string, unknown> | undefined {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
     ? value as Record<string, unknown>
@@ -168,6 +198,15 @@ function getCustomerId(object: Record<string, unknown>): string | undefined {
   }
 
   return getString(getRecord(customer)?.id);
+}
+
+function getPaymentIntentId(object: Record<string, unknown>): string | undefined {
+  const paymentIntent = object.payment_intent;
+  if (typeof paymentIntent === 'string') {
+    return paymentIntent;
+  }
+
+  return getString(getRecord(paymentIntent)?.id);
 }
 
 function mapStripeStatus(status: string | undefined): BillingStatus {
@@ -213,6 +252,10 @@ export function getBillingSyncFromStripeEvent(event: StripeEvent): BillingSyncPa
 
   switch (event.type) {
     case 'checkout.session.completed': {
+      if (getString(object.mode) === 'payment') {
+        return null;
+      }
+
       const plan = getString(metadata.plan) as BillingPlan | undefined;
       return {
         carrierId,
@@ -252,6 +295,38 @@ export function getBillingSyncFromStripeEvent(event: StripeEvent): BillingSyncPa
     default:
       return null;
   }
+}
+
+export function getStripeOneTimePaymentFromStripeEvent(event: StripeEvent): StripeOneTimePaymentPayload | null {
+  if (event.type !== 'checkout.session.completed') {
+    return null;
+  }
+
+  const object = event.data.object;
+  if (getString(object.mode) !== 'payment') {
+    return null;
+  }
+
+  const metadata = getMetadata(object);
+  const carrierId = getString(metadata.carrierId) ?? getString(object.client_reference_id);
+  const sessionId = getString(object.id);
+
+  if (!carrierId || !sessionId) {
+    return null;
+  }
+
+  return {
+    eventId: event.id,
+    carrierId,
+    stripeCustomerId: getCustomerId(object) ?? null,
+    stripeCheckoutSessionId: sessionId,
+    stripePaymentIntentId: getPaymentIntentId(object) ?? null,
+    amountTotal: getNumber(object.amount_total) ?? 0,
+    currency: getString(object.currency) ?? 'usd',
+    status: getString(object.payment_status) ?? getString(object.status) ?? 'unknown',
+    purchaseType: getString(metadata.purchaseType) ?? DEFAULT_ONE_TIME_PURCHASE_TYPE,
+    priceId: getString(metadata.priceId) ?? getStripeOneTimePriceId(),
+  };
 }
 
 async function postStripeForm<T>(path: string, body: URLSearchParams): Promise<T> {
@@ -304,6 +379,40 @@ export async function createStripeCheckoutSession(input: CheckoutSessionInput): 
     body.set('customer', input.stripeCustomerId);
   } else {
     body.set('client_reference_id', input.carrierId);
+  }
+
+  const session = await postStripeForm<{ url?: string }>('/checkout/sessions', body);
+
+  if (!session.url) {
+    throw new Error('stripe_checkout_session_failed');
+  }
+
+  return session.url;
+}
+
+export async function createStripeOneTimeCheckoutSession(input: OneTimeCheckoutSessionInput): Promise<string> {
+  const price = getStripeOneTimePriceId();
+
+  if (!price) {
+    throw new Error('stripe_one_time_price_required');
+  }
+
+  const purchaseType = input.purchaseType?.trim() || DEFAULT_ONE_TIME_PURCHASE_TYPE;
+  const body = new URLSearchParams({
+    mode: 'payment',
+    success_url: getCheckoutSuccessUrl(),
+    cancel_url: getCheckoutCancelUrl(),
+    'line_items[0][price]': price,
+    'line_items[0][quantity]': '1',
+    client_reference_id: input.carrierId,
+    'metadata[carrierId]': input.carrierId,
+    'metadata[purchaseType]': purchaseType,
+    'metadata[priceId]': price,
+    'metadata[mode]': 'payment',
+  });
+
+  if (input.stripeCustomerId) {
+    body.set('customer', input.stripeCustomerId);
   }
 
   const session = await postStripeForm<{ url?: string }>('/checkout/sessions', body);

--- a/apps/api/src/stripe-one-time-payments.ts
+++ b/apps/api/src/stripe-one-time-payments.ts
@@ -1,0 +1,71 @@
+import { PrismaClient } from '@prisma/client';
+import { StripeOneTimePaymentPayload } from './billing';
+import { createPrismaClient } from './prisma-client';
+
+export type StripeOneTimePaymentInput = StripeOneTimePaymentPayload;
+
+interface StripeOneTimePaymentStore {
+  upsert(input: StripeOneTimePaymentInput): Promise<void>;
+}
+
+class MemoryStripeOneTimePaymentStore implements StripeOneTimePaymentStore {
+  private payments = new Map<string, StripeOneTimePaymentInput>();
+
+  async upsert(input: StripeOneTimePaymentInput): Promise<void> {
+    const current = this.payments.get(input.stripeCheckoutSessionId);
+    this.payments.set(input.stripeCheckoutSessionId, {
+      ...current,
+      ...input,
+    });
+  }
+}
+
+class PrismaStripeOneTimePaymentStore implements StripeOneTimePaymentStore {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async upsert(input: StripeOneTimePaymentInput): Promise<void> {
+    await this.prisma.stripeOneTimePayment.upsert({
+      where: { stripeCheckoutSessionId: input.stripeCheckoutSessionId },
+      create: {
+        eventId: input.eventId,
+        carrierId: input.carrierId,
+        stripeCustomerId: input.stripeCustomerId,
+        stripeCheckoutSessionId: input.stripeCheckoutSessionId,
+        stripePaymentIntentId: input.stripePaymentIntentId,
+        amountTotal: input.amountTotal,
+        currency: input.currency,
+        status: input.status,
+        purchaseType: input.purchaseType,
+        priceId: input.priceId,
+      },
+      update: {
+        eventId: input.eventId,
+        carrierId: input.carrierId,
+        stripeCustomerId: input.stripeCustomerId,
+        stripePaymentIntentId: input.stripePaymentIntentId,
+        amountTotal: input.amountTotal,
+        currency: input.currency,
+        status: input.status,
+        purchaseType: input.purchaseType,
+        priceId: input.priceId,
+      },
+    });
+  }
+}
+
+let prismaClient: PrismaClient | null = null;
+let memoryStore: MemoryStripeOneTimePaymentStore | null = null;
+
+export function createStripeOneTimePaymentStore(): StripeOneTimePaymentStore {
+  if (process.env.NODE_ENV === 'test') {
+    memoryStore ??= new MemoryStripeOneTimePaymentStore();
+    return memoryStore;
+  }
+
+  if (!process.env.DATABASE_URL) {
+    throw new Error('DATABASE_URL is required outside of test mode.');
+  }
+
+  prismaClient ??= createPrismaClient();
+  return new PrismaStripeOneTimePaymentStore(prismaClient);
+}

--- a/apps/api/test/billing.test.ts
+++ b/apps/api/test/billing.test.ts
@@ -1,7 +1,12 @@
 import crypto from 'crypto';
 import request from 'supertest';
 import { createApp } from '../src/app';
-import { createStripeCheckoutSession, verifyStripeWebhookSignature } from '../src/billing';
+import {
+  createStripeCheckoutSession,
+  createStripeOneTimeCheckoutSession,
+  getStripeOneTimePaymentFromStripeEvent,
+  verifyStripeWebhookSignature,
+} from '../src/billing';
 
 function createStripeSignature(payload: string, secret: string, timestamp = Math.floor(Date.now() / 1000)): string {
   const digest = crypto
@@ -17,6 +22,8 @@ describe('Stripe billing endpoints', () => {
     process.env.NODE_ENV = 'test';
     process.env.STRIPE_WEBHOOK_SECRET = 'whsec_test_secret';
     delete process.env.STRIPE_SECRET_KEY;
+    delete process.env.STRIPE_PRICE_ONE_TIME;
+    delete process.env.STRIPE_PRICE_AI_ADDON_PACK;
     delete process.env.STRIPE_CHECKOUT_SUCCESS_URL;
     delete process.env.STRIPE_CHECKOUT_CANCEL_URL;
     delete process.env.WEB_APP_URL;
@@ -118,6 +125,75 @@ describe('Stripe billing endpoints', () => {
     expect(body.get('success_url')).toBe(
       'https://www.infamousfreight.com/settings?checkout=success&session_id={CHECKOUT_SESSION_ID}',
     );
+  });
+
+  it('creates one-time Checkout Sessions with trusted server-side Price IDs', async () => {
+    process.env.STRIPE_SECRET_KEY = 'sk_test_checkout';
+    process.env.STRIPE_PRICE_ONE_TIME = 'price_one_time_test';
+    process.env.WEB_APP_URL = 'https://www.infamousfreight.com';
+
+    const fetchMock = jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ url: 'https://checkout.stripe.com/c/pay/cs_one_time_123' }),
+    } as Response);
+
+    const url = await createStripeOneTimeCheckoutSession({
+      carrierId: 'carrier_addon_123',
+      stripeCustomerId: 'cus_addon_123',
+      purchaseType: 'ai_addon_pack',
+    });
+
+    expect(url).toBe('https://checkout.stripe.com/c/pay/cs_one_time_123');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [, requestInit] = fetchMock.mock.calls[0];
+    const body = requestInit?.body as URLSearchParams;
+
+    expect(body.get('mode')).toBe('payment');
+    expect(body.get('line_items[0][price]')).toBe('price_one_time_test');
+    expect(body.get('customer')).toBe('cus_addon_123');
+    expect(body.get('client_reference_id')).toBe('carrier_addon_123');
+    expect(body.get('metadata[carrierId]')).toBe('carrier_addon_123');
+    expect(body.get('metadata[purchaseType]')).toBe('ai_addon_pack');
+    expect(body.get('metadata[priceId]')).toBe('price_one_time_test');
+    expect(body.get('metadata[mode]')).toBe('payment');
+  });
+
+  it('extracts one-time payment records from completed Checkout webhooks', () => {
+    const payment = getStripeOneTimePaymentFromStripeEvent({
+      id: 'evt_one_time_completed',
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          id: 'cs_one_time_123',
+          mode: 'payment',
+          customer: 'cus_one_time_123',
+          payment_intent: 'pi_one_time_123',
+          amount_total: 4900,
+          currency: 'usd',
+          payment_status: 'paid',
+          client_reference_id: 'carrier_one_time_123',
+          metadata: {
+            carrierId: 'carrier_one_time_123',
+            purchaseType: 'ai_addon_pack',
+            priceId: 'price_one_time_test',
+          },
+        },
+      },
+    });
+
+    expect(payment).toMatchObject({
+      eventId: 'evt_one_time_completed',
+      carrierId: 'carrier_one_time_123',
+      stripeCustomerId: 'cus_one_time_123',
+      stripeCheckoutSessionId: 'cs_one_time_123',
+      stripePaymentIntentId: 'pi_one_time_123',
+      amountTotal: 4900,
+      currency: 'usd',
+      status: 'paid',
+      purchaseType: 'ai_addon_pack',
+      priceId: 'price_one_time_test',
+    });
   });
 
   it('blocks duplicate checkout when a carrier already has a Stripe customer', async () => {

--- a/apps/web/src/lib/billingApi.ts
+++ b/apps/web/src/lib/billingApi.ts
@@ -60,6 +60,19 @@ export async function createCheckoutSession(
   return response.data.data.url;
 }
 
+export async function createOneTimeCheckoutSession(
+  context: RequestContext,
+  purchaseType = 'ai_addon_pack',
+): Promise<string> {
+  const response = await api.post<ApiEnvelope<{ url: string }>>(
+    '/api/billing/one-time-checkout-session',
+    { purchaseType },
+    { headers: getHeaders(context) },
+  );
+
+  return response.data.data.url;
+}
+
 export async function createCustomerPortalSession(context: RequestContext): Promise<string> {
   const response = await api.post<ApiEnvelope<{ url: string }>>(
     '/api/billing/customer-portal',

--- a/docs/STRIPE_BILLING_AUTOMATION.md
+++ b/docs/STRIPE_BILLING_AUTOMATION.md
@@ -1,7 +1,7 @@
 # Stripe Billing Automation
 
 Date: May 3, 2026
-Status: Checkout, webhook sync, customer portal, webhook logging, duplicate checkout guard, Checkout Session return IDs, webhook replay protection, and AI usage ledger foundation added
+Status: Checkout, webhook sync, customer portal, webhook logging, duplicate checkout guard, Checkout Session return IDs, webhook replay protection, one-time add-on checkout, and AI usage ledger foundation added
 
 ## Purpose
 
@@ -11,11 +11,13 @@ The implementation adds:
 
 - Backend-created Stripe Checkout Sessions
 - Server-side Stripe Price ID selection
+- One-time add-on Checkout Sessions
 - Stripe webhook verification
 - Stripe webhook replay protection with a 5-minute signature timestamp tolerance
 - Stripe webhook event logging
 - Subscription/customer sync to `Carrier`
-- Duplicate checkout protection
+- One-time payment records in `StripeOneTimePayment`
+- Duplicate subscription checkout protection
 - Checkout Session ID return in success redirects
 - Owner/admin customer portal endpoint
 - AI usage ledger API and database table
@@ -37,6 +39,8 @@ Important implementation details:
 - `/api/billing/webhook` is registered before `express.json()` so the raw request body remains available for signature verification.
 - Webhook signatures are rejected when the timestamp is more than 5 minutes outside the server clock to reduce replay risk.
 - The endpoint should be used as the source of truth for fulfillment and billing sync. Do not mark billing state from the success page alone.
+- Subscription Checkout Sessions update carrier billing state.
+- One-time Checkout Sessions are recorded idempotently in `StripeOneTimePayment`.
 
 Verified events are logged to `StripeWebhookEvent` with status:
 
@@ -47,7 +51,7 @@ failed
 ignored
 ```
 
-### Checkout Session
+### Subscription Checkout Session
 
 ```http
 POST /api/billing/checkout-session
@@ -86,7 +90,32 @@ year
 
 The frontend sends only `plan` and `billingInterval`; the API maps those values to trusted server-side Stripe Price IDs. Do not accept raw prices or Price IDs from browser input.
 
-If a carrier already has a linked Stripe customer, checkout creation returns a conflict. Use the Customer Portal for billing changes after first checkout.
+If a carrier already has a linked Stripe customer, subscription checkout creation returns a conflict. Use the Customer Portal for billing changes after first checkout.
+
+### One-time add-on Checkout Session
+
+```http
+POST /api/billing/one-time-checkout-session
+```
+
+Required headers:
+
+```text
+x-tenant-id: <carrier id>
+x-user-role: owner | admin
+```
+
+Request:
+
+```json
+{
+  "purchaseType": "ai_addon_pack"
+}
+```
+
+This endpoint creates a Stripe Checkout Session in `payment` mode using the trusted server-side one-time Price ID from `STRIPE_PRICE_ONE_TIME` or `STRIPE_PRICE_AI_ADDON_PACK`.
+
+A linked Stripe customer is required before one-time add-ons can be purchased. This keeps add-on purchases tied to an existing carrier billing account.
 
 ### Customer portal
 
@@ -160,8 +189,9 @@ Returns aggregate usage totals for the current carrier.
 API:
 
 ```env
-STRIPE_SECRET_KEY=sk_live_...
-STRIPE_WEBHOOK_SECRET=whsec_...
+STRIPE_SECRET_KEY=replace-with-stripe-secret-key
+STRIPE_WEBHOOK_SECRET=replace-with-stripe-webhook-signing-secret
+STRIPE_PRICE_ONE_TIME=replace-with-one-time-price-id
 STRIPE_PORTAL_RETURN_URL=https://www.infamousfreight.com/settings
 STRIPE_CHECKOUT_SUCCESS_URL=https://www.infamousfreight.com/settings?checkout=success&session_id={CHECKOUT_SESSION_ID}
 STRIPE_CHECKOUT_CANCEL_URL=https://www.infamousfreight.com/settings?checkout=canceled
@@ -171,6 +201,7 @@ Optional fallback:
 
 ```env
 WEB_APP_URL=https://www.infamousfreight.com
+STRIPE_PRICE_AI_ADDON_PACK=replace-with-one-time-price-id
 ```
 
 If `STRIPE_CHECKOUT_SUCCESS_URL` does not include `session_id`, the API automatically appends `session_id={CHECKOUT_SESSION_ID}` before creating the Stripe Checkout Session.
@@ -230,6 +261,29 @@ incomplete
 inactive
 ```
 
+## One-time payment records
+
+`StripeOneTimePayment` stores one-time Checkout fulfillment records.
+
+Track:
+
+```text
+eventId
+carrierId
+stripeCustomerId
+stripeCheckoutSessionId
+stripePaymentIntentId
+amountTotal
+currency
+status
+purchaseType
+priceId
+createdAt
+updatedAt
+```
+
+`stripeCheckoutSessionId` is unique, so repeated webhook deliveries update the same payment record instead of duplicating fulfillment.
+
 ## Webhook event logs
 
 `StripeWebhookEvent` is used for operational debugging.
@@ -250,13 +304,24 @@ Use this table when Stripe shows an event was delivered but the app billing stat
 
 ## Checkout metadata
 
-Backend-created Checkout Sessions include metadata:
+Backend-created subscription Checkout Sessions include metadata:
 
 ```ts
 metadata: {
   carrierId,
   plan,
   billingInterval,
+}
+```
+
+One-time add-on Checkout Sessions include metadata:
+
+```ts
+metadata: {
+  carrierId,
+  purchaseType,
+  priceId,
+  mode: 'payment',
 }
 ```
 
@@ -305,19 +370,23 @@ Keep AI add-ons as one-time packs until the ledger has proven accuracy in produc
 After deployment:
 
 1. Add API env vars.
-2. Configure Stripe live webhook endpoint.
-3. Trigger a test event from Stripe Dashboard.
-4. Confirm `/api/billing/webhook` returns `200`.
-5. Start checkout from Settings → Billing & Plans using an internal carrier.
-6. Complete checkout.
-7. Confirm the success redirect includes `session_id`.
-8. Confirm the carrier row has:
+2. Run the Prisma migration for `StripeOneTimePayment`.
+3. Configure Stripe live webhook endpoint.
+4. Trigger a test event from Stripe Dashboard.
+5. Confirm `/api/billing/webhook` returns `200`.
+6. Start subscription checkout from Settings → Billing & Plans using an internal carrier.
+7. Complete subscription checkout.
+8. Confirm the success redirect includes `session_id`.
+9. Confirm the carrier row has:
    - `stripeCustomerId`
    - correct `subscriptionTier`
    - correct `status`
-9. Confirm `StripeWebhookEvent` logged the webhook as `processed`.
-10. Open customer portal from Settings as owner/admin.
-11. Record one AI usage event and confirm it appears in Settings → Billing & Plans.
+10. Start one-time add-on checkout for the same internal carrier.
+11. Complete one-time checkout.
+12. Confirm `StripeOneTimePayment` has a record for the Checkout Session.
+13. Confirm `StripeWebhookEvent` logged both webhooks as `processed`.
+14. Open customer portal from Settings as owner/admin.
+15. Record one AI usage event and confirm it appears in Settings → Billing & Plans.
 
 ## Notes
 


### PR DESCRIPTION
## Summary

- Add one-time Stripe Checkout Session helper using trusted server-side Price IDs.
- Add `/api/billing/one-time-checkout-session` for owner/admin add-on purchases tied to an existing Stripe customer.
- Record completed one-time Checkout Sessions from verified Stripe webhooks in `StripeOneTimePayment`.
- Add Prisma model and migration for one-time payment records.
- Add frontend billing API client for one-time add-on checkout.
- Update `.env.example` and Stripe billing runbook with one-time payment setup and validation steps.
- Add helper tests for one-time Checkout Session payloads and one-time webhook extraction.

## Notes

The Settings UI panel hook-up was intentionally kept out after the large UI replacement was blocked by tooling; the API client is present and ready for a small follow-up UI patch.

## Validation

- Added API billing helper tests.
- Not run locally in this environment.