### PR TITLE
Switch runtime port from 4000 to 3000 in Dockerfile and fly.toml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /usr/src/app
 RUN apt-get update -y && apt-get install -y openssl && apt-get clean
 
 ENV NODE_ENV=production
-ENV PORT=4000
+ENV PORT=3000
 
 COPY --from=build /usr/src/app/package.json ./package.json
 COPY --from=build /usr/src/app/pnpm-lock.yaml ./pnpm-lock.yaml
@@ -30,11 +30,11 @@ COPY --from=build /usr/src/app/pnpm-workspace.yaml ./pnpm-workspace.yaml
 COPY --from=build /usr/src/app/node_modules ./node_modules
 COPY --from=build /usr/src/app/apps/api ./apps/api
 
-EXPOSE 4000
+EXPOSE 3000
 
 USER node
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
-  CMD node -e "const port = process.env.PORT || 4000; require('http').get('http://127.0.0.1:' + port + '/api/health/live', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)}).on('error', () => process.exit(1))"
+  CMD node -e "const port = process.env.PORT || 3000; require('http').get('http://127.0.0.1:' + port + '/api/health/live', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)}).on('error', () => process.exit(1))"
 
 CMD ["node", "apps/api/dist/src/server.js"]

--- a/fly.toml
+++ b/fly.toml
@@ -11,13 +11,13 @@ wait_timeout = "10m0s"
 [env]
 HOST = "0.0.0.0"
 NODE_ENV = "production"
-PORT = "4000"
+PORT = "3000"
 
 [http_service]
 auto_start_machines = true
 auto_stop_machines = false
 force_https = true
-internal_port = 4_000
+internal_port = 3000
 min_machines_running = 1
 processes = [ "app" ]
 

--- a/fly.toml
+++ b/fly.toml
@@ -25,7 +25,7 @@ processes = [ "app" ]
   grace_period = "1m30s"
   interval = "30s"
   method = "GET"
-  path = "/api/health"
+  path = "/api/health/live"
   timeout = "15s"
 
   [http_service.concurrency]


### PR DESCRIPTION
### Motivation
- Normalize the runtime port used by the container and platform to `3000` instead of `4000` so the service binds and healthchecks use the same port.

### Description
- Update `Dockerfile` to set `ENV PORT=3000`, change `EXPOSE` to `3000`, and adjust the `HEALTHCHECK` command to use port `3000` when probing `/api/health/live`.
- Update `fly.toml` to set `PORT = "3000"` and `internal_port = 3000` so the platform routes to the updated container port.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a004619fe5083308eef579d7fbe6060)