### PR TITLE
Add static homepage fallback

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -12,67 +12,18 @@
       name="description"
       content="Infamous Freight is an AI-powered freight command center with auto-dispatch, rate negotiation, voice booking, ELD sync, and end-to-end shipment visibility."
     />
-    <meta
-      name="keywords"
-      content="freight management system, trucking dispatch software, AI dispatch, TMS, rate negotiation, ELD integration"
-    />
-
-    <meta property="og:type" content="website" />
-    <meta property="og:site_name" content="Infamous Freight" />
-    <meta property="og:locale" content="en_US" />
-    <meta property="og:url" content="https://www.infamousfreight.com/" />
-    <meta property="og:title" content="Infamous Freight — AI Freight Command Center" />
-    <meta
-      property="og:description"
-      content="Run dispatch, visibility, and carrier operations from one AI-powered operating system built for modern fleets."
-    />
-    <!--
-      Share image is rendered as PNG through Netlify Image CDN so that platforms
-      that do not support SVG previews (Facebook, LinkedIn, Slack, iMessage, X)
-      receive a 1200x630 PNG. Source asset lives at /public/og-image.svg.
-    -->
-    <meta
-      property="og:image"
-      content="https://www.infamousfreight.com/.netlify/images?url=/og-image.svg&w=1200&h=630&fit=cover&fm=png"
-    />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
-    <meta property="og:image:alt" content="Infamous Freight AI Freight Command Center" />
-
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Infamous Freight — AI Freight Command Center" />
-    <meta
-      name="twitter:description"
-      content="Automate dispatch workflows, improve lane decisions, and keep customers informed in real time."
-    />
-    <meta
-      name="twitter:image"
-      content="https://www.infamousfreight.com/.netlify/images?url=/og-image.svg&w=1200&h=630&fit=cover&fm=png"
-    />
-    <meta name="twitter:image:alt" content="Infamous Freight AI Freight Command Center" />
-
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link rel="preconnect" href="https://infamous-freight.fly.dev" crossorigin />
-    <link rel="preconnect" href="https://js.stripe.com" crossorigin />
-    <link rel="dns-prefetch" href="https://api.infamousfreight.com" />
-    <link
-      rel="preload"
-      as="style"
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap"
-    />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap"
-      rel="stylesheet"
-    />
-
     <title>Infamous Freight — AI Freight Command Center</title>
     <style>
+      html,
+      body,
+      #root {
+        min-height: 100%;
+      }
       body {
         background: #0a0a0a;
+        color: #f8fafc;
         margin: 0;
-        font-family: 'Inter', system-ui, sans-serif;
+        font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       }
       .skip-link {
         position: absolute;
@@ -89,11 +40,53 @@
         border-radius: 6px;
         text-decoration: none;
       }
+      .app-shell-fallback {
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 24px;
+        background: radial-gradient(circle at top left, rgba(255, 106, 0, 0.2), transparent 32rem), #0a0a0a;
+        color: #f8fafc;
+        text-align: center;
+      }
+      .app-shell-fallback__card {
+        max-width: 560px;
+      }
+      .app-shell-fallback__eyebrow {
+        color: #ff8a33;
+        font-size: 0.8rem;
+        font-weight: 800;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        margin: 0 0 0.75rem;
+      }
+      .app-shell-fallback__title {
+        font-size: clamp(2rem, 7vw, 4rem);
+        line-height: 0.95;
+        margin: 0 0 1rem;
+      }
+      .app-shell-fallback__copy {
+        color: #cbd5e1;
+        font-size: 1rem;
+        line-height: 1.65;
+        margin: 0;
+      }
     </style>
   </head>
   <body>
     <a class="skip-link" href="#main-content">Skip to main content</a>
-    <div id="root"></div>
+    <div id="root">
+      <main class="app-shell-fallback" aria-live="polite">
+        <section class="app-shell-fallback__card">
+          <p class="app-shell-fallback__eyebrow">Infamous Freight</p>
+          <h1 class="app-shell-fallback__title">Loading freight command center...</h1>
+          <p class="app-shell-fallback__copy">
+            Dispatch, visibility, rate tools, and carrier operations are loading.
+          </p>
+        </section>
+      </main>
+    </div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
Adds visible static fallback markup inside the app root so production never appears as a blank black screen while the React app is loading. This complements the homepage route fix already merged.