### PR TITLE
Add new ops SSH key and verification instructions

### DIFF
--- a/docs/operations/ssh-authorized-keys.md
+++ b/docs/operations/ssh-authorized-keys.md
@@ -7,6 +7,7 @@ This document tracks approved SSH public keys for production operations.
 | Key ID | Added (UTC) | Algorithm | Fingerprint (SHA256) | Status | Notes |
 | --- | --- | --- | --- | --- | --- |
 | `ops-key-2026-04-30-01` | 2026-04-30 | RSA 4096 | `ENq3sUhcnOq79ETLvC9RN2Ltb/+52cXTGFaFWPicxsA` | Active | Imported from approved request |
+| `ops-key-2026-05-10-01` | 2026-05-10 | RSA 4096 | `+jmJ2MjDAwxuvW6zu8URZHNkOpAEF2YeI+QzH7PGWC4` | Active | Imported from approved request |
 
 ## Apply key to host safely
 
@@ -15,9 +16,9 @@ Use `scripts/ops/sync-authorized-key.sh` to enforce fingerprint verification bef
 ### Option A: pass environment variables inline
 
 ```bash
-KEY_ID=ops-key-2026-04-30-01 \
-SSH_PUBLIC_KEY='ssh-rsa <full-public-key>' \
-EXPECTED_SHA256='ENq3sUhcnOq79ETLvC9RN2Ltb/+52cXTGFaFWPicxsA' \
+KEY_ID=ops-key-2026-05-10-01 \
+SSH_PUBLIC_KEY='ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC8qFjaUnAirp8w7zj7zJtQLy7DwEwVkwKm7uwKMPoa79iMgELXLOOhIwV5lJo2CGPk/wz0T7Ou4sSj/FFJIj1lJViermPpNCWS1+XArgwefHiWguUMszSWdWwpoJ2VoIyFW57UlQi7UD5S9POgzepy8wVzqMLiuWvS9Cp6ShLBqVQfo/Qad9M1gBjKK3c2YfMQniGZDow4Os1ouv48+ZsjeokTIQWUf37XeKO0QFoQn2DCX4ts9tNy1QF80faTxYIiuVkvoAPBe4AucHDqtX8d/Ehs2wTz4gWKgt8zIisIqztq5hTqbTIRSFBiCMwnnduudoanL2XQzCbVesFizuMawZSjC2qjqtKk5fsLYvfg26SDXZ9mhtd15F8fIcXqMB6UebX9LvpsxnVFbXrRjNiQmjvBkkUtFM10l6uFMcuBFczORyl1CDh93kYahIlovuzqPWLfGgV65kOnixRGmhxnXodotPDk2yZrd3a6uP1W6t/RVfqHvMyqalXs137ArzRtAqNcr8Vror25UMg4GMPRtOoE1KUd3fas4ty0E/smvuP7MFM70VzgRcweo7Gra0qg+nj7pd0gH284wDV9y/+k9V6xFhWojQc398n2OfFWYBfIeSJuFrj1SBmq7I/DEIjhd/KaNJEUdBbfVpOS+Z3EnehSrXnosV0JTP+qsBWDmQ==' \
+EXPECTED_SHA256='+jmJ2MjDAwxuvW6zu8URZHNkOpAEF2YeI+QzH7PGWC4' \
 ./scripts/ops/sync-authorized-key.sh
 ```
 
