### PR TITLE
Add 'api' process to Fly config; detect `flyctl` and add `shellcheck` installer/checks

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -9,6 +9,7 @@ strategy = "rolling"
 wait_timeout = "10m0s"
 
 [processes]
+api = "node apps/api/dist/src/server.js"
 app = "node apps/api/dist/src/server.js"
 web = "node apps/api/dist/src/server.js"
 
@@ -23,7 +24,7 @@ auto_stop_machines = false
 force_https = true
 internal_port = 3000
 min_machines_running = 1
-processes = [ "web" ]
+processes = [ "api", "web" ]
 
   [[http_service.checks]]
   grace_period = "1m30s"

--- a/scripts/fly-preflight.sh
+++ b/scripts/fly-preflight.sh
@@ -5,6 +5,17 @@ APP_NAME="${1:-infamous-freight}"
 APP_URL="${2:-https://infamous-freight.fly.dev}"
 API_URL="${3:-https://api.infamousfreight.com}"
 
+if command -v fly >/dev/null 2>&1; then
+  :
+elif command -v flyctl >/dev/null 2>&1; then
+  fly() {
+    flyctl "$@"
+  }
+else
+  echo "Error: neither 'flyctl' nor 'fly' is installed." >&2
+  exit 1
+fi
+
 fly auth whoami
 fly status --app "${APP_NAME}"
 

--- a/scripts/install-required-clis.sh
+++ b/scripts/install-required-clis.sh
@@ -131,6 +131,29 @@ install_docker() {
   return 1
 }
 
+install_shellcheck() {
+  if command -v shellcheck >/dev/null 2>&1 || [[ -x "${TOOLS_DIR}/shellcheck" ]]; then
+    echo "shellcheck already installed"
+    return
+  fi
+
+  if [[ "$(id -u)" -eq 0 ]]; then
+    apt-get update
+    apt-get install -y shellcheck
+    return
+  fi
+
+  if command -v sudo >/dev/null 2>&1; then
+    sudo apt-get update
+    sudo apt-get install -y shellcheck
+    return
+  fi
+
+  echo "shellcheck requires root privileges to install. Re-run with sudo or as root:" >&2
+  echo "  sudo apt-get update && sudo apt-get install -y shellcheck" >&2
+  return 1
+}
+
 
 install_flyctl
 install_supabase
@@ -139,6 +162,7 @@ install_github_cli
 install_netlify
 install_jq
 install_docker
+install_shellcheck
 
 echo "Required CLIs are available in ${TOOLS_DIR}."
 echo "Add to PATH: export PATH=\"${TOOLS_DIR}:\$PATH\""

--- a/scripts/verify-required-clis.sh
+++ b/scripts/verify-required-clis.sh
@@ -29,6 +29,12 @@ else
   echo "⚠️ jq missing (recommended for scripts/install-dev-clis.sh and operational tooling)" >&2
 fi
 
+if command -v shellcheck >/dev/null 2>&1 || [[ -x "${TOOLS_DIR}/shellcheck" ]]; then
+  echo "✅ shellcheck found (recommended)"
+else
+  echo "⚠️ shellcheck missing (recommended for shell script linting)" >&2
+fi
+
 if [[ "$missing" -ne 0 ]]; then
   exit 1
 fi


### PR DESCRIPTION
### Motivation

- Expose a distinct `api` process in the Fly deployment so health checks and scaling include the API worker separately from `web`.
- Make preflight tooling robust to systems where the Fly CLI is installed as `flyctl` instead of `fly`.
- Include `shellcheck` in the required CLIs to improve shell script linting and developer experience.

### Description

- Added an `api` process entry to `fly.toml` and updated `http_service.processes` to `[ "api", "web" ]` so the API process is part of the HTTP service.
- Enhanced `scripts/fly-preflight.sh` to detect `fly` or `flyctl` and to define a `fly` wrapper when only `flyctl` exists, and to exit with an error if neither is installed.
- Added `install_shellcheck` to `scripts/install-required-clis.sh` and invoked it during CLI setup to install `shellcheck` via `apt-get` when needed.
- Updated `scripts/verify-required-clis.sh` to report the presence of `shellcheck` and to print a recommended warning when it is missing.

### Testing

- Ran the CLI verification script `bash scripts/verify-required-clis.sh` on a machine with the required CLIs and it completed successfully (exits 0) when tools were present.
- Performed a local execution of `scripts/fly-preflight.sh` in an environment with `flyctl` installed to verify the wrapper logic, which succeeded.
- No unit tests were modified or required for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a019c5f468c8330b76551e3f2d9c139)