### PR TITLE
Add Fly health-timeout troubleshooting and secrets-rollout scripts; update runbook

### DIFF
--- a/docs/fly-deployment-runbook.md
+++ b/docs/fly-deployment-runbook.md
@@ -121,3 +121,42 @@ fly secrets set DATABASE_URL='<new_database_url>' --app infamous-freight
 # 5) verify release health
 scripts/fly-post-deploy-check.sh infamous-freight https://infamous-freight.fly.dev https://api.infamousfreight.com
 ```
+
+
+## If deploy times out waiting for health checks
+
+A timeout such as `timeout reached waiting for health checks to pass` means Fly started the Machine, but it never became healthy before deploy timeout.
+
+Run these commands from repo root and keep the app explicit:
+
+```bash
+fly status -a infamous-freight --all
+fly checks list -a infamous-freight
+fly machine status <machine-id> -a infamous-freight
+fly logs -a infamous-freight --machine <machine-id> --no-tail
+
+# one-shot helper:
+scripts/fly-diagnose-health-timeout.sh infamous-freight <machine-id>
+```
+
+Common root causes:
+
+- API process crashed after startup due to bad/missing secrets.
+- Port/host mismatch (must bind `0.0.0.0:3000` in this repo).
+- Health route mismatch or non-200 responses from `/api/health/live`.
+
+Secrets rollout (deterministic sequence):
+
+```bash
+scripts/fly-secrets-rollout.sh infamous-freight
+
+# Equivalent manual steps:
+# fly config save -a infamous-freight --yes
+# fly secrets sync -a infamous-freight --stage
+# fly secrets deploy -a infamous-freight
+```
+
+Notes:
+
+- `--detach` only skips waiting; it does not fix health failures.
+- Use `--stage` + `deploy` when you want one controlled restart window.

--- a/scripts/fly-diagnose-health-timeout.sh
+++ b/scripts/fly-diagnose-health-timeout.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_NAME="${1:-infamous-freight}"
+MACHINE_ID="${2:-}"
+
+if [[ -z "${MACHINE_ID}" ]]; then
+  echo "Usage: $0 <app-name> <machine-id>"
+  echo "Example: $0 infamous-freight 0803666c2ed6d8"
+  exit 1
+fi
+
+echo "==> App status (${APP_NAME})"
+fly status -a "${APP_NAME}" --all
+
+echo "\n==> Health checks (${APP_NAME})"
+fly checks list -a "${APP_NAME}"
+
+echo "\n==> Machine status (${MACHINE_ID})"
+fly machine status "${MACHINE_ID}" -a "${APP_NAME}"
+
+echo "\n==> Machine logs (${MACHINE_ID})"
+fly logs -a "${APP_NAME}" --machine "${MACHINE_ID}" --no-tail

--- a/scripts/fly-secrets-rollout.sh
+++ b/scripts/fly-secrets-rollout.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_NAME="${1:-infamous-freight}"
+
+echo "==> Saving remote Fly config"
+fly config save -a "${APP_NAME}" --yes
+
+echo "==> Staging secret changes"
+fly secrets sync -a "${APP_NAME}" --stage
+
+echo "==> Deploying staged secrets"
+fly secrets deploy -a "${APP_NAME}"
+
+echo "Secrets rollout completed for ${APP_NAME}."


### PR DESCRIPTION
### Motivation

- Provide clear runbook steps for diagnosing deployments that time out waiting for Fly health checks.
- Capture common root causes (crashed API, port binding, health-route mismatch) to speed incident response.
- Offer deterministic secret rollout and a small automation helper to reduce manual errors when rotating secrets.

### Description

- Add a new troubleshooting section to `docs/fly-deployment-runbook.md` with commands, common causes, and notes for `timeout reached waiting for health checks` scenarios.
- Add `scripts/fly-diagnose-health-timeout.sh`, a small helper that runs `fly status`, `fly checks list`, `fly machine status`, and `fly logs` for a provided machine id.
- Add `scripts/fly-secrets-rollout.sh`, a helper that runs `fly config save`, `fly secrets sync --stage`, and `fly secrets deploy` to perform a deterministic secrets rollout.

### Testing

- No automated tests were added or executed for these documentation and operational script changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0064184738833083023ac45241599c)