### PR TITLE
Use @prisma/adapter-pg for Prisma client and add CI fail-fast for Prisma init errors

### DIFF
--- a/.github/workflows/full-validation.yml
+++ b/.github/workflows/full-validation.yml
@@ -96,33 +96,6 @@ jobs:
             -p 3000:3000 \
             "$IMAGE_NAME"
 
-      - name: Fail fast on Prisma runtime initialization errors
-        run: |
-          for i in {1..30}; do
-            if ! docker ps --format '{{.Names}}' | grep -qx "$CONTAINER_NAME"; then
-              echo "Container exited before runtime checks." >&2
-              docker logs "$CONTAINER_NAME" || true
-              exit 1
-            fi
-
-            if docker logs "$CONTAINER_NAME" 2>&1 | grep -Eiq 'Prisma(Client)?InitializationError|PrismaClientConstructorValidationError|PrismaClientRustPanicError|PrismaClientKnownRequestError|Invalid.*PrismaClient|Error validating datasource'; then
-              echo "Detected Prisma runtime initialization failure in container logs." >&2
-              docker logs "$CONTAINER_NAME" || true
-              exit 1
-            fi
-
-            if curl -fsS http://127.0.0.1:3000/api/health/live >/dev/null; then
-              echo "Runtime reached /api/health/live without Prisma initialization errors."
-              exit 0
-            fi
-
-            sleep 2
-          done
-
-          echo "Timed out waiting for runtime startup signal from /api/health/live." >&2
-          docker logs "$CONTAINER_NAME" || true
-          exit 1
-
       - name: Probe Docker healthcheck
         run: |
           for i in {1..60}; do

--- a/.github/workflows/full-validation.yml
+++ b/.github/workflows/full-validation.yml
@@ -96,6 +96,33 @@ jobs:
             -p 3000:3000 \
             "$IMAGE_NAME"
 
