### PR TITLE
CI: Start Postgres for runtime checks and strengthen Docker healthchecks; update image health endpoints

### DIFF
--- a/.github/workflows/full-validation.yml
+++ b/.github/workflows/full-validation.yml
@@ -77,7 +77,9 @@ jobs:
     env:
       IMAGE_NAME: infamous-freight-local-check
       CONTAINER_NAME: infamous-freight-runtime-check-${{ github.run_id }}-${{ github.run_attempt }}
-      DATABASE_URL: postgresql://user:pass@127.0.0.1:5432/db
+      PG_CONTAINER_NAME: infamous-freight-postgres-${{ github.run_id }}-${{ github.run_attempt }}
+      DOCKER_NETWORK: infamous-freight-ci-${{ github.run_id }}-${{ github.run_attempt }}
+      DATABASE_URL: postgresql://user:pass@ci-postgres:5432/db
 
     steps:
       - name: Checkout
@@ -86,6 +88,31 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
+      - name: Start Postgres for runtime checks
+        run: |
+          docker network create "$DOCKER_NETWORK"
+
+          docker run -d \
+            --name "$PG_CONTAINER_NAME" \
+            --network "$DOCKER_NETWORK" \
+            --network-alias ci-postgres \
+            -e POSTGRES_USER=user \
+            -e POSTGRES_PASSWORD=pass \
+            -e POSTGRES_DB=db \
+            postgres:16
+
+          for i in {1..30}; do
+            if docker exec "$PG_CONTAINER_NAME" pg_isready -U user -d db >/dev/null 2>&1; then
+              echo "Postgres is ready."
+              exit 0
+            fi
+            sleep 2
+          done
+
+          echo "Postgres did not become ready in time." >&2
+          docker logs "$PG_CONTAINER_NAME" || true
+          exit 1
+
       - name: Build runtime image
         run: docker build --pull -t "$IMAGE_NAME" .
 
@@ -93,6 +120,7 @@ jobs:
         run: |
           docker run -d \
             --name "$CONTAINER_NAME" \
+            --network "$DOCKER_NETWORK" \
             -e DATABASE_URL="$DATABASE_URL" \
             -e NODE_ENV=production \
             -e PORT=3000 \
@@ -114,12 +142,21 @@ jobs:
 
             case "$health_status" in
               healthy)
+                for j in {1..6}; do
+                  if curl -fsS http://127.0.0.1:3000/api/health/ready >/dev/null; then
+                    break
+                  fi
+                  sleep 5
+                done
                 curl -fsS http://127.0.0.1:3000/api/health/ready >/dev/null
                 echo "Container healthcheck is healthy and /api/health/ready responds."
                 exit 0
                 ;;
               unhealthy)
                 echo "Container healthcheck is unhealthy." >&2
+                docker inspect --format '{{json .State.Health}}' "$CONTAINER_NAME" || true
+                docker inspect --format '{{range .State.Health.Log}}{{println .Output}}{{end}}' "$CONTAINER_NAME" || true
+                curl -i --max-time 5 http://127.0.0.1:3000/api/health/ready || true
                 docker logs "$CONTAINER_NAME" || true
                 exit 1
                 ;;
@@ -135,6 +172,9 @@ jobs:
           done
 
           echo "Docker healthcheck did not become healthy in time." >&2
+          docker inspect --format '{{json .State.Health}}' "$CONTAINER_NAME" || true
+          docker inspect --format '{{range .State.Health.Log}}{{println .Output}}{{end}}' "$CONTAINER_NAME" || true
+          curl -i --max-time 5 http://127.0.0.1:3000/api/health/ready || true
           docker inspect "$CONTAINER_NAME" || true
           docker logs "$CONTAINER_NAME" || true
           exit 1
@@ -157,4 +197,6 @@ jobs:
         if: always()
         run: |
           docker rm -f "$CONTAINER_NAME" || true
+          docker rm -f "$PG_CONTAINER_NAME" || true
+          docker network rm "$DOCKER_NETWORK" || true
           docker image rm -f "$IMAGE_NAME" || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,6 @@ EXPOSE 3000
 USER node
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
-  CMD node -e "const port = process.env.PORT || 3000; require('http').get('http://127.0.0.1:' + port + '/api/health', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)}).on('error', () => process.exit(1))"
+  CMD node -e "const port = process.env.PORT || 3000; require('http').get('http://127.0.0.1:' + port + '/api/health/live', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)}).on('error', () => process.exit(1))"
 
 CMD ["node", "apps/api/dist/src/server.js"]

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -26,6 +26,6 @@ USER nodejs
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD node -e "const port = process.env.PORT || 3000; require('http').get('http://localhost:' + port + '/health', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)}).on('error', () => process.exit(1))"
+  CMD node -e "const port = process.env.PORT || 3000; require('http').get('http://localhost:' + port + '/health/live', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)}).on('error', () => process.exit(1))"
 
 CMD ["node", "dist/src/server.js"]


### PR DESCRIPTION
### Motivation

- Provide a real Postgres instance for the runtime container during CI so the service can perform database-backed readiness checks.
- Make the container health verification more robust and diagnostic in CI to reduce flakiness when checking service readiness.
- Align image `HEALTHCHECK` endpoints with the application's live health route.

### Description

- In `/.github/workflows/full-validation.yml` added `PG_CONTAINER_NAME` and `DOCKER_NETWORK` environment variables, start a Postgres container on a dedicated network with alias `ci-postgres`, wait for it to become ready, and set `DATABASE_URL` to `postgresql://user:pass@ci-postgres:5432/db`.
- Attached the runtime container to the created Docker network and enhanced the runtime probe to perform additional `curl` retries, surface container health JSON and recent health logs on failure, and ensured the Postgres container and network are removed during cleanup.
- Updated `HEALTHCHECK` in `Dockerfile` and `Dockerfile.api` to target the application's live endpoints (`/api/health/live` and `/health/live`) and added more diagnostic output on failures.

### Testing

- Executed the `full-validation` CI workflow including `pnpm install --frozen-lockfile`, `pnpm run lint`, `pnpm run build`, `pnpm -C apps/api run test -- --runInBand`, and the `docker-runtime` job which starts Postgres and performs the health probes.
- All automated checks in the `full-validation` workflow completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc4fe4ca4c8330ad0de84350b51359)