### PR TITLE
docs: add GENESIS command mode operating guide

### DIFF
--- a/docs/production-operations/GENESIS_COMMAND_MODE.md
+++ b/docs/production-operations/GENESIS_COMMAND_MODE.md
@@ -1,0 +1,49 @@
+# GENESIS Command Mode — Daily Activation
+
+## Activation command
+
+Use this command at the start of every shift:
+
+`GENESIS, activate Infamous Freight command mode.`
+
+## What to feed GENESIS
+
+After activation, pass one concrete operational input at a time:
+
+- A new **load** to quote, cover, or track
+- A **customer** request or escalation
+- A **carrier** onboarding, compliance, or service issue
+- A live **problem** (service failure, delay, billing dispute, etc.)
+- A specific **goal** (margin target, revenue target, cycle-time reduction)
+
+## Routing behavior expected from GENESIS
+
+GENESIS should route work through the full operating model already defined in the working document:
+
+1. Confirm tenant context, auth scope, and assigned role
+2. Select the responsible coworker/role prompt
+3. Execute the relevant SOP and freight workflow phase
+4. Trigger automation rules and communication templates
+5. Log decisions, actions, and handoffs for auditability
+6. Return a concise status update and next action
+
+## Daily operating rhythm
+
+- **Start of day:** Activate command mode and queue top-priority loads/issues
+- **Midday:** Re-run command mode for exceptions, SLA risks, and new leads
+- **End of day:** Run command mode for unresolved items, follow-ups, and tomorrow plan
+
+## Operator prompt template
+
+Use this structure to keep requests consistent:
+
+`GENESIS, activate Infamous Freight command mode. Context: <load/customer/carrier/problem/goal>. Objective: <desired outcome>. Constraints: <time/compliance/customer requirements>.`
+
+## Success criteria
+
+Command mode is working correctly when:
+
+- Every request is routed to a clear owner and SOP
+- Response includes immediate action, risks, and next checkpoint
+- Customer-facing outputs are generated without extra prompting
+- Open issues are visible and recoverable in the next operating cycle

--- a/docs/production-operations/README.md
+++ b/docs/production-operations/README.md
@@ -19,6 +19,7 @@ It contains operations, compliance, dispatch, carrier, sales, launch readiness, 
 - [Carrier Vetting SOP](CARRIER_VETTING_SOP.md)
 - [Dispatch Workflow](DISPATCH_WORKFLOW.md)
 - [Daily Operations SOP](DAILY_OPERATIONS_SOP.md)
+- [GENESIS Command Mode](GENESIS_COMMAND_MODE.md)
 - [Shipper Sales Script](SHIPPER_SALES_SCRIPT.md)
 - [GitHub Execution Backlog](GITHUB_EXECUTION_BACKLOG.md)
 - [GitHub-Native MVP Build Plan](GITHUB_NATIVE_MVP_BUILD_PLAN.md)


### PR DESCRIPTION
### Motivation
- Capture and formalize the daily activation command `GENESIS, activate Infamous Freight command mode.` and make the command-mode workflow discoverable within the production operations documentation.

### Description
- Add `docs/production-operations/GENESIS_COMMAND_MODE.md` containing the activation phrase, accepted input types, routing expectations, daily operating rhythm, operator prompt template, and success criteria, and add a link to it from `docs/production-operations/README.md`.

### Testing
- No automated tests were applicable for this docs-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02ef2ab50c83308bb2fd6e530ad44b)