### PR TITLE
refactor: split auto-assigners for issues and PRs, add maintainable config and restrict permissions

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,4 @@
+addAssignees: true
+assignees:
+  - MrMiless44
+numberOfAssignees: 1

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,33 @@
+name: Auto Assign
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  assign-issue:
+    name: Assign Issue
+    if: github.event_name == 'issues'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Auto-assign issue
+        uses: pozil/auto-assign-issue@v1
+        with:
+          assignees: MrMiless44
+          numOfAssignee: 1
+
+  assign-pr:
+    name: Assign Pull Request
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Auto-assign PR
+        uses: kentaro-m/auto-assign-action@v1.2.3
+        with:
+          configuration-path: .github/auto_assign.yml


### PR DESCRIPTION
### Motivation
- Separate issue and pull-request auto-assignment to use the most appropriate action per event and simplify maintenance.
- Centralize PR assignees in a single config file to make updates easier and avoid duplicating configuration.
- Reduce workflow permissions by granting each job only the write scope it needs to follow least-privilege.

### Description
- Add `.github/workflows/auto-assign.yml` which defines two jobs: `assign-issue` (runs on `issues` opens) and `assign-pr` (runs on `pull_request` opens) with event-specific `if` guards.
- `assign-issue` uses `pozil/auto-assign-issue@v1` and supplies `assignees: MrMiless44` and `numOfAssignee: 1`.
- `assign-pr` uses `kentaro-m/auto-assign-action@v1.2.3` and reads PR assignees from `configuration-path: .github/auto_assign.yml`.
- Add `.github/auto_assign.yml` containing the PR assignee list (`MrMiless44`) and `numberOfAssignees: 1`.

### Testing
- File contents were inspected with `nl -ba` to verify the workflow and config match the intended content, and inspection succeeded.
- Repository status showed the new workflow and config files present, and that check succeeded.
- A pull request was created to allow CI validation and further automated testing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdb8d8670c83308120821095037884)