### PR TITLE
chore: align Fly API runtime config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ FROM node:22-slim
 
 WORKDIR /usr/src/app
 
-RUN apt-get update -y && apt-get install -y openssl
+RUN apt-get update -y && apt-get install -y openssl && apt-get clean
 
 ENV NODE_ENV=production
 ENV PORT=4000

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,10 @@ FROM node:22-slim
 
 WORKDIR /usr/src/app
 
-RUN apt-get update -y && apt-get install -y openssl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update -y && apt-get install -y openssl
 
 ENV NODE_ENV=production
-ENV PORT=3000
+ENV PORT=4000
 
 COPY --from=build /usr/src/app/package.json ./package.json
 COPY --from=build /usr/src/app/pnpm-lock.yaml ./pnpm-lock.yaml
@@ -30,11 +30,11 @@ COPY --from=build /usr/src/app/pnpm-workspace.yaml ./pnpm-workspace.yaml
 COPY --from=build /usr/src/app/node_modules ./node_modules
 COPY --from=build /usr/src/app/apps/api ./apps/api
 
-EXPOSE 3000
+EXPOSE 4000
 
 USER node
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
-  CMD node -e "const port = process.env.PORT || 3000; require('http').get('http://127.0.0.1:' + port + '/api/health/live', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)}).on('error', () => process.exit(1))"
+  CMD node -e "const port = process.env.PORT || 4000; require('http').get('http://127.0.0.1:' + port + '/api/health/live', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)}).on('error', () => process.exit(1))"
 
 CMD ["node", "apps/api/dist/src/server.js"]

--- a/fly.toml
+++ b/fly.toml
@@ -1,4 +1,4 @@
-app = "infamous-freight"
+app = "infamous-freight-api"
 primary_region = "dfw"
 
 [build]
@@ -11,13 +11,13 @@ wait_timeout = "10m0s"
 [env]
 HOST = "0.0.0.0"
 NODE_ENV = "production"
-PORT = "3000"
+PORT = "4000"
 
 [http_service]
 auto_start_machines = true
 auto_stop_machines = false
 force_https = true
-internal_port = 3_000
+internal_port = 4_000
 min_machines_running = 1
 processes = [ "app" ]
 


### PR DESCRIPTION
## Summary

This PR applies the safe, non-workflow runtime configuration changes needed for the Fly API deployment move.

## Applied in this branch

- Updates `fly.toml` from `infamous-freight` to `infamous-freight-api`.
- Updates Fly runtime port from `3000` to `4000`.
- Updates Docker runtime `PORT`, `EXPOSE`, and healthcheck fallback from `3000` to `4000`.
- Keeps Docker package cleanup using `apt-get clean`.

## Not applied by the GitHub App/tooling here

The requested `.github/workflows/**` mutations were attempted but blocked before GitHub accepted the file writes. That is consistent with the platform/security boundary around workflow-file mutations and your note that these should be applied with a user PAT/session that has the `workflow` scope.

Use the previously generated workflow change kit to apply the workflow updates on top of this branch:

```bash
gh auth login --scopes repo,workflow
git fetch origin chore/fly-api-workflows
git checkout chore/fly-api-workflows
bash /path/to/infamous-freight-workflow-change-kit/apply-workflow-changes.sh
git add -A .github
git commit -m "chore: update API deployment workflows"
git push
```

## Follow-up validation

- Confirm the Fly app `infamous-freight-api` exists.
- Confirm the app listens on port `4000` in production.
- Confirm `api.infamousfreight.com` routes to the Fly API app.
- Apply the workflow kit with a PAT that has `workflow` scope.
