### PR TITLE
fly.toml: add `processes` and switch http_service to use `web` process

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -8,6 +8,10 @@ dockerfile = "Dockerfile"
 strategy = "rolling"
 wait_timeout = "10m0s"
 
+[processes]
+app = "node apps/api/dist/src/server.js"
+web = "node apps/api/dist/src/server.js"
+
 [env]
 HOST = "0.0.0.0"
 NODE_ENV = "production"
@@ -19,7 +23,7 @@ auto_stop_machines = false
 force_https = true
 internal_port = 3000
 min_machines_running = 1
-processes = [ "app" ]
+processes = [ "web" ]
 
   [[http_service.checks]]
   grace_period = "1m30s"


### PR DESCRIPTION
### Motivation
- Ensure the HTTP service uses the correct process name and provide explicit process entrypoints by defining `app` and `web` to the built Node server. 

### Description
- Add a `[processes]` section with `app = "node apps/api/dist/src/server.js"` and `web = "node apps/api/dist/src/server.js"` to declare runtime entrypoints. 
- Update `[http_service].processes` from `[ "app" ]` to `[ "web" ]` so the service binds to the `web` process. 

### Testing
- No automated tests were run for this configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a019894dee083308a35b6ae60b9ee12)