### PR TITLE
Add workflow linting and OpenSSF Scorecard automation

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,27 @@
+name: Lint GitHub Actions workflows
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run actionlint
+        uses: reviewdog/action-actionlint@v1

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,26 @@
+name: OpenSSF Scorecard
+
+on:
+  schedule:
+    - cron: '15 10 * * 1'
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  scorecard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run OpenSSF Scorecard
+        uses: ossf/scorecard-action@v2.4.3
+        with:
+          publish_results: true


### PR DESCRIPTION
## Summary
Adds the remaining helpful automation bots:

- GitHub Actions workflow linting with Actionlint, triggered on workflow-file changes.
- OpenSSF Scorecard, scheduled weekly and runnable manually, to monitor supply-chain/security posture.

## Launch impact
- [x] No launch impact
- [ ] Private beta readiness
- [ ] Paid beta readiness
- [ ] Public launch readiness
- [ ] Production hotfix

## Area changed
- [ ] Web app
- [ ] API
- [ ] Database or Prisma
- [ ] Auth or roles
- [ ] Billing or Stripe
- [ ] Notifications
- [ ] Freight workflow
- [x] Deployment or CI/CD
- [ ] Documentation only

## Verification
Configuration-only GitHub Actions change. Verified the branch diff contains only:

```text
.github/workflows/actionlint.yml
.github/workflows/scorecard.yml
```

## Evidence
- Branch is ahead of main by 2 commits and behind by 0.
- No application runtime files changed.

## Risk checklist
- [x] No secrets committed
- [x] No production data included
- [x] Role/access behavior considered — no app behavior touched
- [x] Billing/payment behavior considered — no billing code touched
- [x] Rollback path identified — revert this PR
- [x] Docs updated where needed — workflow names are self-documenting

## Launch gate checklist
- [x] API health remains valid or was not touched
- [x] Web app still loads or was not touched
- [x] Quote intake still works or was not touched
- [x] Tracking flow still works or was not touched
- [x] Admin/operator flow still works or was not touched
- [x] Notifications still work or were not touched

## Follow-up issues
None.