### PR TITLE
Add GitHub Actions workflow to run API tests and deploy to Fly.io

### DIFF
--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -19,8 +19,11 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
+    env:
+      CI: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -48,9 +51,8 @@ jobs:
       - name: Build API
         run: pnpm -C apps/api run build
 
-
       - name: Build Docker image
-        run: docker build -t infamous-freight-api:ci .
+        run: docker build --file Dockerfile --tag infamous-freight-api:ci .
 
       - name: Setup flyctl
         uses: superfly/flyctl-actions/setup-flyctl@v1

--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -48,6 +48,10 @@ jobs:
       - name: Build API
         run: pnpm -C apps/api run build
 
+
+      - name: Build Docker image
+        run: docker build -t infamous-freight-api:ci .
+
       - name: Setup flyctl
         uses: superfly/flyctl-actions/setup-flyctl@v1
 

--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -1,0 +1,57 @@
+name: Deploy Fly API
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "apps/api/**"
+      - "Dockerfile"
+      - "fly.toml"
+      - "pnpm-lock.yaml"
+      - "package.json"
+      - ".github/workflows/deploy-fly.yml"
+
+concurrency:
+  group: deploy-fly-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma Client
+        run: pnpm -C apps/api run prisma:generate
+
+      - name: Run API tests (runInBand)
+        run: pnpm -C apps/api run test -- --runInBand
+
+      - name: Build API
+        run: pnpm -C apps/api run build
+
+      - name: Setup flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@v1
+
+      - name: Deploy API to Fly.io
+        run: flyctl deploy --remote-only --config fly.toml
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
### Motivation

- Add a CI/CD workflow to run the API test suite and safely deploy the API to Fly.io on changes to the API or deployment config. 
- Ensure deterministic installs and faster CI with `pnpm` and Node.js caching and prevent overlapping deploys via a concurrency group.

### Description

- Adds a new workflow file at `.github/workflows/deploy-fly.yml` that triggers on `workflow_dispatch` and `push` to `main` limited to `apps/api/**`, `Dockerfile`, `fly.toml`, `pnpm-lock.yaml`, `package.json`, and the workflow file. 
- The job sets a concurrency group, checks out the repo, and configures `pnpm` (v10) and Node.js (`node-version: 22`) with `pnpm` cache. 
- The workflow installs dependencies with `pnpm install --frozen-lockfile`, runs `pnpm -C apps/api run prisma:generate`, runs tests with `pnpm -C apps/api run test -- --runInBand`, and builds the API with `pnpm -C apps/api run build`. 
- It sets up `flyctl` and deploys via `flyctl deploy --remote-only --config fly.toml` using the `FLY_API_TOKEN` secret.

### Testing

- The workflow invokes the API test suite using `pnpm -C apps/api run test -- --runInBand` as an automated step. 
- No automated workflow run results are included in this PR (the workflow will execute on merge to `main` or when manually dispatched).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc403cd5cc83309f22a4709b35420a)