### PR TITLE
Load local dotenv files in codex-env-check.sh

### DIFF
--- a/scripts/codex-env-check.sh
+++ b/scripts/codex-env-check.sh
@@ -15,6 +15,33 @@ fi
 
 printf '\n== Codex Environment Check ==\n\n'
 
+# Load local dotenv files when present so the check matches repo configuration.
+# Precedence: existing exported env vars > .env.local > .env
+load_dotenv_file() {
+  local file_path="$1"
+  [[ -f "$file_path" ]] || return 0
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+    [[ "$line" != *=* ]] && continue
+
+    local name="${line%%=*}"
+    local value="${line#*=}"
+
+    # Trim leading/trailing whitespace around key only.
+    name="${name#${name%%[![:space:]]*}}"
+    name="${name%${name##*[![:space:]]}}"
+
+    # Do not override already-exported environment variables.
+    if [[ -z "${!name:-}" ]]; then
+      export "${name}=${value}"
+    fi
+  done < "$file_path"
+}
+
+load_dotenv_file ".env"
+load_dotenv_file ".env.local"
+
 required_vars=(
   NODE_ENV
   DATABASE_URL


### PR DESCRIPTION
### Motivation

- Ensure the environment diagnostic script reflects repo-local configuration by loading `.env` files when present so checks match developer/workspace settings.
- Preserve secrets by not printing values and avoid overwriting explicitly exported environment variables.

### Description

- Added a `load_dotenv_file` helper to parse dotenv files, skip comments and non key-value lines, trim whitespace around keys, and export values only when the variable is not already set. 
- Invokes `load_dotenv_file` for `.env` and `.env.local` before running the existing environment variable presence checks.
- Keeps the script's original strict-mode handling and non-printing of sensitive values while improving local configurability.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00e7d6c84c8330bc33ce085842f669)