### PR TITLE
Remove Google Fonts preload and rename Fly app to infamous-freight

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -29,10 +29,6 @@
     <title>Infamous Freight — Verified Freight Command</title>
     <link rel="dns-prefetch" href="https://infamous-freight.fly.dev" />
     <link rel="dns-prefetch" href="https://www.googletagmanager.com" />
-    <link rel="dns-prefetch" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Space+Grotesk:wght@500;600;700;800&family=Rajdhani:wght@500;600;700&display=swap" rel="stylesheet" />
     <style>
       html,
       body,

--- a/fly.toml
+++ b/fly.toml
@@ -1,4 +1,4 @@
-app = "infamous-freight-api"
+app = "infamous-freight"
 primary_region = "dfw"
 
 [build]


### PR DESCRIPTION
### Motivation
- Remove external Google Fonts includes to eliminate third-party font requests and rely on system fonts, and align the Fly deployment configuration with the intended app name.

### Description
- Deleted Google Fonts `dns-prefetch`, `preconnect`, and stylesheet link from `apps/web/index.html`, leaving system font fallbacks in CSS.
- Updated the `app` identifier in `fly.toml` from `infamous-freight-api` to `infamous-freight`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a003999295c8330a81d65bc80eda504)