### PR TITLE
Add GitHub Actions workflow to build, test, and deploy API to Fly.io

### DIFF
--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -1,0 +1,88 @@
+name: Deploy Fly API
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "apps/api/**"
+      - "Dockerfile"
+      - "fly.toml"
+      - "pnpm-lock.yaml"
+      - "package.json"
+      - ".github/workflows/deploy-fly.yml"
+
+concurrency:
+  group: deploy-fly-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    env:
+      CI: true
+      FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      SUPABASE_JWT_SECRET: ${{ secrets.SUPABASE_JWT_SECRET }}
+      STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+      STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
+      REDIS_URL: ${{ secrets.REDIS_URL }}
+      REDIS_HOST: ${{ secrets.REDIS_HOST }}
+      REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
+      SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      DAT_API_KEY: ${{ secrets.DAT_API_KEY }}
+      TRUCKSTOP_API_KEY: ${{ secrets.TRUCKSTOP_API_KEY }}
+      LOADBOARD_API_KEY: ${{ secrets.LOADBOARD_API_KEY }}
+      SAMSARA_API_TOKEN: ${{ secrets.SAMSARA_API_TOKEN }}
+      MOTIVE_CLIENT_ID: ${{ secrets.MOTIVE_CLIENT_ID }}
+      MOTIVE_CLIENT_SECRET: ${{ secrets.MOTIVE_CLIENT_SECRET }}
+      QBO_CLIENT_ID: ${{ secrets.QBO_CLIENT_ID }}
+      QBO_CLIENT_SECRET: ${{ secrets.QBO_CLIENT_SECRET }}
+      XERO_CLIENT_ID: ${{ secrets.XERO_CLIENT_ID }}
+      XERO_CLIENT_SECRET: ${{ secrets.XERO_CLIENT_SECRET }}
+      SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
+      RTS_API_KEY: ${{ secrets.RTS_API_KEY }}
+      OTR_API_KEY: ${{ secrets.OTR_API_KEY }}
+      APEX_API_KEY: ${{ secrets.APEX_API_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma Client
+        run: pnpm -C apps/api run prisma:generate
+
+      - name: Run API tests (runInBand)
+        run: pnpm -C apps/api run test -- --runInBand
+
+      - name: Build API
+        run: pnpm -C apps/api run build
+
+      - name: Build Docker image
+        run: docker build --file Dockerfile --tag infamous-freight-api:ci .
+
+      - name: Setup flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@v1
+
+      - name: Deploy API to Fly.io
+        run: flyctl deploy --remote-only --config fly.toml


### PR DESCRIPTION
### Motivation
- Automate CI/CD for the API so changes in `apps/api`, `Dockerfile`, `fly.toml`, or lock/package files trigger a build, test, and deploy to Fly.io.
- Provide runtime configuration by injecting required secrets for the database, Supabase, Stripe, Redis, Sentry and various third-party integrations into the deploy environment.
- Ensure reproducible installs and caching by using `pnpm` and a pinned Node version.

### Description
- Adds a new workflow file `/.github/workflows/deploy-fly.yml` that is triggered on `push` to `main` (with path filters) and `workflow_dispatch` for manual runs.
- The workflow performs checkout, setups for `pnpm` and Node.js, runs `pnpm install --frozen-lockfile`, generates the Prisma client with `pnpm -C apps/api run prisma:generate`, runs API tests with `pnpm -C apps/api run test -- --runInBand`, builds the API with `pnpm -C apps/api run build`, builds a Docker image, installs `flyctl`, and deploys with `flyctl deploy --remote-only --config fly.toml`.
- Adds concurrency and a 30-minute timeout to the job to avoid overlapping deploys.
- Exposes required environment variables from repository secrets for DB, Supabase, Stripe, Redis, Sentry and other third-party API keys used by the API.

### Testing
- The workflow runs API tests via `pnpm -C apps/api run test -- --runInBand` as part of the CI job.
- Tests are executed when the workflow runs in CI; they have not been executed as part of creating this workflow file in the PR preview.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc403cd5cc83309f22a4709b35420a)