### PR TITLE
Add post-deploy Fly.io healthcheck, mock datastore in health tests, and improve Netlify CLI installer

### DIFF
--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -86,3 +86,9 @@ jobs:
 
       - name: Deploy API to Fly.io
         run: flyctl deploy --remote-only --config fly.toml
+
+      - name: Post-deploy health check
+        if: ${{ vars.FLY_HEALTHCHECK_URL != '' }}
+        run: |
+          echo "Checking ${{ vars.FLY_HEALTHCHECK_URL }}"
+          curl --fail --show-error --silent --max-time 20 --retry 5 --retry-delay 5 "${{ vars.FLY_HEALTHCHECK_URL }}"

--- a/apps/api/test/health.test.ts
+++ b/apps/api/test/health.test.ts
@@ -328,6 +328,11 @@ describe('configuration safety', () => {
         },
       });
 
+      const dataStore = dataStoreModule.createDataStore();
+      const listLoadsSpy = jest.spyOn(dataStore, 'listLoads').mockResolvedValue([]);
+      const subscriptionSpy = jest.spyOn(dataStore, 'getCarrierSubscriptionStatus').mockResolvedValue('active');
+      const createDataStoreSpy = jest.spyOn(dataStoreModule, 'createDataStore').mockReturnValue(dataStore);
+
       const response = await request(createApp())
         .get('/api/loads')
         .set('authorization', `Bearer ${token}`)
@@ -336,6 +341,10 @@ describe('configuration safety', () => {
 
       expect(response.status).toBe(200);
       expect(response.body.data).toEqual([]);
+
+      listLoadsSpy.mockRestore();
+      subscriptionSpy.mockRestore();
+      createDataStoreSpy.mockRestore();
     } finally {
       process.env.NODE_ENV = previousNodeEnv;
 

--- a/scripts/install-required-clis.sh
+++ b/scripts/install-required-clis.sh
@@ -80,13 +80,37 @@ install_netlify() {
     return
   fi
 
-  local netlify_prefix
+  local netlify_prefix install_cmd
   netlify_prefix="${REPO_ROOT}/.tools/netlify-cli"
-  npm --prefix "${netlify_prefix}" install --no-save netlify-cli@latest >/dev/null
-  if [[ -x "${netlify_prefix}/node_modules/.bin/netlify" ]]; then
-    cp "${netlify_prefix}/node_modules/.bin/netlify" "${TOOLS_DIR}/netlify"
-    chmod +x "${TOOLS_DIR}/netlify"
+
+  install_cmd=(npm --prefix "${netlify_prefix}" install --no-save netlify-cli@latest)
+  if command -v timeout >/dev/null 2>&1; then
+    if timeout 180 "${install_cmd[@]}" >/dev/null; then
+      if [[ -x "${netlify_prefix}/node_modules/.bin/netlify" ]]; then
+        cp "${netlify_prefix}/node_modules/.bin/netlify" "${TOOLS_DIR}/netlify"
+        chmod +x "${TOOLS_DIR}/netlify"
+        return
+      fi
+    fi
+  else
+    if "${install_cmd[@]}" >/dev/null; then
+      if [[ -x "${netlify_prefix}/node_modules/.bin/netlify" ]]; then
+        cp "${netlify_prefix}/node_modules/.bin/netlify" "${TOOLS_DIR}/netlify"
+        chmod +x "${TOOLS_DIR}/netlify"
+        return
+      fi
+    fi
   fi
+
+  cat > "${TOOLS_DIR}/netlify" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ -x "$(dirname "$0")/../netlify-cli/node_modules/.bin/netlify" ]]; then
+  exec "$(dirname "$0")/../netlify-cli/node_modules/.bin/netlify" "$@"
+fi
+exec npx --yes netlify-cli@latest "$@"
+EOF
+  chmod +x "${TOOLS_DIR}/netlify"
 }
 
 install_jq() {


### PR DESCRIPTION
### Motivation

- Ensure deployments to Fly.io are validated immediately after deploy by running a configurable health check.
- Make API unit tests deterministic in production-auth scenarios by mocking the data store to avoid external dependencies.
- Harden the `install-required-clis.sh` Netlify installer to avoid long/hanging installs and provide a reliable fallback wrapper when install fails or `timeout` is unavailable.

### Description

- Add a `Post-deploy health check` step to `.github/workflows/deploy-fly.yml` that runs `curl` against `vars.FLY_HEALTHCHECK_URL` with retries and timeouts when the variable is set.  
- Update `apps/api/test/health.test.ts` to create a mocked data store and spy on `listLoads` and `getCarrierSubscriptionStatus`, and to mock `createDataStore` to return the fake store, then restore spies after the test.  
- Revise `scripts/install-required-clis.sh` `install_netlify` function to use a timed `npm` install when `timeout` is available, and add a robust fallback by writing a shim executable into `${TOOLS_DIR}/netlify` that will exec a local binary if present or run `npx --yes netlify-cli@latest` otherwise.

### Testing

- Ran API unit tests with `pnpm -C apps/api run test -- --runInBand`, and the test suite (including the updated health tests) completed successfully.  
- The CI deploy workflow builds the API and Docker image via the existing `pnpm -C apps/api run build` and `docker build` steps, and the new health check step is added to that job (invoked only when `FLY_HEALTHCHECK_URL` is set).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe4d4e05208330be055a28c6435b05)