### PR TITLE
Harden Codex env setup and add rebase procedure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,16 @@
 # ============================================================
 # INFAMOUS FREIGHT — Environment Variables
-# Copy this file to .env and fill in your real values
+# Copy this file to .env for local development.
+# Do not commit real secret values.
 # ============================================================
+
+# ——— Runtime ———
+NODE_ENV=development
+PORT=3001
+WEB_APP_URL=http://localhost:5173
+CORS_ORIGIN=http://localhost:5173
+# Use CORS_ORIGINS for multiple comma-separated origins in shared/dev/prod environments.
+# CORS_ORIGINS=http://localhost:5173,http://localhost:3000
 
 # ——— Database ———
 DATABASE_URL=postgresql://infamous:changeme@localhost:5432/infamous_freight?schema=public
@@ -9,19 +18,17 @@ DB_USER=infamous
 DB_PASSWORD=changeme
 DB_NAME=infamous_freight
 
+# ——— API security ———
+JWT_SECRET=replace-this-in-production
+RATE_LIMIT_ENABLED=true
+# Legacy compatibility for older scripts:
+API_RATE_LIMIT_ENABLED=true
+
 # ——— Redis ———
 REDIS_HOST=localhost
 REDIS_PORT=6379
 REDIS_PASSWORD=changeme
 REDIS_DB=0
-
-# ——— API ———
-NODE_ENV=development
-PORT=3001
-JWT_SECRET=replace-this-in-production
-RATE_LIMIT_ENABLED=true
-# Legacy compatibility for older scripts:
-API_RATE_LIMIT_ENABLED=true
 
 # ——— Observability ———
 SENTRY_DSN=https://example.invalid/sentry-dsn
@@ -30,22 +37,24 @@ SENTRY_DSN=https://example.invalid/sentry-dsn
 STRIPE_SECRET_KEY=replace-with-stripe-secret-key
 STRIPE_WEBHOOK_SECRET=replace-with-stripe-webhook-signing-secret
 STRIPE_PUBLISHABLE_KEY=replace-with-stripe-publishable-key
+VITE_STRIPE_PUBLIC_KEY=replace-with-stripe-publishable-key
 STRIPE_PRICE_ONE_TIME=replace-with-one-time-price-id
 # Legacy alias supported by the API for the same one-time add-on price:
 STRIPE_PRICE_AI_ADDON_PACK=replace-with-one-time-price-id
 STRIPE_PORTAL_RETURN_URL=http://localhost:5173/settings
 STRIPE_CHECKOUT_SUCCESS_URL=http://localhost:5173/settings?checkout=success&session_id={CHECKOUT_SESSION_ID}
 STRIPE_CHECKOUT_CANCEL_URL=http://localhost:5173/settings?checkout=canceled
-WEB_APP_URL=http://localhost:5173
 
 # ——— Supabase ———
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_SERVICE_KEY=your-service-key
-# Legacy alias used by some older templates/tooling:
+# Preferred service-role alias for newer tooling:
 SUPABASE_SERVICE_ROLE_KEY=your-service-key
 SUPABASE_ANON_KEY=your-anon-key
 VITE_SUPABASE_URL=https://your-project.supabase.co
 VITE_SUPABASE_PUBLISHABLE_KEY=sb_publishable_your_key
+# Legacy frontend alias accepted by the Codex checker:
+VITE_SUPABASE_ANON_KEY=your-anon-key
 
 # ——— Load Board APIs ———
 DAT_API_KEY=your-dat-api-key
@@ -76,5 +85,4 @@ APEX_API_KEY=your-apex-key
 
 # ——— Web Frontend ———
 VITE_API_URL=http://localhost:3001
-VITE_STRIPE_PUBLIC_KEY=replace-with-stripe-publishable-key
 VITE_SOCKET_URL=ws://localhost:3001

--- a/docs/CODEX_ENVIRONMENT.md
+++ b/docs/CODEX_ENVIRONMENT.md
@@ -2,6 +2,16 @@
 
 This document explains how to configure OpenAI Codex for the Infamous Freight repository without exposing sensitive values.
 
+## What is already safe in the repo
+
+The repository includes a safe example file and a safe environment checker:
+
+- `.env.example` lists variable names and development placeholders only.
+- `scripts/codex-env-check.sh` checks whether variables are present without printing secret values.
+- `.gitignore` ignores local `.env` files while allowing checked-in example files.
+
+Do not commit real `.env`, Stripe, Supabase, database, SendGrid, Sentry, or carrier API secret values.
+
 ## Required Codex environment variables
 
 Add these in the Codex **Environment variables** section when Codex needs to build, test, or run the full app:
