### PR TITLE
Pin @hono/node-server to 1.19.13, update pnpm lockfile, and fix package description

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "infamous-freight",
   "version": "1.0.0",
   "private": true,
-  "description": "Infamous Freight \u2014 The freight dispatch platform built by truckers, for truckers",
+  "description": "Infamous Freight — The freight dispatch platform built by truckers, for truckers",
   "packageManager": "pnpm@10.0.0",
   "repository": {
     "type": "git",
@@ -87,7 +87,10 @@
       "@sentry/cli",
       "esbuild",
       "prisma"
-    ]
+    ],
+    "overrides": {
+      "@hono/node-server": "1.19.13"
+    }
   },
   "dependencies": {
     "@netlify/database": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,13 +4,16 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@hono/node-server': 1.19.13
+
 importers:
 
   .:
     dependencies:
       '@netlify/database':
         specifier: ^1.0.0
-        version: 1.0.0(@electric-sql/pglite@0.4.1)(mysql2@3.15.3)(postgres@3.4.7)
+        version: 1.0.0(mysql2@3.15.3)(postgres@3.4.7)
       netlify-build-plugin-pagewatch:
         specifier: ^1.0.2
         version: 1.0.2
@@ -809,8 +812,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
 
-  '@hono/node-server@1.19.11':
-    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
+  '@hono/node-server@1.19.13':
+    resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
@@ -4959,7 +4962,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@hono/node-server@1.19.11(hono@4.12.18)':
+  '@hono/node-server@1.19.13(hono@4.12.18)':
     dependencies:
       hono: 4.12.18
 
@@ -5257,12 +5260,12 @@ snapshots:
 
   '@neondatabase/serverless@1.1.0': {}
 
-  '@netlify/database@1.0.0(@electric-sql/pglite@0.4.1)(mysql2@3.15.3)(postgres@3.4.7)':
+  '@netlify/database@1.0.0(mysql2@3.15.3)(postgres@3.4.7)':
     dependencies:
       '@neondatabase/serverless': 1.1.0
       '@netlify/runtime-utils': 2.3.0
       pg: 8.20.0
-      waddler: 0.1.1(@electric-sql/pglite@0.4.1)(@neondatabase/serverless@1.1.0)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7)
+      waddler: 0.1.1(@neondatabase/serverless@1.1.0)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7)
       ws: 8.20.0
     transitivePeerDependencies:
       - '@clickhouse/client'
@@ -5569,7 +5572,7 @@ snapshots:
       '@electric-sql/pglite': 0.4.1
       '@electric-sql/pglite-socket': 0.1.1(@electric-sql/pglite@0.4.1)
       '@electric-sql/pglite-tools': 0.3.1(@electric-sql/pglite@0.4.1)
-      '@hono/node-server': 1.19.11(hono@4.12.18)
+      '@hono/node-server': 1.19.13(hono@4.12.18)
       '@prisma/get-platform': 7.2.0
       '@prisma/query-plan-executor': 7.2.0
       '@prisma/streams-local': 0.1.2
@@ -8827,9 +8830,8 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
-  waddler@0.1.1(@electric-sql/pglite@0.4.1)(@neondatabase/serverless@1.1.0)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7):
+  waddler@0.1.1(@neondatabase/serverless@1.1.0)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7):
     optionalDependencies:
-      '@electric-sql/pglite': 0.4.1
       '@neondatabase/serverless': 1.1.0
       mysql2: 3.15.3
       pg: 8.20.0


### PR DESCRIPTION
### Motivation
- Ensure a consistent `@hono/node-server` version across the workspace by adding an explicit pnpm override to avoid transitive version drift.
- Normalize the package description punctuation to use a proper em dash for readability.

### Description
- Added a `pnpm.overrides` entry in `package.json` to pin `@hono/node-server` to `1.19.13`.
- Updated `pnpm-lock.yaml` to include a top-level `overrides` entry for `@hono/node-server` and bumped references from `1.19.11` to `1.19.13` in the lockfile snapshots and package entries.
- Removed transitive references to `@electric-sql/pglite` from some lockfile entries for `@netlify/database` and `waddler` signatures and adjusted related resolution metadata.
- Replaced the escaped em dash in `package.json` `description` with a proper em dash character.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0132f256f48330b9ee48340978662c)