### PR TITLE
Fix Fly API port configuration

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -25,9 +25,9 @@ PORT = "3000"
 auto_start_machines = true
 auto_stop_machines = false
 force_https = true
-internal_port = 3_000
+internal_port = 3000
 min_machines_running = 1
-processes = [ "app" ]
+processes = ["app"]
 
   [[http_service.checks]]
   grace_period = "1m30s"
@@ -45,5 +45,4 @@ processes = [ "app" ]
   cpu_kind = "performance"
   cpus = 1
   memory = "2gb"
-  memory_mb = 2_048
   size = "performance-cpu-1x"


### PR DESCRIPTION
## Summary

- Align Fly `http_service.internal_port` with the API server `PORT=3000`.
- Remove duplicate `memory_mb` VM memory setting and keep `memory = "2gb"`.
- Keep the existing `/api/health/live` health check path.

## Why

The API server reads `process.env.PORT` and defaults to `3000`, so Fly should route traffic to port `3000` inside the machine. This prevents health-check and public routing failures caused by a port mismatch.