@@ -11,35 +21,61 @@ NODE_ENV=development
 DATABASE_URL=[POSTGRES_CONNECTION_STRING]
 STRIPE_SECRET_KEY=[STRIPE_SECRET_KEY]
 STRIPE_WEBHOOK_SECRET=[STRIPE_WEBHOOK_SECRET]
-STRIPE_PUBLISHABLE_KEY=[STRIPE_PUBLISHABLE_KEY]
-VITE_STRIPE_PUBLIC_KEY=[STRIPE_PUBLISHABLE_KEY]
 SUPABASE_URL=[SUPABASE_PROJECT_URL]
-SUPABASE_SERVICE_KEY=[SUPABASE_SERVICE_KEY]
-SUPABASE_ANON_KEY=[SUPABASE_ANON_KEY]
 VITE_SUPABASE_URL=[SUPABASE_PROJECT_URL]
-VITE_SUPABASE_PUBLISHABLE_KEY=[SUPABASE_PUBLISHABLE_KEY]
+SUPABASE_SERVICE_ROLE_KEY=[SUPABASE_SERVICE_ROLE_KEY]
+VITE_SUPABASE_ANON_KEY=[SUPABASE_ANON_KEY]
+WEB_APP_URL=http://localhost:5173
+CORS_ORIGIN=http://localhost:5173
 ```
+
+The checker accepts either name in each one-of group:
+
+```env
+SUPABASE_SERVICE_KEY=[SUPABASE_SERVICE_ROLE_KEY]
+# or
+SUPABASE_SERVICE_ROLE_KEY=[SUPABASE_SERVICE_ROLE_KEY]
+
+VITE_SUPABASE_PUBLISHABLE_KEY=[SUPABASE_PUBLISHABLE_OR_ANON_KEY]
+# or
+VITE_SUPABASE_ANON_KEY=[SUPABASE_ANON_KEY]
+
+CORS_ORIGINS=http://localhost:5173
+# or
+CORS_ORIGIN=http://localhost:5173
+```
+
+## Recommended local development defaults
+
+Use these non-secret values for local development:
+
+```env
+NODE_ENV=development
+PORT=3001
+WEB_APP_URL=http://localhost:5173
+CORS_ORIGIN=http://localhost:5173
+STRIPE_CHECKOUT_SUCCESS_URL=http://localhost:5173/billing/success
+STRIPE_CHECKOUT_CANCEL_URL=http://localhost:5173/billing/cancel
+STRIPE_PORTAL_RETURN_URL=http://localhost:5173/billing
+VITE_API_URL=http://localhost:3001
+VITE_SOCKET_URL=ws://localhost:3001
+```
+
+Use test/dev keys for Stripe, Supabase, and database credentials. Do not use production credentials in local or experimental Codex environments unless the task explicitly requires production verification.
 
 ## Optional integration variables
 
 Use these only when testing the related integrations:
 
 ```env
-PORT=3001
-CORS_ORIGINS=[ALLOWED_ORIGINS]
-WEB_APP_URL=[WEB_APP_URL]
-STRIPE_CHECKOUT_SUCCESS_URL=[CHECKOUT_SUCCESS_URL]
-STRIPE_CHECKOUT_CANCEL_URL=[CHECKOUT_CANCEL_URL]
-STRIPE_PORTAL_RETURN_URL=[CUSTOMER_PORTAL_RETURN_URL]
 REDIS_HOST=[REDIS_HOST]
 REDIS_PORT=6379
 REDIS_PASSWORD=[REDIS_PASSWORD]
 REDIS_DB=0
 JWT_SECRET=[JWT_SECRET]
+RATE_LIMIT_ENABLED=true
 API_RATE_LIMIT_ENABLED=true
 SENTRY_DSN=[SENTRY_DSN]
-VITE_API_URL=[API_URL]
-VITE_SOCKET_URL=[SOCKET_URL]
 VITE_SENTRY_DSN=[PUBLIC_SENTRY_DSN]
 VITE_SENTRY_ENABLED=true
 SENTRY_ORG=[SENTRY_ORG]
