### PR TITLE
Enforce required secrets, add PR validation & CI, improve compose/smoke scripts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,13 +13,13 @@ CORS_ORIGIN=http://localhost:5173
 # CORS_ORIGINS=http://localhost:5173,http://localhost:3000
 
 # ——— Database ———
-DATABASE_URL=postgresql://infamous:changeme@localhost:5432/infamous_freight?schema=public
+DATABASE_URL=postgresql://infamous:<set-db-password>@localhost:5432/infamous_freight?schema=public
 DB_USER=infamous
-DB_PASSWORD=changeme
+DB_PASSWORD=<set-db-password>
 DB_NAME=infamous_freight
 
 # ——— API security ———
-JWT_SECRET=replace-this-in-production
+JWT_SECRET=<set-jwt-secret-at-least-32-chars>
 RATE_LIMIT_ENABLED=true
 # Legacy compatibility for older scripts:
 API_RATE_LIMIT_ENABLED=true
@@ -27,7 +27,7 @@ API_RATE_LIMIT_ENABLED=true
 # ——— Redis ———
 REDIS_HOST=localhost
 REDIS_PORT=6379
-REDIS_PASSWORD=changeme
+REDIS_PASSWORD=<set-redis-password>
 REDIS_DB=0
 
 # ——— Observability ———
@@ -35,27 +35,27 @@ SENTRY_DSN=https://example.invalid/sentry-dsn
 
 # ——— Stripe ———
 STRIPE_ACCOUNT_ID=acct_your-stripe-account-id
-STRIPE_SECRET_KEY=replace-with-stripe-secret-key
-STRIPE_WEBHOOK_SECRET=replace-with-stripe-webhook-signing-secret
-STRIPE_PUBLISHABLE_KEY=replace-with-stripe-publishable-key
-VITE_STRIPE_PUBLIC_KEY=replace-with-stripe-publishable-key
-STRIPE_PRICE_ONE_TIME=replace-with-one-time-price-id
+STRIPE_SECRET_KEY=<set-stripe-secret-key>
+STRIPE_WEBHOOK_SECRET=<set-stripe-webhook-signing-secret>
+STRIPE_PUBLISHABLE_KEY=<set-stripe-publishable-key>
+VITE_STRIPE_PUBLIC_KEY=<set-stripe-publishable-key>
+STRIPE_PRICE_ONE_TIME=<set-stripe-price-id>
 # Legacy alias supported by the API for the same one-time add-on price:
-STRIPE_PRICE_AI_ADDON_PACK=replace-with-one-time-price-id
+STRIPE_PRICE_AI_ADDON_PACK=<set-stripe-price-id>
 STRIPE_PORTAL_RETURN_URL=http://localhost:5173/settings
 STRIPE_CHECKOUT_SUCCESS_URL=http://localhost:5173/settings?checkout=success&session_id={CHECKOUT_SESSION_ID}
 STRIPE_CHECKOUT_CANCEL_URL=http://localhost:5173/settings?checkout=canceled
 
 # ——— Supabase ———
 SUPABASE_URL=https://your-project.supabase.co
-SUPABASE_SERVICE_KEY=your-service-key
+SUPABASE_SERVICE_KEY=<set-supabase-service-key>
 # Preferred service-role alias for newer tooling:
-SUPABASE_SERVICE_ROLE_KEY=your-service-key
-SUPABASE_ANON_KEY=your-anon-key
+SUPABASE_SERVICE_ROLE_KEY=<set-supabase-service-key>
+SUPABASE_ANON_KEY=<set-supabase-anon-key>
 VITE_SUPABASE_URL=https://your-project.supabase.co
 VITE_SUPABASE_PUBLISHABLE_KEY=sb_publishable_your_key
 # Legacy frontend alias accepted by the Codex checker:
-VITE_SUPABASE_ANON_KEY=your-anon-key
+VITE_SUPABASE_ANON_KEY=<set-supabase-anon-key>
 
 # ——— Load Board APIs ———
 DAT_API_KEY=your-dat-api-key
