### PR TITLE
web: add CSP and HSTS headers to Netlify config

### DIFF
--- a/apps/web/netlify.toml
+++ b/apps/web/netlify.toml
@@ -74,6 +74,8 @@
     X-XSS-Protection = "1; mode=block"
     Referrer-Policy = "strict-origin-when-cross-origin"
     Permissions-Policy = "geolocation=(), microphone=(), camera=()"
+    Strict-Transport-Security = "max-age=63072000; includeSubDomains; preload"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' https://js.stripe.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https://*.supabase.co https://www.google-analytics.com; connect-src 'self' https://infamous-freight.fly.dev https://api.infamousfreight.com https://*.supabase.co wss://*.supabase.co https://api.stripe.com https://*.sentry.io https://*.ingest.sentry.io https://www.google-analytics.com; frame-src https://js.stripe.com https://hooks.stripe.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; worker-src 'self'"
 
 # Cache control
 [[headers]]


### PR DESCRIPTION
### Motivation
- Security scan reported a missing Content-Security-Policy header for `www.infamousfreight.com` and related public resources, and HSTS was not enforced. 
- Add global response headers at the CDN edge to quickly remediate the scanner finding without changing application logic.

### Description
- Added a global `Strict-Transport-Security` header to the frontend Netlify configuration in `apps/web/netlify.toml` to enforce HTTPS on supported clients. 
- Added a global `Content-Security-Policy` header to the same Netlify header block with explicit `script-src`, `style-src`, `img-src`, `connect-src`, and other directives tailored for the deployed assets and third-party integrations. 
- Kept the existing header and caching blocks intact and scoped the changes to the Netlify config only.

### Testing
- Parsed `apps/web/netlify.toml` with Python `tomllib` to validate TOML syntax and the file loaded successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb8de38c408330bde692fe958ae479)