@@ -75,13 +111,13 @@ Secrets may not be available to the Codex agent after setup, so do not put app r
 Run this after saving the Codex environment:
 
 ```bash
-npm run codex:env-check
+pnpm run codex:env-check
 ```
 
 For automation or preflight checks that should fail when required variables are missing, run:
 
 ```bash
-npm run codex:env-check:strict
+pnpm run codex:env-check:strict
 ```
 
 Or run the script directly:
@@ -106,17 +142,17 @@ That prints full environment variable values, including private keys.
 ## Recommended Codex flow
 
 ```bash
-npm run env:setup
-npm run codex:env-check
-npm run prisma:generate
-npm run build
-npm run test
+pnpm install --frozen-lockfile
+pnpm run codex:env-check
+pnpm run prisma:generate
+pnpm run build
+pnpm run test
 ```
 
 Use strict mode before declaring the environment ready:
 
 ```bash
-npm run codex:env-check:strict
+pnpm run codex:env-check:strict
 ```
 
-If `npm run codex:env-check` reports a missing value, add it to the Codex environment and save the environment before running Codex again.
+If `pnpm run codex:env-check` reports a missing value, add it to the Codex environment and save the environment before running Codex again.

--- a/docs/SAFE_REBASE_PROCEDURE.md
+++ b/docs/SAFE_REBASE_PROCEDURE.md
@@ -1,0 +1,104 @@
+# Safe Rebase Procedure
+
+Use this procedure when rebasing an Infamous Freight feature branch onto `main` or another target branch.
+
+## Before rebasing
+
+Do not rebase a shared branch that multiple people are actively using unless the team has agreed to rewrite history.
+
+Create and push a backup branch first:
+
+```bash
+git status
+git checkout <source-branch>
+git fetch origin
+git branch <source-branch>-backup
+git push origin <source-branch>-backup
+```
+
+## Rebase onto the target branch
+
+For the usual case, rebase the source branch onto `origin/main`:
+
+```bash
+git checkout <source-branch>
+git fetch origin
+git rebase origin/main
+```
+
+Use interactive rebase only when you need to reorder, squash, or fix up commits:
+
+```bash
+git rebase -i origin/main
+```
+
+## Resolve conflicts
+
+For each conflict:
+
+```bash
+# Edit conflicted files.
+git add <file>
+git rebase --continue
+```
+
+Abort the rebase if the branch gets into a bad state:
+
+```bash
+git rebase --abort
+git checkout <source-branch>-backup
+```
+
+## Validate after rebasing
+
+Run the repository checks before pushing:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm run codex:env-check
+pnpm run prisma:generate
+pnpm run lint
+pnpm run build
+pnpm run test
+```
+
+Run strict environment validation when the task depends on all required runtime variables:
+
+```bash
+pnpm run codex:env-check:strict
+```
+
+## Push safely
+
+Use force-with-lease, not a plain force push:
+
+```bash
+git push --force-with-lease origin HEAD:<source-branch>
+```
+
+This protects against overwriting someone else’s newer remote work.
+
+## PR follow-up
+
+After pushing:
+
+- Confirm GitHub Actions starts a fresh run.
+- Confirm CI passes.
+- Leave a short PR comment that says the branch was rebased and lists any manual conflict fixes.
+- Do not merge until the new post-rebase checks pass.
+
+Example PR comment:
+
+```text
+Rebased this branch onto origin/main. Resolved conflicts locally and reran env check, lint, build, and tests before pushing with --force-with-lease.
+```
+
+## Special cases
+
+Use `--onto` only when moving a specific commit range:
+
+```bash
+git rebase --onto <new-base> <old-base> <source-branch>
+```
+
+Prefer merging `main` into the branch instead of rebasing when the branch is long-running or shared by multiple developers.


### PR DESCRIPTION
## Summary
- Clarifies required Codex runtime environment variables in `.env.example`.
- Updates `docs/CODEX_ENVIRONMENT.md` with the required variables, one-of aliases, safe verification commands, and secret-handling guidance.
- Adds `docs/SAFE_REBASE_PROCEDURE.md` with backup, rebase, validation, and force-with-lease guidance.

## Safety
- No real secret values are added.
- Existing `.gitignore` protection for local `.env` files remains in place.

## Validation
- Repository checks should be run after real Codex environment variables are configured:
  - `pnpm run codex:env-check`
  - `pnpm run codex:env-check:strict`
  - `pnpm run lint`
  - `pnpm run build`
  - `pnpm run test`