### PR TITLE
Add HSTS and propagate security headers to static assets in Nginx configs

### DIFF
--- a/apps/web/nginx.conf
+++ b/apps/web/nginx.conf
@@ -12,10 +12,15 @@ server {
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Strict-Transport-Security "max-age=31536000" always;
 
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Strict-Transport-Security "max-age=31536000" always;
     }
 
     location / {

--- a/apps/web/nginx.conf
+++ b/apps/web/nginx.conf
@@ -11,6 +11,7 @@ server {
 
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Strict-Transport-Security "max-age=31536000" always;
 
@@ -19,6 +20,7 @@ server {
         add_header Cache-Control "public, immutable";
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
+        add_header X-XSS-Protection "1; mode=block" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Strict-Transport-Security "max-age=31536000" always;
     }

--- a/nginx.conf
+++ b/nginx.conf
@@ -15,6 +15,7 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Strict-Transport-Security "max-age=31536000" always;
 
     # API proxy
     location /api {
@@ -45,6 +46,10 @@ server {
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Strict-Transport-Security "max-age=31536000" always;
     }
 
     # SPA fallback

--- a/nginx.conf
+++ b/nginx.conf
@@ -48,6 +48,7 @@ server {
         add_header Cache-Control "public, immutable";
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
+        add_header X-XSS-Protection "1; mode=block" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Strict-Transport-Security "max-age=31536000" always;
     }


### PR DESCRIPTION
### Motivation
- Ensure HTTP responses and long-lived cached static assets carry consistent security headers and enforce HTTPS via HSTS.

### Description
- Add `add_header Strict-Transport-Security "max-age=31536000" always;` to the server block in both `nginx.conf` and `apps/web/nginx.conf`.
- Replicate `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, and `Strict-Transport-Security` headers inside the static assets `location` blocks so cached files also receive the security headers.
- Preserve existing gzip, proxy, and SPA fallback configuration while applying header changes only.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0110e8d6488330941a7f910a994dc7)