### PR TITLE
Update .env.example: add site, Redis, Sentry, Supabase, Fly and API variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,9 @@
 NODE_ENV=development
 PORT=3001
 WEB_APP_URL=http://localhost:5173
+SITE_URL=http://localhost:5173
+PUBLIC_SITE_URL=http://localhost:5173
+FRONTEND_URL=http://localhost:5173
 CORS_ORIGIN=http://localhost:5173
 # Use CORS_ORIGINS for multiple comma-separated origins in shared/dev/prod environments.
 # CORS_ORIGINS=http://localhost:5173,http://localhost:3000
@@ -29,9 +32,16 @@ REDIS_HOST=localhost
 REDIS_PORT=6379
 REDIS_PASSWORD=<set-redis-password>
 REDIS_DB=0
+REDIS_URL=redis://:<set-redis-password>@localhost:6379/0
 
 # ——— Observability ———
-SENTRY_DSN=https://example.invalid/sentry-dsn
+SENTRY_DSN=https://sentry.local/ingest
+VITE_SENTRY_DSN=https://sentry.local/ingest
+NEXT_PUBLIC_SENTRY_DSN=https://sentry.local/ingest
+VITE_SENTRY_ENABLED=false
+SENTRY_ORG=infamousfreight
+SENTRY_PROJECT=web
+SENTRY_AUTH_TOKEN=<set-sentry-auth-token>
 
 # ——— Stripe ———
 STRIPE_ACCOUNT_ID=acct_your-stripe-account-id
@@ -47,15 +57,18 @@ STRIPE_CHECKOUT_SUCCESS_URL=http://localhost:5173/settings?checkout=success&sess
 STRIPE_CHECKOUT_CANCEL_URL=http://localhost:5173/settings?checkout=canceled
 
 # ——— Supabase ———
-SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_URL=https://prod-infamousfreight.supabase.co
 SUPABASE_SERVICE_KEY=<set-supabase-service-key>
 # Preferred service-role alias for newer tooling:
 SUPABASE_SERVICE_ROLE_KEY=<set-supabase-service-key>
 SUPABASE_ANON_KEY=<set-supabase-anon-key>
-VITE_SUPABASE_URL=https://your-project.supabase.co
-VITE_SUPABASE_PUBLISHABLE_KEY=sb_publishable_your_key
+SUPABASE_JWT_SECRET=<set-supabase-jwt-secret>
+VITE_SUPABASE_URL=https://prod-infamousfreight.supabase.co
+VITE_SUPABASE_PUBLISHABLE_KEY=sb_publishable_live_key
 # Legacy frontend alias accepted by the Codex checker:
 VITE_SUPABASE_ANON_KEY=<set-supabase-anon-key>
+VITE_SUPABASE_DATABASE_URL=postgresql://postgres:<set-db-password>@localhost:5432/postgres
+NEXT_PUBLIC_SUPABASE_URL=https://prod-infamousfreight.supabase.co
 
 # ——— Load Board APIs ———
 DAT_API_KEY=your-dat-api-key
@@ -84,6 +97,10 @@ RTS_API_KEY=your-rts-key
 OTR_API_KEY=your-otr-key
 APEX_API_KEY=your-apex-key
 
+# ——— Fly.io / Deploy Tooling ———
+FLY_API_TOKEN=<set-fly-api-token>
+
 # ——— Web Frontend ———
 VITE_API_URL=http://localhost:3001
+API_PUBLIC_URL=http://localhost:3001
 VITE_SOCKET_URL=ws://localhost:3001


### PR DESCRIPTION
### Motivation
- Provide a more complete and standardized development example environment by adding common service and frontend environment variables.
- Replace placeholder endpoints with project-specific defaults to simplify local and staging configuration.
- Add compatibility aliases and legacy variables expected by various tooling and frontend code.

### Description
- Added new frontend/site variables including `SITE_URL`, `PUBLIC_SITE_URL`, `FRONTEND_URL`, and `API_PUBLIC_URL` and preserved `CORS_ORIGIN` and `VITE_API_URL` for compatibility.
- Added `REDIS_URL` alongside discrete Redis host/port settings and updated Redis example to include a URL form.
- Updated Sentry defaults and added Sentry-related envs `VITE_SENTRY_DSN`, `NEXT_PUBLIC_SENTRY_DSN`, `VITE_SENTRY_ENABLED`, `SENTRY_ORG`, `SENTRY_PROJECT`, and `SENTRY_AUTH_TOKEN`.
- Replaced Supabase placeholder values with project-specific URLs and added `SUPABASE_JWT_SECRET`, `VITE_SUPABASE_URL`, `VITE_SUPABASE_PUBLISHABLE_KEY`, `VITE_SUPABASE_DATABASE_URL`, and `NEXT_PUBLIC_SUPABASE_URL` while keeping legacy aliases like `VITE_SUPABASE_ANON_KEY`.
- Added `FLY_API_TOKEN` for Fly.io/deploy tooling and kept existing keys for Stripe, SendGrid, load boards, ELD providers, QuickBooks, Xero, and factoring providers.

### Testing
- No automated tests were run for this change because it only updates the `.env.example` documentation file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00f2eb28f08330b9eddce8d1334dba)