### PR TITLE
docs: add explicit remediation for Fly multi-image machine warning

### DIFF
--- a/docs/fly-deployment-runbook.md
+++ b/docs/fly-deployment-runbook.md
@@ -146,6 +146,25 @@ APP_NAME=infamous-freight bash scripts/fly-reconcile-single-image.sh
 
 The script prints the number of machines per image and exits with status 1 (no changes) if multiple images are found, including the exact command needed to enable pruning.
 
+
+**If Fly warns that your app is running multiple images:**
+
+When you see:
+
+```
+Your app is currently running multiple images.
+```
+
+run a dry run first, then prune to the newest image only:
+
+```bash
+APP_NAME=infamous-freight bash scripts/fly-reconcile-single-image.sh
+PRUNE_OLD_IMAGES=true APP_NAME=infamous-freight KEEP_IMAGE=<newest-image-from-dry-run> bash scripts/fly-reconcile-single-image.sh
+```
+
+For the sample distribution below, keep `infamous-freight:deployment-01KRA9YB5HK4TFJH0XXNAFPRZB` because it has the newest deployment id and already runs 2 machines; prune the two older one-machine images and the older two-machine image only after verifying traffic and health checks.
+
+
 **Prune machines on old images:**
 
 ```bash


### PR DESCRIPTION
### Motivation
- Provide operators a clear, safe remediation path when Fly reports `Your app is currently running multiple images` so they can converge machines to a single image without accidental mass destruction.

### Description
- Add a subsection to `docs/fly-deployment-runbook.md` that documents a two-step flow: run `APP_NAME=infamous-freight bash scripts/fly-reconcile-single-image.sh` (dry run) then run `PRUNE_OLD_IMAGES=true APP_NAME=infamous-freight KEEP_IMAGE=<newest-image-from-dry-run> bash scripts/fly-reconcile-single-image.sh` to prune stale-image machines.
- Include explicit operator guidance for the sample machine distribution recommending keeping `infamous-freight:deployment-01KRA9YB5HK4TFJH0XXNAFPRZB` and to verify traffic and health checks before pruning older-image machines.

### Testing
- Ran targeted Jest suites with `pnpm -s jest apps/api/test/fly-reconcile-single-image-script.test.ts apps/api/test/fly-reconcile-single-image-behavior.test.ts --runInBand`, which failed due to the repository Jest ESM/transform configuration (`Cannot use import statement outside a module`) and is unrelated to this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0130c9f6f4833087e22705cbd1bc61)