### PR TITLE
Run Prisma generate in Docker build and include Prisma artifacts in runtime; migrate API scripts to pnpm

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -6,6 +6,7 @@ COPY apps/api/package.json ./package.json
 RUN npm install
 
 COPY apps/api ./
+RUN npx prisma generate --schema prisma/schema.prisma
 RUN npx tsc -p tsconfig.build.json
 
 FROM node:22-noble AS runtime
@@ -18,6 +19,8 @@ COPY apps/api/package.json ./package.json
 RUN npm install --omit=dev
 
 COPY --from=build /app/apps/api/dist ./dist
+COPY --from=build /app/apps/api/node_modules/.prisma ./node_modules/.prisma
+COPY --from=build /app/apps/api/node_modules/@prisma ./node_modules/@prisma
 
 RUN groupadd --system --gid 1001 nodejs
 RUN useradd --system --uid 1001 --gid 1001 nodejs

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,12 +9,12 @@
   },
   "type": "commonjs",
   "scripts": {
-    "build": "npm run prisma:generate && tsc -p tsconfig.json",
+    "build": "pnpm run prisma:generate && tsc -p tsconfig.json",
     "start:dev": "tsx watch src/server.ts",
-    "start:prod": "node dist/src/server.js",
-    "test": "npm run prisma:generate && node scripts/run-jest.cjs --runInBand",
-    "test:coverage": "npm run prisma:generate && node scripts/run-jest.cjs --runInBand --coverage",
-    "lint": "npm run prisma:generate && tsc -p tsconfig.json --noEmit",
+    "start:prod": "pnpm run prisma:generate && node dist/src/server.js",
+    "test": "pnpm run prisma:generate && node scripts/run-jest.cjs",
+    "test:coverage": "pnpm run prisma:generate && node scripts/run-jest.cjs --coverage",
+    "lint": "pnpm run prisma:generate && tsc -p tsconfig.json --noEmit",
     "prisma:generate": "pnpm exec prisma generate --schema prisma/schema.prisma"
   },
   "dependencies": {


### PR DESCRIPTION
### Motivation
- Ensure the Prisma client is generated during image build so the runtime image has the necessary Prisma artifacts and native engines.
- Include generated Prisma artifacts in the runtime image to avoid runtime generation and missing binaries.
- Standardize package scripts to `pnpm` to match the monorepo package manager and ensure consistent local/CI behavior.

### Description
- In `Dockerfile.api` run `npx prisma generate --schema prisma/schema.prisma` in the build stage before TypeScript compilation.
- Copy Prisma runtime artifacts from the build stage into the runtime image by adding `COPY --from=build /app/apps/api/node_modules/.prisma ./node_modules/.prisma` and `COPY --from=build /app/apps/api/node_modules/@prisma ./node_modules/@prisma`.
- Update `apps/api/package.json` scripts to use `pnpm` instead of `npm` for `build`, `start:prod`, `test`, `test:coverage`, `lint`, and set `prisma:generate` to `pnpm exec prisma generate --schema prisma/schema.prisma`.
- Adjust test and start scripts to remove previous `--runInBand` usage and prepend Prisma generation via `pnpm` where applicable.

### Testing
- No automated tests were executed as part of this rollout.
- Recommended validations: run `pnpm run prisma:generate`, `pnpm run build` and build the API image with `docker build -f Dockerfile.api .` to verify the Prisma client and native engines are present in the runtime image.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcb61f10388330971815469dd156fb)