### PR TITLE
Fix public homepage route

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -51,8 +51,8 @@ function App() {
       <Suspense fallback={<RouteFallback />}>
         <SeoManager />
         <Routes>
+        <Route path="/" element={<LandingPage />} />
         <Route element={<AppLayout />}>
-          <Route path="/" element={<DashboardPage />} />
           <Route path="/ops" element={<DashboardPage />} />
           <Route path="/loads" element={<LoadsPage />} />
           <Route path="/dispatch" element={<DispatchBoardPage />} />


### PR DESCRIPTION
This changes the public root path to render the marketing landing page and keeps the operations dashboard available at /ops. This should address the blank black homepage / NO_FCP behavior on the production domain.