### PR TITLE
Validate Fly image refs, enable optional prebuilt image deploy, and add tests

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,8 +12,8 @@
     "build": "npm run prisma:generate && tsc -p tsconfig.json",
     "start:dev": "tsx watch src/server.ts",
     "start:prod": "node dist/src/server.js",
-    "test": "node scripts/run-jest.cjs --runInBand",
-    "test:coverage": "node scripts/run-jest.cjs --runInBand --coverage",
+    "test": "npm run prisma:generate && node scripts/run-jest.cjs --runInBand",
+    "test:coverage": "npm run prisma:generate && node scripts/run-jest.cjs --runInBand --coverage",
     "lint": "npm run prisma:generate && tsc -p tsconfig.json --noEmit",
     "prisma:generate": "pnpm exec prisma generate --schema prisma/schema.prisma"
   },

--- a/apps/api/test/deploy-script.test.ts
+++ b/apps/api/test/deploy-script.test.ts
@@ -1,0 +1,46 @@
+import path from 'path';
+import { spawnSync } from 'child_process';
+
+describe('root deploy script', () => {
+  const scriptPath = path.resolve(__dirname, '../../../deploy.sh');
+
+  const runValidation = (imageRef: string) => spawnSync(
+    'bash',
+    ['-lc', `source "${scriptPath}"; validate_container_image_ref "${imageRef}"`],
+    { encoding: 'utf8' },
+  );
+
+  it('rejects image refs with whitespace', () => {
+    const result = runValidation('registry.fly.io/app:bad tag');
+
+    expect(result.status).toBe(1);
+    expect(result.stdout + result.stderr).toContain('must not contain whitespace');
+  });
+
+
+  it('rejects non-Fly registry image refs', () => {
+    const result = runValidation('ghcr.io/infamous-freight:deployment-123');
+
+    expect(result.status).toBe(1);
+    expect(result.stdout + result.stderr).toContain('expected image in registry.fly.io');
+  });
+
+  it('rejects untagged image refs', () => {
+    const result = runValidation('registry.fly.io/app');
+
+    expect(result.status).toBe(1);
+    expect(result.stdout + result.stderr).toContain('expected a tagged image');
+  });
+
+  it('accepts digest image refs', () => {
+    const result = runValidation('registry.fly.io/infamous-freight@sha256:abcdef123456');
+
+    expect(result.status).toBe(0);
+  });
+
+  it('accepts tagged image refs', () => {
+    const result = runValidation('registry.fly.io/infamous-freight:deployment-123');
+
+    expect(result.status).toBe(0);
+  });
+});

--- a/deploy.sh
+++ b/deploy.sh
@@ -174,6 +174,26 @@ run_tests() {
 # DEPLOYMENT FUNCTIONS
 # ===========================================================================
 
+validate_container_image_ref() {
+  local image_ref="$1"
+
+  # Conservative validation for container image references used in deployment.
+  if [[ "$image_ref" =~ [[:space:]] ]]; then
+    error "Invalid FLY_DEPLOY_IMAGE: must not contain whitespace"
+    exit 1
+  fi
+
+  if [[ "$image_ref" != registry.fly.io/* ]]; then
+    error "Invalid FLY_DEPLOY_IMAGE: expected image in registry.fly.io/<app>:<tag> format"
+    exit 1
+  fi
+
+  if [[ "$image_ref" != *":"* && "$image_ref" != *@sha256:* ]]; then
+    error "Invalid FLY_DEPLOY_IMAGE: expected a tagged image or digest (example: registry.fly.io/app:tag)"
+    exit 1
+  fi
+}
+
 deploy_fly() {
   local env="$1"
   log "Deploying to Fly.io ($env)..."
@@ -192,8 +212,17 @@ deploy_fly() {
   export FLY_APP_NAME="$app_name"
 
   cd "$PROJECT_ROOT"
+
+  local deploy_image="${FLY_DEPLOY_IMAGE:-}"
+  local -a fly_args=(deploy --app "$app_name" --remote-only)
+  if [[ -n "$deploy_image" ]]; then
+    validate_container_image_ref "$deploy_image"
+    log "Deploying prebuilt Fly image: $deploy_image"
+    fly_args+=(--image "$deploy_image")
+  fi
+
   # Redact any lines that look like secrets from the tee'd log
-  flyctl deploy --app "$app_name" --remote-only 2>&1 \
+  flyctl "${fly_args[@]}" 2>&1 \
     | grep -v -iE '(secret|key|token|password)' \
     | tee -a "$LOG_FILE" \
     || true   # let the trap handle real failures; grep exit-codes aren't failures
@@ -450,4 +479,6 @@ main() {
   success "=========================================="
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi


### PR DESCRIPTION
### Motivation

- Prevent accidental deployments of invalid container image references and allow deploying a prebuilt Fly image via `FLY_DEPLOY_IMAGE` to support CI-built images.

### Description

- Added `validate_container_image_ref` to `deploy.sh` to conservatively validate image refs for whitespace, registry prefix `registry.fly.io/`, and presence of a tag or digest.
- Updated `deploy_fly` in `deploy.sh` to read `FLY_DEPLOY_IMAGE`, call `validate_container_image_ref` when provided, and pass `--image` to `flyctl` via a constructed `fly_args` array. 
- Changed script exit behavior to only run `main` when the script is executed directly by guarding `main` with `if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then main "$@"; fi` to allow safe sourcing from tests.
- Updated `apps/api/package.json` `test` and `test:coverage` scripts to run `npm run prisma:generate` before invoking Jest so Prisma client is generated for tests.
- Added a Jest test `apps/api/test/deploy-script.test.ts` which sources `deploy.sh` and calls `validate_container_image_ref` to assert acceptance and rejection of various image ref formats.

### Testing

- Ran the API test suite with `npm test` in `apps/api`; the new Jest tests including `deploy-script.test.ts` executed and passed.
- Ran the TypeScript checks with `npm run lint`/`npx tsc` used by the script, and the typechecks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb945d4788833096cdc672f6cf70b3)