### PR TITLE
Support DATADOG_API_KEY/DATADOG_APP_KEY and skip workflow when secrets are missing

### DIFF
--- a/.github/workflows/datadog-synthetics.yml
+++ b/.github/workflows/datadog-synthetics.yml
@@ -8,7 +8,10 @@
 
 # To get started:
 
-# 1. Add your Datadog API (DD_API_KEY) and Application Key (DD_APP_KEY) as secrets to your GitHub repository. For more information, see: https://docs.datadoghq.com/account_management/api-app-keys/.
+# 1. Add your Datadog API and Application Keys as secrets to your GitHub repository.
+#    Supported secret names in this workflow are DATADOG_API_KEY / DATADOG_APP_KEY
+#    (preferred) and DD_API_KEY / DD_APP_KEY (backward compatible).
+#    For more information, see: https://docs.datadoghq.com/account_management/api-app-keys/.
 # 2. Start using the action within your workflow
 
 name: Run Datadog Synthetic tests
@@ -26,13 +29,17 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
+    - name: Datadog credentials not configured
+      if: ${{ !( (secrets.DATADOG_API_KEY != '' || secrets.DD_API_KEY != '') && (secrets.DATADOG_APP_KEY != '' || secrets.DD_APP_KEY != '') ) }}
+      run: |
+        echo "::notice::Skipping Datadog Synthetic tests. Set DATADOG_API_KEY and DATADOG_APP_KEY (or DD_API_KEY/DD_APP_KEY) repository secrets to enable this workflow."
+
     # Run Synthetic tests within your GitHub workflow.
     # For additional configuration options visit the action within the marketplace: https://github.com/marketplace/actions/datadog-synthetics-ci
     - name: Run Datadog Synthetic tests
+      if: ${{ (secrets.DATADOG_API_KEY != '' || secrets.DD_API_KEY != '') && (secrets.DATADOG_APP_KEY != '' || secrets.DD_APP_KEY != '') }}
       uses: DataDog/synthetics-ci-github-action@c84a23515bda46d8a060f77a6ad88644377f90be # v4.0.0
       with:
-        api_key: ${{secrets.DD_API_KEY}}
-        app_key: ${{secrets.DD_APP_KEY}}
+        api_key: ${{ secrets.DATADOG_API_KEY || secrets.DD_API_KEY }}
+        app_key: ${{ secrets.DATADOG_APP_KEY || secrets.DD_APP_KEY }}
         test_search_query: 'tag:e2e-tests' #Modify this tag to suit your tagging strategy
-
-


### PR DESCRIPTION
### Motivation
- Make the Datadog GitHub Actions workflow accept preferred secret names and remain backward compatible with existing `DD_*` secrets.
- Avoid noisy failures by skipping synthetic test execution when Datadog credentials are not configured and emit a clear notice instead.

### Description
- Update the workflow documentation to mention `DATADOG_API_KEY` / `DATADOG_APP_KEY` (preferred) and `DD_API_KEY` / `DD_APP_KEY` (backward compatible).
- Add a step that prints a notice and exits early when the required Datadog secrets are not present using an `if` conditional.
- Guard the `Run Datadog Synthetic tests` step with an `if` conditional and wire the action inputs to use fallbacks: `secrets.DATADOG_API_KEY || secrets.DD_API_KEY` and `secrets.DATADOG_APP_KEY || secrets.DD_APP_KEY`.

### Testing
- No automated tests were added or executed for this change; the modification is limited to the GitHub Actions workflow YAML file and does not alter runtime application code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb8bc03d78833096028b1600b19a6a)