### PR TITLE
docs: add verification entry to recommended-fixes-report

### DIFF
--- a/recommended-fixes-report.md
+++ b/recommended-fixes-report.md
@@ -16,3 +16,8 @@
 
 - `pnpm --filter @infamous-freight/api lint`
 - `pnpm --filter @infamous-freight/api test -- --runInBand`
+
+## Verification (2026-05-12)
+
+- ✅ `pnpm --filter @infamous-freight/api lint`
+- ✅ `pnpm --filter @infamous-freight/api test -- --runInBand`


### PR DESCRIPTION
### Motivation
- Capture and document the successful verification of the previously-applied recommended fixes so repo health signals are recorded in `recommended-fixes-report.md`.

### Description
- Add a `## Verification (2026-05-12)` section to `recommended-fixes-report.md` that lists the validation commands that were run.

### Testing
- Ran `pnpm --filter @infamous-freight/api lint` and `pnpm --filter @infamous-freight/api test -- --runInBand`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02ea0a890c8330a27dae6dfa963610)