### PR TITLE
Centralize brand URL and fix social/referral share link generation

### DIFF
--- a/apps/web/src/components/ReferralProgram.tsx
+++ b/apps/web/src/components/ReferralProgram.tsx
@@ -6,10 +6,12 @@ import { useState } from 'react';
 import { motion } from 'framer-motion';
 import { Gift, Copy, Check, Users, DollarSign, Share2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { BRAND } from '@/lib/brand';
 
 export function ReferralProgram() {
   const [copied, setCopied] = useState(false);
-  const referralLink = 'https://infamousfreight.netlify.app/?ref=MILES50';
+  const referralLink = `${BRAND.siteUrl}/?ref=MILES50`;
+  const twitterReferralText = 'Just started using @InfamousFreight - best TMS for trucking!';
   
   const stats = {
     referralsMade: 3,
@@ -54,7 +56,13 @@ export function ReferralProgram() {
           <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
         </svg>
       ),
-      action: () => window.open(`https://twitter.com/intent/tweet?text=Just started using @InfamousFreight - best TMS for trucking!&url=${encodeURIComponent(referralLink)}`),
+      action: () => {
+        const params = new URLSearchParams({
+          text: twitterReferralText,
+          url: referralLink,
+        });
+        window.open(`https://twitter.com/intent/tweet?${params.toString()}`);
+      },
     },
   ];
 

--- a/apps/web/src/pages/ProductHunt.tsx
+++ b/apps/web/src/pages/ProductHunt.tsx
@@ -6,11 +6,23 @@ import { useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { ArrowUpRight, MessageSquare, Globe, Share2, Users, TrendingUp, Zap } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { BRAND } from '@/lib/brand';
 
 export default function ProductHunt() {
   useEffect(() => {
     document.title = 'Infamous Freight on Product Hunt - TMS for Modern Fleets';
   }, []);
+
+
+  const productHuntShareText =
+    'Just discovered @InfamousFreight - the TMS that actually understands trucking! #ProductHunt';
+  const tweetShareUrl = `https://twitter.com/intent/tweet?${new URLSearchParams({
+    text: productHuntShareText,
+    url: BRAND.siteUrl,
+  }).toString()}`;
+  const linkedInShareUrl = `https://www.linkedin.com/sharing/share-offsite/?${new URLSearchParams({
+    url: BRAND.siteUrl,
+  }).toString()}`;
 
   return (
     <div className="min-h-screen bg-black text-white">
@@ -156,7 +168,7 @@ export default function ProductHunt() {
           <p className="text-zinc-400 mb-6">Share Infamous Freight with your network</p>
           <div className="flex justify-center gap-4">
             <a 
-              href="https://twitter.com/intent/tweet?text=Just%20discovered%20@InfamousFreight%20-%20the%20TMS%20that%20actually%20understands%20trucking!%20%23ProductHunt"
+              href={tweetShareUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="flex items-center gap-2 bg-zinc-900 border border-zinc-800 rounded-lg px-4 py-2 hover:bg-zinc-800 transition-colors"
@@ -165,7 +177,7 @@ export default function ProductHunt() {
               <span className="text-sm">Tweet</span>
             </a>
             <a 
-              href="https://www.linkedin.com/sharing/share-offsite/?url=https://infamousfreight.netlify.app"
+              href={linkedInShareUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="flex items-center gap-2 bg-zinc-900 border border-zinc-800 rounded-lg px-4 py-2 hover:bg-zinc-800 transition-colors"


### PR DESCRIPTION
### Motivation
- Prevent brittle hardcoded domains for referral and social links by using the canonical brand URL and ensure share query params are properly encoded.

### Description
- Replaced hardcoded referral link with `BRAND.siteUrl` in `ReferralProgram.tsx` and added a `twitterReferralText` constant for reuse.
- Switched the referral Twitter action to build its query using `URLSearchParams` for correct encoding and safer link generation.
- Updated `ProductHunt.tsx` to import `BRAND` and compute `tweetShareUrl` and `linkedInShareUrl` via `URLSearchParams`, then replaced the previous hardcoded hrefs with these constants.
- Files changed: `apps/web/src/components/ReferralProgram.tsx` and `apps/web/src/pages/ProductHunt.tsx`.

### Testing
- Ran `pnpm --filter web test -- --runInBand` and all tests passed (vitest output: 3 files, 8 tests passed).
- Ran `pnpm --filter web build` and the frontend build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fda7c5354883308c7884910357b1ce)