### PR TITLE
ci: add Docker build check workflow

### DIFF
--- a/.github/workflows/docker-build-check.yml
+++ b/.github/workflows/docker-build-check.yml
@@ -1,0 +1,15 @@
+name: Docker Build Check
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Docker image
+        run: docker build -t infamous-freight-check -f Dockerfile .


### PR DESCRIPTION
## Summary
Adds a GitHub Actions workflow to verify the Docker image build in CI.

## Why
Docker image build verification was blocked in the Codex/container environment because the Docker daemon could not start due to container/kernel permission restrictions. This moves the remaining Docker verification into GitHub Actions, which provides a Docker-capable runner.

## Previously verified
- Prisma generation passed
- API build passed
- Web build passed
- API Jest suite passed
- Runtime /health check passed

## Docker verification
This PR adds CI coverage for:

```bash
docker build -t infamous-freight-check -f Dockerfile .
```

Production-readiness verification is fully complete once this GitHub Actions check passes.