### PR TITLE
fix(web): align @stripe/stripe-js with @stripe/react-stripe-js peer range

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@sentry/react": "^8.55.1",
     "@stripe/react-stripe-js": "^6.3.0",
-    "@stripe/stripe-js": "^2.2.0",
+    "@stripe/stripe-js": "^9.3.1",
     "@supabase/supabase-js": "^2.105.3",
     "axios": "^1.16.0",
     "class-variance-authority": "^0.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,10 +83,10 @@ importers:
         version: 8.55.2(react@18.3.1)
       '@stripe/react-stripe-js':
         specifier: ^6.3.0
-        version: 6.3.0(@stripe/stripe-js@2.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 6.3.0(@stripe/stripe-js@9.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@stripe/stripe-js':
-        specifier: ^2.2.0
-        version: 2.4.0
+        specifier: ^9.3.1
+        version: 9.4.0
       '@supabase/supabase-js':
         specifier: ^2.105.3
         version: 2.105.3
@@ -1479,8 +1479,9 @@ packages:
       react: '>=16.8.0 <20.0.0'
       react-dom: '>=16.8.0 <20.0.0'
 
-  '@stripe/stripe-js@2.4.0':
-    resolution: {integrity: sha512-WFkQx1mbs2b5+7looI9IV1BLa3bIApuN3ehp9FP58xGg7KL9hCHDECgW3BwO9l9L+xBPVAD7Yjn1EhGe6EDTeA==}
+  '@stripe/stripe-js@9.4.0':
+    resolution: {integrity: sha512-zXG86DnoLU5nH2U18tX5ApTE3IAm+txoiPm4YFyEtRS0K5y7ZDH9M8e1Le/cZyI6wvW3BkJn2daZe2FqZOrSSg==}
+    engines: {node: '>=12.16'}
 
   '@supabase/auth-js@2.105.3':
     resolution: {integrity: sha512-hMFuzP++mjRfe0/BUq4/e82CXIDgyjUgg0khLN8waol/gzoM1t2iGmhfJSGvQHQ1dr3XqWpP6ThAw4bLHMot5Q==}
@@ -5530,14 +5531,14 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
-  '@stripe/react-stripe-js@6.3.0(@stripe/stripe-js@2.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@stripe/react-stripe-js@6.3.0(@stripe/stripe-js@9.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@stripe/stripe-js': 2.4.0
+      '@stripe/stripe-js': 9.4.0
       prop-types: 15.8.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@stripe/stripe-js@2.4.0': {}
+  '@stripe/stripe-js@9.4.0': {}
 
   '@supabase/auth-js@2.105.3':
     dependencies:


### PR DESCRIPTION
### Motivation
- The monorepo `npm install` in `apps/api` failed with an `ERESOLVE` peer dependency error because `@stripe/react-stripe-js@6.3.0` requires `@stripe/stripe-js >=9.3.1 <10.0.0` while the web workspace declared an older `^2.x` range. 
- Aligning the Stripe JS runtime package to the peer range prevents dependency-resolution failures across workspace installs.

### Description
- Updated `apps/web/package.json` to set `@stripe/stripe-js` to `^9.3.1` so it satisfies `@stripe/react-stripe-js@6.3.0`'s peer range. 
- Regenerated lockfile entries in `pnpm-lock.yaml` so the workspace resolves `@stripe/stripe-js@9.4.0` and the `@stripe/react-stripe-js` snapshot references that version. 
- Ensured the lockfile still exposes the `@stripe/react-stripe-js` peer requirement `'>=9.3.1 <10.0.0'` and that the selected version complies with it.

### Testing
- Ran `pnpm install --filter @infamous-freight/web` which completed successfully. 
- Ran `cd apps/api && npm install --no-save --no-package-lock` which previously errored but completed successfully after the change. 
- Verified dependency entries in `apps/web/package.json` and `pnpm-lock.yaml` reflect the updated versions and peer alignment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9a7fc3aac8330a5a6f682186225b2)