+      - name: Fail fast on Prisma runtime initialization errors
+        run: |
+          for i in {1..30}; do
+            if ! docker ps --format '{{.Names}}' | grep -qx "$CONTAINER_NAME"; then
+              echo "Container exited before runtime checks." >&2
+              docker logs "$CONTAINER_NAME" || true
+              exit 1
+            fi
+
+            if docker logs "$CONTAINER_NAME" 2>&1 | grep -Eiq 'Prisma(Client)?InitializationError|PrismaClientConstructorValidationError|PrismaClientRustPanicError|PrismaClientKnownRequestError|Invalid.*PrismaClient|Error validating datasource'; then
+              echo "Detected Prisma runtime initialization failure in container logs." >&2
+              docker logs "$CONTAINER_NAME" || true
+              exit 1
+            fi
+
+            if curl -fsS http://127.0.0.1:3000/api/health/live >/dev/null; then
+              echo "Runtime reached /api/health/live without Prisma initialization errors."
+              exit 0
+            fi
+
+            sleep 2
+          done
+
+          echo "Timed out waiting for runtime startup signal from /api/health/live." >&2
+          docker logs "$CONTAINER_NAME" || true
+          exit 1
+
       - name: Probe Docker healthcheck
         run: |
           for i in {1..60}; do

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,6 +18,7 @@
     "prisma:generate": "pnpm exec prisma generate --schema prisma/schema.prisma"
   },
   "dependencies": {
+    "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "7.8.0",
     "@prisma/extension-accelerate": "3.0.1",
     "@sentry/node": "^10.51.0",

--- a/apps/api/src/prisma-client.ts
+++ b/apps/api/src/prisma-client.ts
@@ -1,25 +1,11 @@
+import { PrismaPg } from '@prisma/adapter-pg';
 import { PrismaClient } from '@prisma/client';
-
-type AccelerateExtension = Parameters<PrismaClient['$extends']>[0];
 
 let client: PrismaClient | null = null;
 
 const globalForPrisma = globalThis as unknown as {
   __infamousPrismaClient?: PrismaClient;
 };
-
-function loadAccelerateExtension(): (() => AccelerateExtension) | null {
-  try {
-    const accelerateModule = require('@prisma/extension-accelerate') as {
-      withAccelerate?: () => AccelerateExtension;
-    };
-    return typeof accelerateModule.withAccelerate === 'function'
-      ? accelerateModule.withAccelerate
-      : null;
-  } catch {
-    return null;
-  }
-}
 
 export function createPrismaClient(): PrismaClient {
   if (client) return client;
@@ -34,31 +20,12 @@ export function createPrismaClient(): PrismaClient {
 
   const databaseUrl = process.env.DATABASE_URL;
 
-  if (typeof databaseUrl === 'string' && databaseUrl.trim().length === 0) {
-    throw new Error('DATABASE_URL is set but empty.');
+  if (typeof databaseUrl !== 'string' || databaseUrl.trim().length === 0) {
+    throw new Error('DATABASE_URL must be set to a non-empty PostgreSQL connection string.');
   }
 
-  const useAccelerate = typeof databaseUrl === 'string' && databaseUrl.startsWith('prisma+postgres://');
-
-  if (useAccelerate) {
-    const withAccelerate = loadAccelerateExtension();
-
-    if (!withAccelerate) {
-      throw new Error(
-        'DATABASE_URL is configured for Prisma Accelerate, but @prisma/extension-accelerate is not installed.',
-      );
-    }
-
-    client = new PrismaClient().$extends(withAccelerate()) as unknown as PrismaClient;
-
-    if (shouldUseGlobalCache) {
-      globalForPrisma.__infamousPrismaClient = client;
-    }
-
-    return client;
-  }
-
-  client = new PrismaClient();
+  const adapter = new PrismaPg({ connectionString: databaseUrl });
+  client = new PrismaClient({ adapter });
 
   if (shouldUseGlobalCache) {
     globalForPrisma.__infamousPrismaClient = client;

--- a/apps/api/test/prisma-client.test.ts
+++ b/apps/api/test/prisma-client.test.ts
@@ -7,60 +7,41 @@ describe('createPrismaClient', () => {
     jest.clearAllMocks();
   });
 
-  test('throws when accelerate URL is configured but extension is unavailable', () => {
-    process.env.DATABASE_URL = 'prisma+postgres://example';
-
-    jest.doMock('@prisma/client', () => {
-      class PrismaClient {
-        $extends = jest.fn();
-      }
-      return { PrismaClient };
-    });
-
-    jest.doMock('@prisma/extension-accelerate', () => ({ withAccelerate: undefined }), { virtual: true });
-
-    const { createPrismaClient } = require('../src/prisma-client') as typeof import('../src/prisma-client');
-
-    expect(() => createPrismaClient()).toThrow(
-      'DATABASE_URL is configured for Prisma Accelerate, but @prisma/extension-accelerate is not installed.',
-    );
-  });
-
-  test('uses accelerate extension when accelerate URL is configured and extension exists', () => {
-    process.env.DATABASE_URL = 'prisma+postgres://example';
-
-    const extendedClient = { marker: 'accelerated-client' };
-    const extendsSpy = jest.fn(() => extendedClient);
-
-    jest.doMock('@prisma/client', () => {
-      class PrismaClient {
-        $extends = extendsSpy;
-      }
-      return { PrismaClient };
-    });
-
-    const withAccelerate = jest.fn(() => ({ name: 'accelerate-extension' }));
-    jest.doMock('@prisma/extension-accelerate', () => ({ withAccelerate }), { virtual: true });
-
-    const { createPrismaClient } = require('../src/prisma-client') as typeof import('../src/prisma-client');
-
-    expect(createPrismaClient()).toBe(extendedClient);
-    expect(withAccelerate).toHaveBeenCalledTimes(1);
-    expect(extendsSpy).toHaveBeenCalledTimes(1);
-  });
-
-  test('creates default prisma client when accelerate is not configured', () => {
-    process.env.DATABASE_URL = 'postgres://example';
-
-    const prismaInstance = { marker: 'default-prisma-client' };
+  test('throws when DATABASE_URL is missing', () => {
+    delete process.env.DATABASE_URL;
 
     jest.doMock('@prisma/client', () => ({
-      PrismaClient: jest.fn(() => prismaInstance),
+      PrismaClient: jest.fn(),
+    }));
+
+    jest.doMock('@prisma/adapter-pg', () => ({
+      PrismaPg: jest.fn(),
     }));
 
     const { createPrismaClient } = require('../src/prisma-client') as typeof import('../src/prisma-client');
 
+    expect(() => createPrismaClient()).toThrow(
+      'DATABASE_URL must be set to a non-empty PostgreSQL connection string.',
+    );
+  });
+
+  test('creates prisma client with PrismaPg adapter using DATABASE_URL', () => {
+    process.env.DATABASE_URL = 'postgres://example';
+
+    const prismaInstance = { marker: 'default-prisma-client' };
+    const adapterInstance = { marker: 'pg-adapter' };
+
+    const PrismaClient = jest.fn(() => prismaInstance);
+    const PrismaPg = jest.fn(() => adapterInstance);
+
+    jest.doMock('@prisma/client', () => ({ PrismaClient }));
+    jest.doMock('@prisma/adapter-pg', () => ({ PrismaPg }));
+
+    const { createPrismaClient } = require('../src/prisma-client') as typeof import('../src/prisma-client');
+
     expect(createPrismaClient()).toBe(prismaInstance);
     expect(createPrismaClient()).toBe(prismaInstance);
+    expect(PrismaPg).toHaveBeenCalledWith({ connectionString: 'postgres://example' });
+    expect(PrismaClient).toHaveBeenCalledWith({ adapter: adapterInstance });
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
 
   apps/api:
     dependencies:
+      '@prisma/adapter-pg':
+        specifier: ^7.8.0
+        version: 7.8.0
       '@prisma/client':
         specifier: 7.8.0
         version: 7.8.0(prisma@7.8.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.3))(typescript@6.0.3)
@@ -1125,6 +1128,9 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
+  '@prisma/adapter-pg@7.8.0':
+    resolution: {integrity: sha512-ygb3UkerK3v8MDpXVgCISdRNDozpxh6+JVJgiIGbSr5KBgz10LLf5ejUskPGoXlsIjxsOu6nuy1JVQr2EKGSlg==}
+
   '@prisma/client-runtime-utils@7.8.0':
     resolution: {integrity: sha512-5NQZztQ0oY/ADFkmd9gPuweH5A1/CCY8YQPorLLO0Mu6a87mY5gsnDkzmFmIHs9NFaLnZojzgddFVN4RpKYrdw==}
 
@@ -1151,6 +1157,9 @@ packages:
 
   '@prisma/dev@0.24.3':
     resolution: {integrity: sha512-ffHlQuKXZiaDt9Go0OnCTdJZrHxK0k7omJKNV86/VjpsXu5EIHZLK0T7JSWgvNlJwh56kW9JFu9v0qJciFzepg==}
+
+  '@prisma/driver-adapter-utils@7.8.0':
+    resolution: {integrity: sha512-/Q13o0ZT0rjc1Xk0Q9KhZYwuq2EW/vSbWUBKfgEKkaCuB/Sg6bqnjmTZqC5cD4d6y1vfFAEwBRzfzoSMIVJ55A==}
 
   '@prisma/engines-version@7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a':
     resolution: {integrity: sha512-fJPQxCkLgA5EayWaW8eArgCvjJ+N+Kz3VyeNKMEeYiQC4alNkxRKFVAGxv/ZUzuJISKqdw+zGeDbS6mn6RCPOA==}
@@ -1866,6 +1875,9 @@ packages:
 
   '@types/pg@8.15.6':
     resolution: {integrity: sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==}
+
+  '@types/pg@8.20.0':
+    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
 
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
@@ -3514,9 +3526,20 @@ packages:
   perfect-debounce@2.1.0:
     resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
 
+  pg-cloudflare@1.3.0:
+    resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
+
+  pg-connection-string@2.12.0:
+    resolution: {integrity: sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==}
+
   pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
     engines: {node: '>=4.0.0'}
+
+  pg-pool@3.13.0:
+    resolution: {integrity: sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==}
+    peerDependencies:
+      pg: '>=8.0'
 
   pg-protocol@1.13.0:
     resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
@@ -3524,6 +3547,18 @@ packages:
   pg-types@2.2.0:
     resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
     engines: {node: '>=4'}
+
+  pg@8.20.0:
+    resolution: {integrity: sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -3557,6 +3592,10 @@ packages:
   postgres-array@2.0.0:
     resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
     engines: {node: '>=4'}
+
+  postgres-array@3.0.4:
+    resolution: {integrity: sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==}
+    engines: {node: '>=12'}
 
   postgres-bytea@1.0.1:
     resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
@@ -3877,6 +3916,10 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -5290,6 +5333,15 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
+  '@prisma/adapter-pg@7.8.0':
+    dependencies:
+      '@prisma/driver-adapter-utils': 7.8.0
+      '@types/pg': 8.20.0
+      pg: 8.20.0
+      postgres-array: 3.0.4
+    transitivePeerDependencies:
+      - pg-native
+
   '@prisma/client-runtime-utils@7.8.0': {}
 
   '@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.3))(typescript@6.0.3)':
@@ -5333,6 +5385,10 @@ snapshots:
       zeptomatch: 2.1.0
     transitivePeerDependencies:
       - typescript
+
+  '@prisma/driver-adapter-utils@7.8.0':
+    dependencies:
+      '@prisma/debug': 7.8.0
 
   '@prisma/engines-version@7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a': {}
 
@@ -6020,6 +6076,12 @@ snapshots:
       '@types/pg': 8.15.6
 
   '@types/pg@8.15.6':
+    dependencies:
+      '@types/node': 25.6.0
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+
+  '@types/pg@8.20.0':
     dependencies:
       '@types/node': 25.6.0
       pg-protocol: 1.13.0
@@ -7757,7 +7819,16 @@ snapshots:
 
   perfect-debounce@2.1.0: {}
 
+  pg-cloudflare@1.3.0:
+    optional: true
+
+  pg-connection-string@2.12.0: {}
+
   pg-int8@1.0.1: {}
+
+  pg-pool@3.13.0(pg@8.20.0):
+    dependencies:
+      pg: 8.20.0
 
   pg-protocol@1.13.0: {}
 
@@ -7768,6 +7839,20 @@ snapshots:
       postgres-bytea: 1.0.1
       postgres-date: 1.0.7
       postgres-interval: 1.2.0
+
+  pg@8.20.0:
+    dependencies:
+      pg-connection-string: 2.12.0
+      pg-pool: 3.13.0(pg@8.20.0)
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.3.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
 
   picocolors@1.1.1: {}
 
@@ -7796,6 +7881,8 @@ snapshots:
       source-map-js: 1.2.1
 
   postgres-array@2.0.0: {}
+
+  postgres-array@3.0.4: {}
 
   postgres-bytea@1.0.1: {}
 
@@ -8155,6 +8242,8 @@ snapshots:
       source-map: 0.6.1
 
   source-map@0.6.1: {}
+
+  split2@4.2.0: {}
 
   sprintf-js@1.0.3: {}
 


### PR DESCRIPTION
### Motivation

- Replace custom Prisma Accelerate extension branching with the official PostgreSQL adapter to simplify runtime initialization and configuration validation.
- Surface Prisma runtime initialization failures earlier during CI container startup to avoid long waits for failing containers.

### Description

- Updated `apps/api/src/prisma-client.ts` to require `PrismaPg` from `@prisma/adapter-pg`, validate that `DATABASE_URL` is a non-empty PostgreSQL connection string, and instantiate `PrismaClient` with the `adapter` option instead of the previous accelerate extension branching logic.
- Added `@prisma/adapter-pg` to `apps/api/package.json` and updated `pnpm-lock.yaml` to include the new adapter and its transitive dependencies.
- Rewrote tests in `apps/api/test/prisma-client.test.ts` to reflect the new behavior, including a test for missing `DATABASE_URL` and a test that asserts the adapter is constructed and passed into `PrismaClient`.
- Enhanced the GitHub Actions workflow `/.github/workflows/full-validation.yml` with a `Fail fast on Prisma runtime initialization errors` step that tails container logs, detects known Prisma initialization error patterns, and polls the `/api/health/live` endpoint to confirm successful startup before proceeding.

### Testing

- Ran the API unit tests via the package test script with `npm test` in `apps/api`, which updated and exercised `prisma-client.test.ts` and completed successfully.
- Verified the modified `full-validation.yml` logic locally by exercising the container startup loop and log-check behavior (CI step added to detect and fail fast on Prisma initialization errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb474fcfbc833098a5be9b48a17a90)