@@ -76,7 +76,7 @@ XERO_CLIENT_ID=your-xero-client-id
 XERO_CLIENT_SECRET=your-xero-secret
 
 # ——— SendGrid ———
-SENDGRID_API_KEY=your-sendgrid-key
+SENDGRID_API_KEY=<set-sendgrid-api-key>
 FROM_EMAIL=noreply@infamousfreight.com
 
 # ——— Factoring ———

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,11 @@
+name: "Infamous Freight CodeQL Config"
+
+paths:
+  - apps/api
+  - apps/web
+
+paths-ignore:
+  - node_modules
+  - dist
+  - coverage
+  - "**/*.test.ts"

--- a/.github/workflows/validate-pr-ready.yml
+++ b/.github/workflows/validate-pr-ready.yml
@@ -9,17 +9,19 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v4.1.0
         with:
           version: 10.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/validate-pr-ready.yml
+++ b/.github/workflows/validate-pr-ready.yml
@@ -1,0 +1,33 @@
+name: Validate PR Ready
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.0.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate PR readiness
+        env:
+          SKIP_INSTALL: "1"
+        run: ./scripts/validate-pr-ready.sh

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: compose-up compose-down smoke-api validate-pr-ready
+
+compose-up:
+	./scripts/docker-compose.sh up -d --build
+
+compose-down:
+	./scripts/docker-compose.sh down
+
+smoke-api:
+	./scripts/smoke-api-health.sh
+
+validate-pr-ready:
+	./scripts/validate-pr-ready.sh

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -32,7 +32,7 @@
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.6",
     "@types/jest": "^29.5.14",
-    "@types/node": "^25.6.2",
+    "@types/node": "^22.15.30",
     "@types/supertest": "^7.2.0",
     "jest": "^29.7.0",
     "prisma": "7.8.0",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     restart: unless-stopped
     environment:
       POSTGRES_USER: ${DB_USER:-infamous}
-      POSTGRES_PASSWORD: ${DB_PASSWORD:-changeme}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD is required}
       POSTGRES_DB: ${DB_NAME:-infamous_freight}
     volumes:
       - postgres_data:/var/lib/postgresql/data
@@ -28,7 +28,7 @@ services:
     image: redis:7-alpine
     container_name: infamous-redis
     restart: unless-stopped
-    command: redis-server --requirepass ${REDIS_PASSWORD:-changeme}
+    command: redis-server --requirepass ${REDIS_PASSWORD:?REDIS_PASSWORD is required}
     volumes:
       - redis_data:/data
     ports:
@@ -51,12 +51,12 @@ services:
     restart: unless-stopped
     environment:
       NODE_ENV: production
-      PORT: 3001
-      DATABASE_URL: postgresql://${DB_USER:-infamous}:${DB_PASSWORD:-changeme}@postgres:5432/${DB_NAME:-infamous_freight}?schema=public
+      PORT: 3000
+      DATABASE_URL: postgresql://${DB_USER:-infamous}:${DB_PASSWORD:?DB_PASSWORD is required}@postgres:5432/${DB_NAME:-infamous_freight}?schema=public
       REDIS_HOST: redis
       REDIS_PORT: 6379
-      REDIS_PASSWORD: ${REDIS_PASSWORD:-changeme}
-      JWT_SECRET: ${JWT_SECRET:-changeme}
+      REDIS_PASSWORD: ${REDIS_PASSWORD:?REDIS_PASSWORD is required}
+      JWT_SECRET: ${JWT_SECRET:?JWT_SECRET is required}
       STRIPE_ACCOUNT_ID: ${STRIPE_ACCOUNT_ID}
       STRIPE_SECRET_KEY: ${STRIPE_SECRET_KEY}
       STRIPE_WEBHOOK_SECRET: ${STRIPE_WEBHOOK_SECRET}
@@ -71,7 +71,7 @@ services:
       XERO_CLIENT_SECRET: ${XERO_CLIENT_SECRET}
       SENDGRID_API_KEY: ${SENDGRID_API_KEY}
     ports:
