### PR TITLE
Add frontend env safety check script, tests, and CI step

### DIFF
--- a/.github/workflows/required-checks.yml
+++ b/.github/workflows/required-checks.yml
@@ -58,6 +58,9 @@ jobs:
       - name: Verify required environment variables
         run: pnpm run codex:env-check:strict
 
+      - name: Verify frontend env safety
+        run: bash scripts/check-client-env-safety.sh
+
       - name: Generate Prisma client
         run: pnpm run prisma:generate
 

--- a/apps/api/test/check-client-env-safety-script.test.ts
+++ b/apps/api/test/check-client-env-safety-script.test.ts
@@ -1,0 +1,85 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+describe('check-client-env-safety.sh', () => {
+  const sourceScript = path.resolve(__dirname, '..', '..', '..', 'scripts', 'check-client-env-safety.sh');
+
+  function setupRepoFixture(prefix: string): { tmp: string; scriptPath: string; webDir: string } {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+    const scriptDir = path.join(tmp, 'scripts');
+    const webDir = path.join(tmp, 'apps', 'web');
+
+    fs.mkdirSync(scriptDir, { recursive: true });
+    fs.mkdirSync(webDir, { recursive: true });
+
+    const scriptPath = path.join(scriptDir, 'check-client-env-safety.sh');
+    fs.copyFileSync(sourceScript, scriptPath);
+    fs.chmodSync(scriptPath, 0o755);
+
+    return { tmp, scriptPath, webDir };
+  }
+
+  it('passes for VITE_* and approved Sentry keys', () => {
+    const { tmp, scriptPath, webDir } = setupRepoFixture('client-env-safe-');
+    fs.writeFileSync(
+      path.join(webDir, '.env.example'),
+      [
+        'VITE_API_URL=https://api.example.com',
+        'VITE_SUPABASE_URL=https://project.supabase.co',
+        'SENTRY_ORG=infamous',
+        'SENTRY_PROJECT=frontend',
+      ].join('\n'),
+    );
+
+    const result = spawnSync('/usr/bin/bash', [scriptPath], {
+      cwd: tmp,
+      encoding: 'utf8',
+      env: process.env,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Frontend env safety check passed');
+  });
+
+  it('fails when server-side secrets appear in frontend env files', () => {
+    const { tmp, scriptPath, webDir } = setupRepoFixture('client-env-secret-');
+    fs.writeFileSync(
+      path.join(webDir, '.env.production'),
+      [
+        'VITE_API_URL=https://api.example.com',
+        'STRIPE_SECRET_KEY=sk_live_should_not_be_here',
+      ].join('\n'),
+    );
+
+    const result = spawnSync('/usr/bin/bash', [scriptPath], {
+      cwd: tmp,
+      encoding: 'utf8',
+      env: process.env,
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('disallowed key STRIPE_SECRET_KEY');
+  });
+
+  it('fails when non-VITE non-allowlisted keys are present', () => {
+    const { tmp, scriptPath, webDir } = setupRepoFixture('client-env-key-policy-');
+    fs.writeFileSync(
+      path.join(webDir, '.env.local'),
+      [
+        'VITE_API_URL=https://api.example.com',
+        'WEB_INTERNAL_TOKEN=unexpected',
+      ].join('\n'),
+    );
+
+    const result = spawnSync('/usr/bin/bash', [scriptPath], {
+      cwd: tmp,
+      encoding: 'utf8',
+      env: process.env,
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('non-public key WEB_INTERNAL_TOKEN must be VITE_* or explicitly allowlisted');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "netlify:production:readiness": "bash scripts/netlify-production-readiness.sh",
     "production:secrets:setup": "bash scripts/setup-production-secrets.sh",
     "production:secrets:dry-run": "DRY_RUN=true bash scripts/setup-production-secrets.sh",
-    "check:prisma-versions": "node scripts/check-prisma-version-alignment.js"
+    "check:prisma-versions": "node scripts/check-prisma-version-alignment.js",
+    "env:check:frontend": "bash scripts/check-client-env-safety.sh"
   },
   "devDependencies": {
     "@netlify/edge-functions": "^3.0.6",

--- a/scripts/check-client-env-safety.sh
+++ b/scripts/check-client-env-safety.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WEB_ENV_GLOB='apps/web/.env*'
+ALLOWED_NON_VITE_KEYS=(
+  SENTRY_AUTH_TOKEN
+  SENTRY_ORG
+  SENTRY_PROJECT
+  SENTRY_DISABLE_UPLOAD
+  SENTRY_SOURCEMAPS
+)
+
+# Frontend env files must never carry server-side secret keys.
+DISALLOWED_KEYS=(
+  DATABASE_URL
+  DIRECT_URL
+  SUPABASE_SERVICE_ROLE_KEY
+  STRIPE_SECRET_KEY
+  STRIPE_WEBHOOK_SECRET
+  OPENAI_API_KEY
+  ANTHROPIC_API_KEY
+  JWT_SECRET
+)
+
+if ! compgen -G "$WEB_ENV_GLOB" > /dev/null; then
+  echo "::error::No frontend env files found matching ${WEB_ENV_GLOB}"
+  exit 1
+fi
+
+violations=()
+while IFS= read -r env_file; do
+  [[ -f "$env_file" ]] || continue
+
+  # 1) Explicit deny-list of backend secrets.
+  for key in "${DISALLOWED_KEYS[@]}"; do
+    if rg -n "^${key}=" "$env_file" >/dev/null; then
+      violations+=("${env_file}: disallowed key ${key}")
+    fi
+  done
+
+  # 2) Allow only VITE_* and known build-time keys.
+  while IFS= read -r line; do
+    key="${line%%=*}"
+    [[ -z "$key" ]] && continue
+    [[ "$key" =~ ^[[:space:]]*# ]] && continue
+    [[ "$key" =~ ^[[:space:]]*$ ]] && continue
+
+    key="$(echo "$key" | xargs)"
+
+    if [[ "$key" == VITE_* ]]; then
+      continue
+    fi
+
+    allowed=false
+    for allowed_key in "${ALLOWED_NON_VITE_KEYS[@]}"; do
+      if [[ "$key" == "$allowed_key" ]]; then
+        allowed=true
+        break
+      fi
+    done
+
+    if [[ "$allowed" == false ]]; then
+      violations+=("${env_file}: non-public key ${key} must be VITE_* or explicitly allowlisted")
+    fi
+  done < <(rg "^[A-Za-z_][A-Za-z0-9_]*=" "$env_file" -or '$0')
+done < <(find apps/web -maxdepth 1 -type f -name '.env*' | sort)
+
+if (( ${#violations[@]} > 0 )); then
+  {
+    echo "::error::Frontend env safety violations found:"
+    for violation in "${violations[@]}"; do
+      echo "- ${violation}"
+    done
+    echo "Only VITE_* public keys (plus approved Sentry build-time keys) are allowed in apps/web/.env* files."
+  } >&2
+  exit 1
+fi
+
+echo "Frontend env safety check passed for apps/web/.env* files."


### PR DESCRIPTION
### Motivation

- Prevent accidental leakage of server-side secrets into frontend env files by enforcing a policy for `apps/web/.env*` files. 
- Ensure this policy is enforced automatically in CI before build and test steps to catch mistakes early.

### Description

- Add a new enforcement script `scripts/check-client-env-safety.sh` that denies a set of backend secret keys and allows only `VITE_*` keys plus an explicit allowlist of build-time Sentry keys. 
- Add a CI step `Verify frontend env safety` to `.github/workflows/required-checks.yml` that runs the new script during required checks. 
- Add a package script `env:check:frontend` mapped to `bash scripts/check-client-env-safety.sh` in `package.json`. 
- Add unit tests `apps/api/test/check-client-env-safety-script.test.ts` that exercise passing and failing scenarios for public keys, disallowed secrets, and non-allowlisted non-`VITE_` keys.

### Testing

- Added unit tests under `apps/api/test/check-client-env-safety-script.test.ts` which include three cases covering allowed `VITE_*` and Sentry keys, detection of server-side secrets, and detection of non-`VITE_` non-allowlisted keys. 
- Running the test suite with `pnpm run test` executes the new tests; they passed locally in the development run. 
- The CI required-checks workflow now runs the `Verify frontend env safety` step as part of the normal `pnpm install`, `pnpm run lint`, `pnpm run build`, and `pnpm run test` sequence.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a011680b24483308d58a4d80f4bd3ce)