### PR TITLE
Enforce expected Fly app in image validation; update deploy flow, tests, and docs

### DIFF
--- a/apps/api/test/deploy-script.test.ts
+++ b/apps/api/test/deploy-script.test.ts
@@ -4,11 +4,15 @@ import { spawnSync } from 'child_process';
 describe('root deploy script', () => {
   const scriptPath = path.resolve(__dirname, '../../../deploy.sh');
 
-  const runValidation = (imageRef: string) => spawnSync(
-    'bash',
-    ['-lc', `source "${scriptPath}"; validate_container_image_ref "${imageRef}"`],
-    { encoding: 'utf8' },
-  );
+  const runValidation = (imageRef: string, expectedApp?: string) => {
+    const expectedArg = expectedApp ? ` "${expectedApp}"` : '';
+
+    return spawnSync(
+      'bash',
+      ['-lc', `source "${scriptPath}"; validate_container_image_ref "${imageRef}"${expectedArg}`],
+      { encoding: 'utf8' },
+    );
+  };
 
   it('rejects image refs with whitespace', () => {
     const result = runValidation('registry.fly.io/app:bad tag');
@@ -43,4 +47,18 @@ describe('root deploy script', () => {
 
     expect(result.status).toBe(0);
   });
+
+  it('rejects image refs for the wrong app when expected app is provided', () => {
+    const result = runValidation('registry.fly.io/another-app:deployment-123', 'infamous-freight');
+
+    expect(result.status).toBe(1);
+    expect(result.stdout + result.stderr).toContain('app mismatch');
+  });
+
+  it('accepts image refs that match the expected app', () => {
+    const result = runValidation('registry.fly.io/infamous-freight:deployment-123', 'infamous-freight');
+
+    expect(result.status).toBe(0);
+  });
+
 });

--- a/deploy.sh
+++ b/deploy.sh
@@ -176,6 +176,7 @@ run_tests() {
 
 validate_container_image_ref() {
   local image_ref="$1"
+  local expected_app="${2:-}"
 
   # Conservative validation for container image references used in deployment.
   if [[ "$image_ref" =~ [[:space:]] ]]; then
@@ -191,6 +192,17 @@ validate_container_image_ref() {
   if [[ "$image_ref" != *":"* && "$image_ref" != *@sha256:* ]]; then
     error "Invalid FLY_DEPLOY_IMAGE: expected a tagged image or digest (example: registry.fly.io/app:tag)"
     exit 1
+  fi
+
+  if [[ -n "$expected_app" ]]; then
+    local image_app="${image_ref#registry.fly.io/}"
+    image_app="${image_app%%:*}"
+    image_app="${image_app%%@sha256:*}"
+
+    if [[ "$image_app" != "$expected_app" ]]; then
+      error "Invalid FLY_DEPLOY_IMAGE: app mismatch (expected ${expected_app}, got ${image_app})"
+      exit 1
+    fi
   fi
 }
 
@@ -216,7 +228,7 @@ deploy_fly() {
   local deploy_image="${FLY_DEPLOY_IMAGE:-}"
   local -a fly_args=(deploy --app "$app_name" --remote-only)
   if [[ -n "$deploy_image" ]]; then
-    validate_container_image_ref "$deploy_image"
+    validate_container_image_ref "$deploy_image" "$app_name"
     log "Deploying prebuilt Fly image: $deploy_image"
     fly_args+=(--image "$deploy_image")
   fi

--- a/docs/operations/deployment-images.md
+++ b/docs/operations/deployment-images.md
@@ -1,0 +1,7 @@
+# Deployment Image Ledger
+
+## 2026-05-10
+
+- Fly.io production image candidate: `registry.fly.io/infamous-freight:deployment-01KR8JZYJNANQ5DBHJPR0A7EGF`
+- Validation: image follows `registry.fly.io/<app>:<tag>` format expected by `deploy.sh`.
+


### PR DESCRIPTION
### Motivation
- Prevent accidental deployments of prebuilt images to the wrong Fly.io app by verifying the image's app component against the expected app name.
- Record and document deployment image candidates for traceability.

### Description
- Extend `validate_container_image_ref` to accept an optional `expected_app` parameter and fail if the image's app segment does not match the expected app.
- Pass the resolved `app_name` into `validate_container_image_ref` from `deploy_fly` when `FLY_DEPLOY_IMAGE` is provided.
- Update `apps/api/test/deploy-script.test.ts` to support the optional expected app argument and add tests that cover both matching and non-matching app names.
- Add `docs/operations/deployment-images.md` with the latest Fly.io production image candidate and format expectations.

### Testing
- Ran the unit test suite with `npm test -- --coverage` including the updated `apps/api` deploy script tests, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a004e78f2288330b0abce81d835065b)