### PR TITLE
test(api): isolate Stripe secret env in billing helper tests

### DIFF
--- a/apps/api/test/billing-helpers.test.ts
+++ b/apps/api/test/billing-helpers.test.ts
@@ -327,6 +327,10 @@ describe('getBillingPortalReturnUrl', () => {
 });
 
 describe('createStripeCheckoutSession error paths', () => {
+  beforeEach(() => {
+    delete process.env.STRIPE_SECRET_KEY;
+  });
+
   afterEach(() => {
     delete process.env.STRIPE_SECRET_KEY;
     jest.restoreAllMocks();


### PR DESCRIPTION
## Summary
Fixes the billing helper test suite so the `STRIPE_SECRET_KEY` environment variable is cleared before the error-path test that expects `stripe_secret_key_required`.

## Why
The required checks workflow provides a CI Stripe test key globally. That made the missing-secret test call Stripe with the CI placeholder key instead of exercising the intended missing-secret branch.

## Validation context
- PR #1912 merged with Docker Build Check passing on the latest PR head.
- This follow-up isolates the test environment so Required Checks can exercise the intended billing error path.

## Scope
- Test-only change in `apps/api/test/billing-helpers.test.ts`.