### PR TITLE
Extract Sentry upload config resolver and wire into Vite config; add tests

### DIFF
--- a/apps/web/sentryUploadConfig.test.ts
+++ b/apps/web/sentryUploadConfig.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { resolveSentryUploadConfig } from './sentryUploadConfig';
+
+describe('resolveSentryUploadConfig', () => {
+  it('enables upload for valid credentials', () => {
+    const result = resolveSentryUploadConfig({
+      authToken: ' token ',
+      org: ' org ',
+      project: ' project ',
+    });
+
+    expect(result.enableSentryUpload).toBe(true);
+    expect(result.normalizedSentryToken).toBe('token');
+    expect(result.normalizedSentryOrg).toBe('org');
+    expect(result.normalizedSentryProject).toBe('project');
+  });
+
+  it('disables upload for placeholder token', () => {
+    const result = resolveSentryUploadConfig({
+      authToken: 'your-sentry-auth-token',
+      org: 'infmous',
+      project: 'infamous-freight',
+    });
+
+    expect(result.hasLikelyPlaceholderCredentials).toBe(true);
+    expect(result.enableSentryUpload).toBe(false);
+  });
+
+  it('disables upload when explicitly disabled (case-insensitive)', () => {
+    const result = resolveSentryUploadConfig({
+      authToken: 'token',
+      org: 'infmous',
+      project: 'infamous-freight',
+      disableUpload: 'TRUE',
+    });
+
+    expect(result.enableSentryUpload).toBe(false);
+  });
+
+  it('disables upload for masked/template org or project values', () => {
+    const withMaskedOrg = resolveSentryUploadConfig({
+      authToken: 'token',
+      org: '***',
+      project: 'infamous-freight',
+    });
+    const withTemplateProject = resolveSentryUploadConfig({
+      authToken: 'token',
+      org: 'infmous',
+      project: '${SENTRY_PROJECT}',
+    });
+
+    expect(withMaskedOrg.enableSentryUpload).toBe(false);
+    expect(withTemplateProject.enableSentryUpload).toBe(false);
+  });
+
+  it('disables upload when any credential is missing after trim', () => {
+    const result = resolveSentryUploadConfig({
+      authToken: ' token ',
+      org: '   ',
+      project: 'project',
+    });
+
+    expect(result.hasSentryCredentials).toBe(false);
+    expect(result.enableSentryUpload).toBe(false);
+  });
+
+});

--- a/apps/web/sentryUploadConfig.ts
+++ b/apps/web/sentryUploadConfig.ts
@@ -1,0 +1,50 @@
+export type SentryUploadInputs = {
+  authToken?: string;
+  org?: string;
+  project?: string;
+  disableUpload?: string;
+};
+
+const normalize = (value?: string): string => (typeof value === 'string' ? value.trim() : '');
+
+const looksMaskedOrTemplateValue = (value: string): boolean =>
+  value.startsWith('${') || value.includes('***');
+
+const looksPlaceholderValue = (value: string, knownPlaceholders: readonly string[] = []): boolean => {
+  const normalizedValue = value.toLowerCase();
+  return knownPlaceholders.some((placeholder) => normalizedValue === placeholder.toLowerCase());
+};
+
+export const resolveSentryUploadConfig = (input: SentryUploadInputs) => {
+  const normalizedSentryToken = normalize(input.authToken);
+  const normalizedSentryOrg = normalize(input.org);
+  const normalizedSentryProject = normalize(input.project);
+
+  const hasSentryCredentials =
+    Boolean(normalizedSentryToken) && Boolean(normalizedSentryOrg) && Boolean(normalizedSentryProject);
+
+  const isLikelyPlaceholderSentryToken =
+    looksMaskedOrTemplateValue(normalizedSentryToken) ||
+    looksPlaceholderValue(normalizedSentryToken, ['changeme', 'your-sentry-auth-token']);
+  const isLikelyPlaceholderSentryOrg =
+    looksMaskedOrTemplateValue(normalizedSentryOrg) ||
+    looksPlaceholderValue(normalizedSentryOrg, ['changeme', 'your-sentry-org']);
+  const isLikelyPlaceholderSentryProject =
+    looksMaskedOrTemplateValue(normalizedSentryProject) ||
+    looksPlaceholderValue(normalizedSentryProject, ['changeme', 'your-sentry-project']);
+
+  const disableSentryUpload =
+    input.disableUpload === '1' || input.disableUpload?.toLowerCase() === 'true';
+
+  const hasLikelyPlaceholderCredentials =
+    isLikelyPlaceholderSentryToken || isLikelyPlaceholderSentryOrg || isLikelyPlaceholderSentryProject;
+
+  return {
+    normalizedSentryToken,
+    normalizedSentryOrg,
+    normalizedSentryProject,
+    hasSentryCredentials,
+    hasLikelyPlaceholderCredentials,
+    enableSentryUpload: hasSentryCredentials && !hasLikelyPlaceholderCredentials && !disableSentryUpload,
+  };
+};

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -2,10 +2,14 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 import { sentryVitePlugin } from '@sentry/vite-plugin';
+import { resolveSentryUploadConfig } from './sentryUploadConfig';
 
