### PR TITLE
Run Jest in-band for apps/api test script

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,7 +12,7 @@
     "build": "pnpm run prisma:generate && tsc -p tsconfig.build.json",
     "start:dev": "tsx watch src/server.ts",
     "start:prod": "pnpm run prisma:generate && node dist/src/server.js",
-    "test": "pnpm run prisma:generate && node scripts/run-jest.cjs",
+    "test": "pnpm run prisma:generate && node scripts/run-jest.cjs --runInBand",
     "test:coverage": "pnpm run prisma:generate && node scripts/run-jest.cjs --coverage",
     "lint": "pnpm run prisma:generate && tsc -p tsconfig.json --noEmit",
     "prisma:generate": "pnpm exec prisma generate --schema prisma/schema.prisma"


### PR DESCRIPTION
### Motivation
- Ensure the test runner executes serially to avoid concurrency issues (e.g. with Prisma or shared resources) by disabling parallel Jest workers.

### Description
- Updated `apps/api/package.json` to change the `test` script from `node scripts/run-jest.cjs` to `node scripts/run-jest.cjs --runInBand`.

### Testing
- Ran `pnpm --filter @infamous-freight/api test`, which invokes `pnpm run prisma:generate` and Jest with `--runInBand`, and the automated test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01363a243483308540c5a1abe63eac)