### PR TITLE
Fix Fly runtime port and deploy convergence

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -139,7 +139,14 @@ jobs:
         uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1  # master (2026-04-08)
 
       - name: Deploy to Fly.io
-        run: flyctl deploy --remote-only --app infamous-freight
+        run: flyctl deploy --remote-only --wait-timeout 10m --strategy rolling --app infamous-freight
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+      - name: Verify Fly.io release convergence
+        run: |
+          flyctl status --app infamous-freight
+          flyctl checks list --app infamous-freight
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
@@ -151,6 +158,7 @@ jobs:
             echo ""
             echo "Target: Fly.io app infamous-freight"
             echo "API: https://api.infamousfreight.com"
+            echo "Deploy command: flyctl deploy --remote-only --wait-timeout 10m --strategy rolling --app infamous-freight"
           } >> "$GITHUB_STEP_SUMMARY"
 
   # ===== NOTIFY =====

--- a/fly.toml
+++ b/fly.toml
@@ -12,7 +12,7 @@ primary_region = 'dfw'
 [env]
   HOST = '0.0.0.0'
   NODE_ENV = 'production'
-  PORT = '3000'
+  PORT = '8080'
 
 [http_service]
   internal_port = 8080


### PR DESCRIPTION
## Summary

- Align Fly runtime `PORT` with `http_service.internal_port` by setting `PORT=8080` in `fly.toml`.
- Deploy with `flyctl deploy --remote-only --wait-timeout 10m --strategy rolling --app infamous-freight` so GitHub Actions waits for rollout convergence.
- Add post-deploy Fly status/checks output so mixed-image or failed-health situations are visible in CI.

## Why

The Fly dashboard shows two machines running different images and health checks at `0/1`. The app was configured with `PORT=3000` while Fly routes/checks `internal_port=8080`, which can cause failed health checks and unstable rollout behavior.

## Validation

- Not run locally in this environment.