-      - "3001:3001"
+      - "3001:3000"
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,7 @@ This directory contains operational, architectural, and launch-readiness documen
 - [INFAMOUS_FREIGHT_MVP_BUILD_PLAN.md](./INFAMOUS_FREIGHT_MVP_BUILD_PLAN.md) — MVP build plan.
 - [MVP_LAUNCH_DEMO_DATA_SET.md](./MVP_LAUNCH_DEMO_DATA_SET.md) — Demo data set for MVP launch.
 - [REPO-ACCURATE-STATUS.md](./REPO-ACCURATE-STATUS.md) — Current repo status.
+- [RELEASE.md](./RELEASE.md) — Pre-merge release checklist and deployment safety gates.
 - [launch/](./launch) — Additional launch artifacts.
 
 ## 🛠️ Production Operations

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,21 @@
+# Release Checklist
+
+## Required checks before merge
+
+1. `pnpm --filter @infamous-freight/api lint`
+2. `pnpm --filter @infamous-freight/api test -- --runInBand`
+3. `pnpm -r build`
+4. `./scripts/smoke-api-health.sh`
+
+## Deployment safety gates
+
+- Prisma client generated before runtime.
+- API binds to `PORT=3000` in production runtime.
+- Health endpoint returns HTTP 200.
+- No placeholder secrets remain in tracked env templates.
+
+## Rollout
+
+- Deploy backend first, then web.
+- Run post-deploy health checks for `/health` and `/api/health`.
+- Verify tenant-scoped protected routes with auth headers in staging.

--- a/recommended-fixes-report.md
+++ b/recommended-fixes-report.md
@@ -1,0 +1,18 @@
+# Recommended Fixes Report (v2 rollout)
+
+## Applied
+
+- Enforced required sensitive compose env vars for DB, Redis, and JWT.
+- Removed weak/secret-like placeholders from `.env.example`.
+- Aligned API `@types/node` with Node 22 baseline.
+- Added compose compatibility wrapper (`docker compose`/`docker-compose`).
+- Added root `Makefile` helper targets.
+- Strengthened smoke test to validate `/health` and `/api/health` response payloads (`status: ok`).
+- Added PR readiness validator script for install/build/lint/test/audit/placeholder scan.
+- Added CodeQL config scoping and ignore patterns.
+- Added release checklist documentation.
+
+## Validation commands
+
+- `pnpm --filter @infamous-freight/api lint`
+- `pnpm --filter @infamous-freight/api test -- --runInBand`

--- a/scripts/docker-compose.sh
+++ b/scripts/docker-compose.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+  exec docker compose "$@"
+fi
+
+if command -v docker-compose >/dev/null 2>&1; then
+  exec docker-compose "$@"
+fi
+
+echo "Neither 'docker compose' nor 'docker-compose' is installed." >&2
+exit 1

