### PR TITLE
Add multi-image detection and optional override to Fly post-deploy check

### DIFF
--- a/apps/api/test/fly-post-deploy-check-script.test.ts
+++ b/apps/api/test/fly-post-deploy-check-script.test.ts
@@ -17,6 +17,11 @@ describe('fly post deploy check script', () => {
     expect(content).toContain('flyctl auth whoami');
     expect(content).toContain('flyctl status --app "${APP_NAME}"');
     expect(content).toContain('flyctl checks list --app "${APP_NAME}"');
+    expect(content).toContain('ALLOW_MULTI_IMAGE_DEPLOY="${ALLOW_MULTI_IMAGE_DEPLOY:-false}"');
+    expect(content).toContain('flyctl machine list --app "${APP_NAME}" --json');
+    expect(content).toContain('ERROR: ${APP_NAME} has ${unique_image_count} deployed images across machines.');
+    expect(content).toContain('machine(s) with ${image}: ${ids}');
+    expect(content).toContain('WARN: Continuing because ALLOW_MULTI_IMAGE_DEPLOY=true');
     expect(content).toContain('curl -fsS "${APP_URL}/api/health" >/dev/null');
     expect(content).toContain('curl -fsS "${API_URL}/api/health" >/dev/null');
   });

--- a/scripts/fly-post-deploy-check.sh
+++ b/scripts/fly-post-deploy-check.sh
@@ -4,10 +4,32 @@ set -euo pipefail
 APP_NAME="${1:-infamous-freight}"
 APP_URL="${2:-https://infamous-freight.fly.dev}"
 API_URL="${3:-https://api.infamousfreight.com}"
+ALLOW_MULTI_IMAGE_DEPLOY="${ALLOW_MULTI_IMAGE_DEPLOY:-false}"
 
 flyctl auth whoami
 flyctl status --app "${APP_NAME}"
 flyctl checks list --app "${APP_NAME}"
+
+machine_json="$(flyctl machine list --app "${APP_NAME}" --json)"
+image_report="$(printf '%s' "${machine_json}" | node -e 'let raw=""; process.stdin.on("data", c => raw += c); process.stdin.on("end", () => { const machines = JSON.parse(raw || "[]"); const byImage = new Map(); for (const m of machines) { const key = m.image_ref || "unknown-image"; const bucket = byImage.get(key) || []; bucket.push(m.id || "unknown-machine"); byImage.set(key, bucket); } const rows = [...byImage.entries()].map(([image, ids]) => `${ids.length}|${image}|${ids.join(",")}`); process.stdout.write(rows.join("\n")); });')"
+
+unique_image_count="$(printf '%s' "${image_report}" | sed '/^$/d' | wc -l | tr -d ' ')"
+
+if [[ "${unique_image_count}" != "1" ]]; then
+  echo "ERROR: ${APP_NAME} has ${unique_image_count} deployed images across machines." >&2
+  printf '%s\n' "${image_report}" | while IFS='|' read -r count image ids; do
+    [[ -n "${image}" ]] || continue
+    echo "${count} machine(s) with ${image}: ${ids}" >&2
+  done
+  echo "Run: flyctl machine list --app ${APP_NAME}" >&2
+  echo "Keep one active deployment image before scaling with the UI or flyctl scale." >&2
+
+  if [[ "${ALLOW_MULTI_IMAGE_DEPLOY}" != "true" ]]; then
+    exit 1
+  fi
+
+  echo "WARN: Continuing because ALLOW_MULTI_IMAGE_DEPLOY=true (expected only during active rollout)." >&2
+fi
 
 curl -fsS "${APP_URL}/api/health" >/dev/null
 curl -fsS "${API_URL}/api/health" >/dev/null


### PR DESCRIPTION
### Motivation
- Ensure Fly deployments have a single active image across machines to avoid inconsistent behavior during scaling or traffic shifts.
- Provide an explicit opt-out for in-progress rollouts by honoring an environment variable `ALLOW_MULTI_IMAGE_DEPLOY`.

### Description
- Introduces `ALLOW_MULTI_IMAGE_DEPLOY` environment variable and defaults it to `false` in `scripts/fly-post-deploy-check.sh`.
- Adds a `flyctl machine list --app "${APP_NAME}" --json` call and parses the JSON via `node -e` to aggregate machines by `image_ref` and build a compact `image_report`.
- Computes `unique_image_count` and emits an error summary with per-image machine counts and IDs, exiting with non-zero status unless `ALLOW_MULTI_IMAGE_DEPLOY=true`.
- Updates the unit test `apps/api/test/fly-post-deploy-check-script.test.ts` to assert the presence of the new checks and messages.

### Testing
- Ran the updated unit test file `apps/api/test/fly-post-deploy-check-script.test.ts`, which verifies script content and the new multi-image detection strings, and the test passed.
- The modified script was exercised by the test assertions that check for the new `flyctl` call and reporting lines, and those assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0052e65fd08330a24db140205995d1)