### PR TITLE
Fix Jest Prisma module resolution and add production secrets / Stripe hardening docs

### DIFF
--- a/apps/api/jest.config.js
+++ b/apps/api/jest.config.js
@@ -1,8 +1,12 @@
+const path = require('path');
+
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   roots: ['<rootDir>/test'],
   moduleNameMapper: {
-    '^@prisma/client$': '<rootDir>/node_modules/@prisma/client/index.js',
+    '^@prisma/client$': require.resolve('@prisma/client', {
+      paths: [path.resolve(__dirname), path.resolve(__dirname, '..', '..')],
+    }),
   },
 };

--- a/docs/production-operations/GITHUB_EXECUTION_BACKLOG.md
+++ b/docs/production-operations/GITHUB_EXECUTION_BACKLOG.md
@@ -26,3 +26,44 @@
 - [ ] Validate BOC-3 filing
 - [ ] Validate carrier packet workflow
 - [ ] Validate document retention process
+
+## Production Dashboard Hardening Follow-ups
+
+### Summary
+
+Track remaining production dashboard work after the environment and billing hardening changes were merged.
+
+### Execution checklist (production)
+
+- [ ] Review all production environment variables in the deployment provider dashboard and set every secret token/key to **Secret/Sensitive** visibility.
+- [ ] Rotate any credential that was ever stored as plain text or visible in dashboard history.
+- [ ] Re-add rotated credentials only through provider secret-management controls (never via git, issue comments, chat, screenshots, or logs).
+- [ ] Configure the production Stripe webhook endpoint to the production API billing webhook route.
+- [ ] Add `STRIPE_WEBHOOK_SECRET` (live) via secret-management controls.
+- [ ] Use a restricted live key for server-side Stripe operations where supported.
+- [ ] Add `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` (live publishable) for frontend checkout flows.
+- [ ] Trigger a fresh production deployment after environment updates.
+- [ ] Verify checkout, webhooks, customer portal, subscription lifecycle transitions, and billing access updates end-to-end.
+
+### Required Stripe webhook events
+
+- `checkout.session.completed`
+- `customer.subscription.created`
+- `customer.subscription.updated`
+- `customer.subscription.deleted`
+- `invoice.payment_succeeded`
+- `invoice.payment_failed`
+- `payment_intent.succeeded`
+- `payment_intent.payment_failed`
+
+### Verification evidence to capture
+
+- [ ] Deployment revision ID for the release containing rotated credentials.
+- [ ] Timestamped screenshot/export showing secret visibility is masked for production environment entries.
+- [ ] Stripe webhook delivery success sample for each required event type.
+- [ ] One successful live checkout + subscription activation record.
+- [ ] One failed payment simulation and expected access downgrade/recovery behavior.
+
+### Security notes
+
+Do not paste credentials into GitHub issues, comments, chat, screenshots, build logs, or source files.

--- a/docs/production-operations/PRODUCTION_SECRETS_SETUP.md
+++ b/docs/production-operations/PRODUCTION_SECRETS_SETUP.md
@@ -66,6 +66,36 @@ If Netlify needs a site ID, set it explicitly:
 NETLIFY_SITE_ID=<site-id> bash scripts/setup-production-secrets.sh .env.production.secrets
 ```
 
+
+## Stripe production hardening checklist
+
+Complete these after applying or rotating production secrets:
+
+- [ ] Confirm all Stripe runtime values are stored as hidden/secret values in provider settings.
+- [ ] Rotate any Stripe key or webhook signing secret previously entered as visible/plain-text.
+- [ ] Re-add rotated values only via secret managers (never in git, comments, screenshots, or logs).
+- [ ] Use a restricted live secret key for backend operations when endpoint compatibility allows.
+- [ ] Ensure the frontend uses only `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`.
+- [ ] Trigger a fresh Fly.io API deploy and a fresh Netlify production deploy after updates.
+
+Required webhook events:
+
+- `checkout.session.completed`
+- `customer.subscription.created`
+- `customer.subscription.updated`
+- `customer.subscription.deleted`
+- `invoice.payment_succeeded`
+- `invoice.payment_failed`
+- `payment_intent.succeeded`
+- `payment_intent.payment_failed`
+
+Validation steps:
+
+- [ ] Successful checkout.session and subscription activation path.
+- [ ] Webhook delivery success for each required event type.
+- [ ] Customer portal access from production billing UI.
+- [ ] Failed payment flow updates access state correctly.
+
 ## Required dashboard checks
 
 ### Stripe


### PR DESCRIPTION
### Motivation

- Ensure Jest in the `apps/api` package resolves `@prisma/client` reliably across monorepo layouts and avoid brittle hard-coded module path mappings. 
- Capture remaining production dashboard and secrets hardening tasks after recent environment and billing changes. 
- Provide an explicit Stripe webhook and verification checklist to prevent missed production billing configurations.

### Description

- Replace the brittle `moduleNameMapper` string mapping for `@prisma/client` in `apps/api/jest.config.js` with a `require.resolve` call and add a `path` import so Jest can resolve the package using explicit `paths` rooted at the package and repository levels. 
- Add a `Production Dashboard Hardening Follow-ups` section to `docs/production-operations/GITHUB_EXECUTION_BACKLOG.md` containing a production execution checklist, required Stripe webhook events, verification evidence to capture, and security notes. 
- Add a `Stripe production hardening checklist` section to `docs/production-operations/PRODUCTION_SECRETS_SETUP.md` with guidance to rotate and store Stripe secrets properly, required webhook events, and validation steps for production billing flows. 

### Testing

- Ran the `apps/api` Jest test run to validate the updated resolver configuration for `@prisma/client`, and the test run completed successfully. 
- Documentation updates were added and require no automated tests but were linted/previewed as plain markdown without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb28bed9ec83308602f209a2f55cfb)