### PR TITLE
Use Fly immediate deploy strategy under machine limit

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -139,7 +139,7 @@ jobs:
         uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1  # master (2026-04-08)
 
       - name: Deploy to Fly.io
-        run: flyctl deploy --remote-only --wait-timeout 10m --strategy rolling --app infamous-freight
+        run: flyctl deploy --remote-only --wait-timeout 10m --strategy immediate --app infamous-freight
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
@@ -158,7 +158,7 @@ jobs:
             echo ""
             echo "Target: Fly.io app infamous-freight"
             echo "API: https://api.infamousfreight.com"
-            echo "Deploy command: flyctl deploy --remote-only --wait-timeout 10m --strategy rolling --app infamous-freight"
+            echo "Deploy command: flyctl deploy --remote-only --wait-timeout 10m --strategy immediate --app infamous-freight"
           } >> "$GITHUB_STEP_SUMMARY"
 
   # ===== NOTIFY =====

--- a/fly.toml
+++ b/fly.toml
@@ -9,6 +9,10 @@ primary_region = 'dfw'
 [build]
   dockerfile = 'Dockerfile'
 
+[deploy]
+  strategy = 'immediate'
+  wait_timeout = '10m'
+
 [env]
   HOST = '0.0.0.0'
   NODE_ENV = 'production'


### PR DESCRIPTION
## Summary

- Set Fly deploy strategy to `immediate` in `fly.toml`.
- Update GitHub Actions deploy command to use `--strategy immediate`.
- Keep `PORT=8080` aligned with Fly `internal_port=8080`.

## Why

Fly deploy is failing because the organization has reached its Machine limit. Rolling updates can require replacement capacity during the rollout. `immediate` updates existing Machines directly, which is the safest unblocker under the current limit, with the tradeoff that a brief API interruption is possible during deploy.

## Validation

- Not run locally in this environment.