### PR TITLE
Add analytics hosts to Netlify CSP and add CSP validation test

### DIFF
--- a/apps/api/test/netlify-csp.test.ts
+++ b/apps/api/test/netlify-csp.test.ts
@@ -1,0 +1,36 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const REQUIRED_ANALYTICS_HOSTS = [
+  'https://www.googletagmanager.com',
+  'https://www.google-analytics.com',
+  'https://stats.g.doubleclick.net',
+] as const;
+
+function read(filePath: string): string {
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+describe('Netlify CSP policy', () => {
+  const repoRoot = path.resolve(__dirname, '../../..');
+  const rootNetlify = path.join(repoRoot, 'netlify.toml');
+  const webNetlify = path.join(repoRoot, 'apps/web/netlify.toml');
+
+  it('keeps analytics domains allowed in root and web netlify config', () => {
+    const rootContent = read(rootNetlify);
+    const webContent = read(webNetlify);
+
+    for (const host of REQUIRED_ANALYTICS_HOSTS) {
+      expect(rootContent).toContain(host);
+      expect(webContent).toContain(host);
+    }
+  });
+
+  it('keeps strict worker policy globally in root netlify config', () => {
+    const rootContent = read(rootNetlify);
+    expect(rootContent).toContain("for = \"/*\"");
+    expect(rootContent).toContain("worker-src 'none'");
+    expect(rootContent).toContain("for = \"/driver-pwa/*\"");
+    expect(rootContent).toContain("worker-src 'self'");
+  });
+});

--- a/apps/web/netlify.toml
+++ b/apps/web/netlify.toml
@@ -75,7 +75,7 @@
     Referrer-Policy = "strict-origin-when-cross-origin"
     Permissions-Policy = "geolocation=(), microphone=(), camera=()"
     Strict-Transport-Security = "max-age=63072000; includeSubDomains; preload"
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' https://js.stripe.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https://*.supabase.co https://www.google-analytics.com; connect-src 'self' https://infamous-freight.fly.dev https://api.infamousfreight.com https://*.supabase.co wss://*.supabase.co https://api.stripe.com https://*.sentry.io https://*.ingest.sentry.io https://www.google-analytics.com; frame-src https://js.stripe.com https://hooks.stripe.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; worker-src 'self'"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' https://js.stripe.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https://*.supabase.co https://www.google-analytics.com https://stats.g.doubleclick.net; connect-src 'self' https://infamous-freight.fly.dev https://api.infamousfreight.com https://*.supabase.co wss://*.supabase.co https://api.stripe.com https://*.sentry.io https://*.ingest.sentry.io https://www.google-analytics.com https://www.googletagmanager.com; frame-src https://js.stripe.com https://hooks.stripe.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; worker-src 'self'"
 
 # Cache control
 [[headers]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -50,7 +50,7 @@
     X-XSS-Protection = "1; mode=block"
     Referrer-Policy = "strict-origin-when-cross-origin"
     Strict-Transport-Security = "max-age=63072000; includeSubDomains; preload"
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' https://js.stripe.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https://*.supabase.co; connect-src 'self' https://infamous-freight.fly.dev https://api.infamousfreight.com https://*.supabase.co wss://*.supabase.co https://api.stripe.com https://*.sentry.io https://*.ingest.sentry.io; frame-src https://js.stripe.com https://hooks.stripe.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; worker-src 'none'"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' https://js.stripe.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https://*.supabase.co https://www.google-analytics.com https://stats.g.doubleclick.net; connect-src 'self' https://infamous-freight.fly.dev https://api.infamousfreight.com https://*.supabase.co wss://*.supabase.co https://api.stripe.com https://*.sentry.io https://*.ingest.sentry.io https://www.google-analytics.com https://www.googletagmanager.com; frame-src https://js.stripe.com https://hooks.stripe.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; worker-src 'none'"
     Cross-Origin-Embedder-Policy = "unsafe-none"
     Cross-Origin-Opener-Policy = "same-origin-allow-popups"
     Cross-Origin-Resource-Policy = "same-origin"


### PR DESCRIPTION
### Motivation
- Ensure Google Analytics and Tag Manager domains are allowed by the site Content-Security-Policy so analytics continue to function. 
- Keep the worker policy strict globally while allowing the PWA driver worker scope to run. 
- Add an automated check to prevent accidental removal of required analytics hosts or worker-src settings.

### Description
- Updated `netlify.toml` and `apps/web/netlify.toml` to include `https://www.googletagmanager.com`, `https://www.google-analytics.com`, and `https://stats.g.doubleclick.net` in the appropriate `script-src`, `img-src`, and `connect-src` directives. 
- Preserved the strict worker policy in the root `netlify.toml` (`worker-src 'none'`) and the PWA driver override (`worker-src 'self'` for `/driver-pwa/*`). 
- Added a Jest test `apps/api/test/netlify-csp.test.ts` that asserts the presence of the required analytics hosts and verifies the global and PWA `worker-src` settings.

### Testing
- Added the test file `apps/api/test/netlify-csp.test.ts` which runs under the repository Jest test suite. 
- Ran the workspace test suite with `pnpm -w test` and the tests, including the new CSP checks, completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc2f8cfaf48330979ed4e2d90c199c)