@@ -25,12 +26,19 @@ EXPECTED_SHA256='ENq3sUhcnOq79ETLvC9RN2Ltb/+52cXTGFaFWPicxsA' \
 
 ```bash
 cat > ./.ssh-key.env <<'ENV'
-KEY_ID=ops-key-2026-04-30-01
-SSH_PUBLIC_KEY="ssh-rsa <full-public-key>"
-EXPECTED_SHA256=ENq3sUhcnOq79ETLvC9RN2Ltb/+52cXTGFaFWPicxsA
+KEY_ID=ops-key-2026-05-10-01
+SSH_PUBLIC_KEY="ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC8qFjaUnAirp8w7zj7zJtQLy7DwEwVkwKm7uwKMPoa79iMgELXLOOhIwV5lJo2CGPk/wz0T7Ou4sSj/FFJIj1lJViermPpNCWS1+XArgwefHiWguUMszSWdWwpoJ2VoIyFW57UlQi7UD5S9POgzepy8wVzqMLiuWvS9Cp6ShLBqVQfo/Qad9M1gBjKK3c2YfMQniGZDow4Os1ouv48+ZsjeokTIQWUf37XeKO0QFoQn2DCX4ts9tNy1QF80faTxYIiuVkvoAPBe4AucHDqtX8d/Ehs2wTz4gWKgt8zIisIqztq5hTqbTIRSFBiCMwnnduudoanL2XQzCbVesFizuMawZSjC2qjqtKk5fsLYvfg26SDXZ9mhtd15F8fIcXqMB6UebX9LvpsxnVFbXrRjNiQmjvBkkUtFM10l6uFMcuBFczORyl1CDh93kYahIlovuzqPWLfGgV65kOnixRGmhxnXodotPDk2yZrd3a6uP1W6t/RVfqHvMyqalXs137ArzRtAqNcr8Vror25UMg4GMPRtOoE1KUd3fas4ty0E/smvuP7MFM70VzgRcweo7Gra0qg+nj7pd0gH284wDV9y/+k9V6xFhWojQc398n2OfFWYBfIeSJuFrj1SBmq7I/DEIjhd/KaNJEUdBbfVpOS+Z3EnehSrXnosV0JTP+qsBWDmQ=="
+EXPECTED_SHA256=+jmJ2MjDAwxuvW6zu8URZHNkOpAEF2YeI+QzH7PGWC4
 ENV
 
 ENV_FILE=./.ssh-key.env ./scripts/ops/sync-authorized-key.sh
+```
+
+### Verify fingerprint before applying
+
+```bash
+printf '%s\n' "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC8qFjaUnAirp8w7zj7zJtQLy7DwEwVkwKm7uwKMPoa79iMgELXLOOhIwV5lJo2CGPk/wz0T7Ou4sSj/FFJIj1lJViermPpNCWS1+XArgwefHiWguUMszSWdWwpoJ2VoIyFW57UlQi7UD5S9POgzepy8wVzqMLiuWvS9Cp6ShLBqVQfo/Qad9M1gBjKK3c2YfMQniGZDow4Os1ouv48+ZsjeokTIQWUf37XeKO0QFoQn2DCX4ts9tNy1QF80faTxYIiuVkvoAPBe4AucHDqtX8d/Ehs2wTz4gWKgt8zIisIqztq5hTqbTIRSFBiCMwnnduudoanL2XQzCbVesFizuMawZSjC2qjqtKk5fsLYvfg26SDXZ9mhtd15F8fIcXqMB6UebX9LvpsxnVFbXrRjNiQmjvBkkUtFM10l6uFMcuBFczORyl1CDh93kYahIlovuzqPWLfGgV65kOnixRGmhxnXodotPDk2yZrd3a6uP1W6t/RVfqHvMyqalXs137ArzRtAqNcr8Vror25UMg4GMPRtOoE1KUd3fas4ty0E/smvuP7MFM70VzgRcweo7Gra0qg+nj7pd0gH284wDV9y/+k9V6xFhWojQc398n2OfFWYBfIeSJuFrj1SBmq7I/DEIjhd/KaNJEUdBbfVpOS+Z3EnehSrXnosV0JTP+qsBWDmQ==" | ssh-keygen -lf -
+# Expected: 4096 SHA256:+jmJ2MjDAwxuvW6zu8URZHNkOpAEF2YeI+QzH7PGWC4
 ```
 
 ## Key custody and rotation policy


### PR DESCRIPTION
### Motivation

- Register a newly approved SSH public key for production operations to maintain an up-to-date access registry. 
- Provide concrete, safe instructions for applying the key with fingerprint verification to reduce risk of adding an incorrect key.

### Description

- Add `ops-key-2026-05-10-01` to the active keys table with its RSA 4096 fingerprint. 
- Update the Option A and Option B usage examples to use the new `KEY_ID`, the full `SSH_PUBLIC_KEY`, and the `EXPECTED_SHA256` fingerprint. 
- Add a verification snippet showing how to confirm the public key fingerprint using `ssh-keygen -lf -` before applying the key.

### Testing

- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a010891ff4c83308cc6d5cb22f6370b)