### PR TITLE
Prevent Sentry source-map upload when `SENTRY_AUTH_TOKEN` is placeholder or masked

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -15,10 +15,21 @@ const buildTime = process.env.VITE_BUILD_TIME ?? new Date().toISOString();
 // and avoid hard build failures on auth issues.
 const hasSentryCredentials =
   Boolean(sentryAuthToken) && Boolean(sentryOrg) && Boolean(sentryProject);
+const normalizedSentryToken = typeof sentryAuthToken === 'string' ? sentryAuthToken.trim() : '';
+const isLikelyPlaceholderSentryToken =
+  normalizedSentryToken.length === 0 ||
+  normalizedSentryToken === 'your-sentry-auth-token' ||
+  normalizedSentryToken.toLowerCase() === 'changeme' ||
+  normalizedSentryToken.startsWith('${') ||
+  normalizedSentryToken.includes('***');
 const disableSentryUpload =
   process.env.SENTRY_DISABLE_UPLOAD === '1' ||
   process.env.SENTRY_DISABLE_UPLOAD === 'true';
-const enableSentryUpload = hasSentryCredentials && !disableSentryUpload;
+const enableSentryUpload =
+  hasSentryCredentials && !isLikelyPlaceholderSentryToken && !disableSentryUpload;
+if (hasSentryCredentials && isLikelyPlaceholderSentryToken) {
+  console.warn('[sentry-vite-plugin] source-map upload disabled: SENTRY_AUTH_TOKEN appears to be a placeholder or masked value.');
+}
 const uploadSourcemaps =
   enableSentryUpload || process.env.SENTRY_SOURCEMAPS === '1';
 


### PR DESCRIPTION
### Motivation

- Prevent accidental Sentry source-map uploads when `SENTRY_AUTH_TOKEN` is missing, masked, or set to a placeholder in CI/Netlify environments. 
- Provide a clear runtime warning when the token appears to be a placeholder so engineers understand why uploads are disabled.

### Description

- Add `normalizedSentryToken` and `isLikelyPlaceholderSentryToken` checks that detect empty, common placeholder values, templated variables, or masked tokens (e.g. containing `***`).
- Update `enableSentryUpload` to require `hasSentryCredentials` and that the token is not a likely placeholder, and still respect `SENTRY_DISABLE_UPLOAD`.
- Emit a `console.warn` when credentials exist but the token appears to be a placeholder, and only add `sentryVitePlugin` to `plugins` when `enableSentryUpload` is true while retaining `uploadSourcemaps` override via `SENTRY_SOURCEMAPS`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb98b1daa483309be2f380c9dbb32a)