-const sentryAuthToken = process.env.SENTRY_AUTH_TOKEN;
-const sentryOrg = process.env.SENTRY_ORG;
-const sentryProject = process.env.SENTRY_PROJECT;
+const sentryConfig = resolveSentryUploadConfig({
+  authToken: process.env.SENTRY_AUTH_TOKEN,
+  org: process.env.SENTRY_ORG,
+  project: process.env.SENTRY_PROJECT,
+  disableUpload: process.env.SENTRY_DISABLE_UPLOAD,
+});
 // Build identification surfaced into the bundle for diagnostics. Falls back to
 // 'unknown' so dev builds still type-check; CI/Netlify can populate these.
 const buildGitSha =
@@ -13,25 +17,11 @@ const buildGitSha =
 const buildTime = process.env.VITE_BUILD_TIME ?? new Date().toISOString();
 // Enable Sentry uploads when credentials exist, but allow CI to opt out
 // and avoid hard build failures on auth issues.
-const hasSentryCredentials =
-  Boolean(sentryAuthToken) && Boolean(sentryOrg) && Boolean(sentryProject);
-const normalizedSentryToken = typeof sentryAuthToken === 'string' ? sentryAuthToken.trim() : '';
-const isLikelyPlaceholderSentryToken =
-  normalizedSentryToken.length === 0 ||
-  normalizedSentryToken === 'your-sentry-auth-token' ||
-  normalizedSentryToken.toLowerCase() === 'changeme' ||
-  normalizedSentryToken.startsWith('${') ||
-  normalizedSentryToken.includes('***');
-const disableSentryUpload =
-  process.env.SENTRY_DISABLE_UPLOAD === '1' ||
-  process.env.SENTRY_DISABLE_UPLOAD === 'true';
-const enableSentryUpload =
-  hasSentryCredentials && !isLikelyPlaceholderSentryToken && !disableSentryUpload;
-if (hasSentryCredentials && isLikelyPlaceholderSentryToken) {
-  console.warn('[sentry-vite-plugin] source-map upload disabled: SENTRY_AUTH_TOKEN appears to be a placeholder or masked value.');
+if (sentryConfig.hasSentryCredentials && sentryConfig.hasLikelyPlaceholderCredentials) {
+  console.warn('[sentry-vite-plugin] source-map upload disabled: SENTRY_* credentials appear to be placeholders or masked values.');
 }
 const uploadSourcemaps =
-  enableSentryUpload || process.env.SENTRY_SOURCEMAPS === '1';
+  sentryConfig.enableSentryUpload || process.env.SENTRY_SOURCEMAPS === '1';
 
 export default defineConfig({
   define: {
@@ -40,12 +30,12 @@ export default defineConfig({
   },
   plugins: [
     react(),
-    ...(enableSentryUpload
+    ...(sentryConfig.enableSentryUpload
       ? [
           sentryVitePlugin({
-            org: sentryOrg as string,
-            project: sentryProject as string,
-            authToken: sentryAuthToken as string,
+            org: sentryConfig.normalizedSentryOrg,
+            project: sentryConfig.normalizedSentryProject,
+            authToken: sentryConfig.normalizedSentryToken,
             errorHandler: (error) => {
               const message = error.message ?? String(error);
               console.warn('[sentry-vite-plugin] source-map upload skipped:', message);


### PR DESCRIPTION
### Motivation

- Centralize and harden the logic that decides whether Sentry source-map uploads should run to avoid duplicated checks and improve handling of masked/placeholder values.
- Allow the Vite config to consume a single resolved config object instead of reimplementing normalization and placeholder detection inline.

### Description

- Add `apps/web/sentryUploadConfig.ts` which exports `resolveSentryUploadConfig` and encapsulates normalization, placeholder/masked detection, and `disableUpload` parsing.
- Update `apps/web/vite.config.ts` to use `resolveSentryUploadConfig` and consume `normalizedSentryToken`, `normalizedSentryOrg`, `normalizedSentryProject`, and `enableSentryUpload` when configuring `@sentry/vite-plugin` and upload behavior.
- Add unit tests in `apps/web/sentryUploadConfig.test.ts` that validate trimming, placeholder detection, masked/template detection, explicit disable flags, and behavior when credentials are missing.

### Testing

- Ran the new unit tests with `vitest` in `apps/web` and the `resolveSentryUploadConfig` test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc342248f88330b5a1407fa0385f44)