--- a/scripts/smoke-api-health.sh
+++ b/scripts/smoke-api-health.sh
@@ -10,6 +10,7 @@ cleanup() {
 trap cleanup EXIT
 
 export PORT="${PORT:-3000}"
+SMOKE_TIMEOUT_SECONDS="${SMOKE_TIMEOUT_SECONDS:-20}"
 
 if [[ -z "${DATABASE_URL:-}" ]]; then
   echo "DATABASE_URL is not set; running smoke test in NODE_ENV=test fallback mode." >&2
@@ -19,14 +20,31 @@ fi
 node apps/api/dist/src/server.js >/tmp/if-api-smoke.log 2>&1 &
 API_PID=$!
 
-for _ in {1..20}; do
-  if curl -fsS "http://127.0.0.1:${PORT}/health" >/tmp/if-api-health.json 2>/dev/null; then
-    cat /tmp/if-api-health.json
+check_endpoint() {
+  local endpoint="$1"
+  local output_file="/tmp/if-api-health-$(echo "$endpoint" | tr '/' '_').json"
+
+  if ! curl -fsS "http://127.0.0.1:${PORT}${endpoint}" >"${output_file}" 2>/dev/null; then
+    return 1
+  fi
+
+  if ! node -e "const fs=require('fs');const p=process.argv[1];const d=JSON.parse(fs.readFileSync(p,'utf8'));if(!(d && d.status==='ok')) process.exit(1);" "${output_file}"; then
+    echo "Health response from ${endpoint} did not include status=ok" >&2
+    cat "${output_file}" >&2
+    return 1
+  fi
+
+  cat "${output_file}"
+  return 0
+}
+
+for _ in $(seq 1 "$SMOKE_TIMEOUT_SECONDS"); do
+  if check_endpoint "/health" || check_endpoint "/api/health"; then
     exit 0
   fi
-  sleep 0.5
+  sleep 1
 done
 
-echo "API health check failed on PORT=${PORT}. Logs:" >&2
+echo "API health check failed on PORT=${PORT} after ${SMOKE_TIMEOUT_SECONDS}s. Logs:" >&2
 cat /tmp/if-api-smoke.log >&2
 exit 1

--- a/scripts/validate-pr-ready.sh
+++ b/scripts/validate-pr-ready.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+: "${SKIP_INSTALL:=0}"
+: "${SKIP_AUDIT:=0}"
+
+if [[ "$SKIP_INSTALL" != "1" ]]; then
+  pnpm install --frozen-lockfile
+fi
+
+pnpm -r build
+pnpm --filter @infamous-freight/api lint
+pnpm --filter @infamous-freight/api test -- --runInBand
+./scripts/smoke-api-health.sh
+
+if [[ "$SKIP_AUDIT" != "1" ]]; then
+  pnpm audit --prod
+fi
+
+if rg -n "changeme|sk_test_|whsec_|SG\.|replace-this-in-production" .env.example docker-compose.yml; then
+  echo "Secret-like placeholders still detected in tracked templates." >&2
+  exit 1
+fi
+
+echo "PR readiness checks completed."


### PR DESCRIPTION
### Motivation
- Prevent accidental use of weak placeholder secrets and fail early when required sensitive env vars are missing from compose/runtime.
- Add automated PR readiness validation and CodeQL scoping to catch build/lint/test/audit issues before merge.
- Make local developer workflows and smoke tests more robust and compatible with both `docker compose` and `docker-compose`.

### Description
- Replaced weak placeholders in `.env.example` with explicit `<set-...>` hints and updated `docker-compose.yml` to use parameter expansion with `:?` to require `DB_PASSWORD`, `REDIS_PASSWORD`, and `JWT_SECRET`, and changed the API container to bind to `PORT=3000` with host mapping `3001:3000`.
- Added a portability wrapper script `scripts/docker-compose.sh` and a root `Makefile` with helper targets `compose-up`, `compose-down`, `smoke-api`, and `validate-pr-ready` for common developer tasks.
- Strengthened the smoke test in `scripts/smoke-api-health.sh` to validate both `/health` and `/api/health` endpoints, assert a JSON `status: ok` payload, add a configurable timeout, and capture logs on failure.
- Added a PR readiness script `scripts/validate-pr-ready.sh`, a GitHub Actions workflow `.github/workflows/validate-pr-ready.yml` to run the validator on PRs, and a CodeQL config file `.github/codeql/codeql-config.yml` to scope analysis.
- Added `docs/RELEASE.md`, `recommended-fixes-report.md`, and updated `apps/api/package.json` to align `@types/node` with Node 22.

### Testing
- Run full build with `pnpm -r build`, which completed successfully.
- Run API lint with `pnpm --filter @infamous-freight/api lint`, which completed successfully.
- Run API tests with `pnpm --filter @infamous-freight/api test -- --runInBand`, which completed successfully.
- Run the smoke health check with `./scripts/smoke-api-health.sh`, which verified the `/health` or `/api/health` endpoint and succeeded.
- Run `pnpm audit --prod` as part of readiness checks (skippable via `SKIP_AUDIT`), which was executed and returned without blocking the rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00df5bd5a48330b7bed762051c8576)