### PR TITLE
Add Fly deployment helper scripts and improve CLI installer

### DIFF
--- a/scripts/01_preflight_image_and_fly.sh
+++ b/scripts/01_preflight_image_and_fly.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP="${FLY_APP:-infamous-freight-api}"
+IMAGE_TAG="${IMAGE_TAG:-ghcr.io/infaemous-freight/infamous-freight-api:a21800dae96e56fda18195ef00ad6d276b48bb43}"
+IMAGE_DIGEST="${IMAGE_DIGEST:-ghcr.io/infaemous-freight/infamous-freight-api@sha256:43fd4f0f0eafd34a17ab1b18a6e5b1760e54e56f2bf0491be325e06da105bc00}"
+
+FLY_BIN="$(command -v flyctl || command -v fly || true)"
+if [[ -z "${FLY_BIN}" ]]; then
+  echo "ERROR: Fly CLI is missing. Install flyctl, then run fly auth login." >&2
+  exit 1
+fi
+
+echo "Fly app: ${APP}"
+echo "Image tag: ${IMAGE_TAG}"
+echo "Image digest: ${IMAGE_DIGEST}"
+echo
+
+echo "Checking Fly login and app access..."
+"${FLY_BIN}" auth whoami
+"${FLY_BIN}" status --app "${APP}"
+echo
+
+if command -v docker >/dev/null 2>&1; then
+  echo "Checking local Docker can inspect/pull the image..."
+  docker manifest inspect "${IMAGE_DIGEST}" >/dev/null || docker manifest inspect "${IMAGE_TAG}" >/dev/null || {
+    echo "WARNING: Docker could not inspect the image. If GHCR is private, run: docker login ghcr.io" >&2
+  }
+else
+  echo "Docker not found locally. Skipping local image inspection."
+fi
+
+echo
+echo "Checking required Fly secret names are present..."
+SECRETS_FILE="/tmp/${APP}_secrets_list.txt"
+"${FLY_BIN}" secrets list --app "${APP}" | tee "${SECRETS_FILE}"
+
+missing=0
+for key in DATABASE_URL SUPABASE_JWT_SECRET STRIPE_SECRET_KEY STRIPE_WEBHOOK_SECRET; do
+  if ! grep -q "^${key}\b" "${SECRETS_FILE}"; then
+    echo "MISSING: ${key}" >&2
+    missing=1
+  fi
+done
+
+if [[ "${missing}" -eq 1 ]]; then
+  echo
+  echo "Required secrets are missing. Set them before deploy." >&2
+  exit 1
+fi
+
+echo "Preflight passed."

--- a/scripts/02_deploy_pinned_digest_canary.sh
+++ b/scripts/02_deploy_pinned_digest_canary.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP="${FLY_APP:-infamous-freight-api}"
+IMAGE_DIGEST="${IMAGE_DIGEST:-ghcr.io/infaemous-freight/infamous-freight-api@sha256:43fd4f0f0eafd34a17ab1b18a6e5b1760e54e56f2bf0491be325e06da105bc00}"
+FLY_BIN="$(command -v flyctl || command -v fly || true)"
+
+if [[ -z "${FLY_BIN}" ]]; then
+  echo "ERROR: Fly CLI is missing." >&2
+  exit 1
+fi
+
+echo "Deploying pinned image digest to ${APP}:"
+echo "${IMAGE_DIGEST}"
+echo
+
+"${FLY_BIN}" deploy \
+  --app "${APP}" \
+  --image "${IMAGE_DIGEST}" \
+  --strategy rolling \
+  --max-concurrent 1 \
+  --wait-timeout 10m \
+  --yes
+
+echo
+echo "Deploy command finished."

--- a/scripts/03_verify_after_deploy.sh
+++ b/scripts/03_verify_after_deploy.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP="${FLY_APP:-infamous-freight-api}"
+BASE_URL="${BASE_URL:-https://infamous-freight-api.fly.dev}"
+FLY_BIN="$(command -v flyctl || command -v fly || true)"
+
+if [[ -z "${FLY_BIN}" ]]; then
+  echo "ERROR: Fly CLI is missing." >&2
+  exit 1
+fi
+
+echo "Status:"
+"${FLY_BIN}" status --app "${APP}"
+echo
+
+echo "Checks:"
+"${FLY_BIN}" checks list --app "${APP}" || true
+echo
+
+echo "Releases:"
+"${FLY_BIN}" releases --app "${APP}" --image || true
+echo
+
+echo "Health endpoints:"
+for path in /api/health/live /api/health /health/live /health; do
+  echo "--- ${BASE_URL}${path}"
+  curl -fsS -i --max-time 20 "${BASE_URL}${path}" | sed -n '1,40p' || true
+  echo
+done
+
+echo "Recent logs:"
+"${FLY_BIN}" logs --app "${APP}" --no-tail || true

--- a/scripts/04_show_rollback_candidates.sh
+++ b/scripts/04_show_rollback_candidates.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP="${FLY_APP:-infamous-freight-api}"
+FLY_BIN="$(command -v flyctl || command -v fly || true)"
+
+if [[ -z "${FLY_BIN}" ]]; then
+  echo "ERROR: Fly CLI is missing." >&2
+  exit 1
+fi
+
+echo "Release history with images:"
+"${FLY_BIN}" releases --app "${APP}" --image
+
+cat <<'EOF2'
+
+Rollback pattern:
+
+  fly deploy --app infamous-freight-api --image <LAST_GOOD_IMAGE> --strategy rolling --max-concurrent 1 --wait-timeout 10m --yes
+
+Important:
+- This rolls back the VM image only.
+- It does not roll back database migrations.
+EOF2

--- a/scripts/05_run_all_recommended_checks.sh
+++ b/scripts/05_run_all_recommended_checks.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+APP="${FLY_APP:-infamous-freight-api}"
+FLY_CONFIG="${FLY_CONFIG:-fly.toml}"
+LIVE_URL="${LIVE_URL:-https://infamous-freight-api.fly.dev/api/health/live}"
+FLY_BIN="$(command -v flyctl || command -v fly || true)"
+RUN_CLI_BOOTSTRAP="${RUN_CLI_BOOTSTRAP:-0}"
+
+failures=0
+
+run_check() {
+  local label="$1"
+  shift
+
+  echo
+  echo ">>> ${label}"
+  if "$@"; then
+    echo "PASS: ${label}"
+  else
+    echo "FAIL: ${label}" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+if [[ "${RUN_CLI_BOOTSTRAP}" == "1" ]]; then
+  run_check "bash scripts/bootstrap-install-all-clis.sh" bash scripts/bootstrap-install-all-clis.sh
+fi
+
+run_check "pnpm install --frozen-lockfile" pnpm install --frozen-lockfile
+run_check "pnpm run env:check:frontend" pnpm run env:check:frontend
+run_check "pnpm run env:check:supabase-client" pnpm run env:check:supabase-client
+run_check "pnpm run build" pnpm run build
+run_check "pnpm run test" pnpm run test
+
+if [[ -n "${FLY_BIN}" ]]; then
+  run_check "${FLY_BIN} config validate --config ${FLY_CONFIG}" "${FLY_BIN}" config validate --config "${FLY_CONFIG}"
+  run_check "${FLY_BIN} checks list -a ${APP}" "${FLY_BIN}" checks list -a "${APP}"
+else
+  echo
+  echo "WARN: Fly CLI not found; skipped Fly checks."
+fi
+
+run_check "curl -i ${LIVE_URL}" curl -i "${LIVE_URL}"
+
+if [[ "${failures}" -gt 0 ]]; then
+  echo
+  echo "Completed with ${failures} failed check(s)." >&2
+  exit 1
+fi
+
+echo
+echo "All recommended checks passed."

--- a/scripts/bootstrap-install-all-clis.sh
+++ b/scripts/bootstrap-install-all-clis.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "Bootstrapping CLI installation (including Fly CLI)..."
+bash "${SCRIPT_DIR}/install-all-clis.sh"
+
+echo
+echo "Verifying installed CLIs..."
+bash "${SCRIPT_DIR}/verify-required-clis.sh"

--- a/scripts/install-all-clis.sh
+++ b/scripts/install-all-clis.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "Installing all required CLIs for Infamous Freight..."
+bash "${SCRIPT_DIR}/install-required-clis.sh"

--- a/scripts/install-required-clis.sh
+++ b/scripts/install-required-clis.sh
@@ -9,9 +9,13 @@ mkdir -p "${TOOLS_DIR}"
 install_flyctl() {
   if command -v flyctl >/dev/null 2>&1 || [[ -x "${TOOLS_DIR}/flyctl" ]]; then
     echo "flyctl already installed"
-    return
+  else
+    curl -fsSL https://fly.io/install.sh | FLYCTL_INSTALL="${REPO_ROOT}/.tools" sh
   fi
-  curl -fsSL https://fly.io/install.sh | FLYCTL_INSTALL="${REPO_ROOT}/.tools" sh
+
+  if [[ -x "${TOOLS_DIR}/flyctl" && ! -e "${TOOLS_DIR}/fly" ]]; then
+    ln -s "${TOOLS_DIR}/flyctl" "${TOOLS_DIR}/fly"
+  fi
 }
 
 install_supabase() {


### PR DESCRIPTION
### Motivation
- Provide a small suite of reproducible Fly.io deployment helper scripts to preflight, deploy a pinned image digest as a canary, verify post-deploy health, and list rollback candidates.
- Bundle convenience wrappers to install and bootstrap required CLIs so CI or developers can reproduce the environment consistently.
- Improve idempotent installation of `flyctl` in the repository-local tools dir and ensure a `fly` symlink is available for compatibility.

### Description
- Added new deployment and operations scripts: `scripts/01_preflight_image_and_fly.sh`, `scripts/02_deploy_pinned_digest_canary.sh`, `scripts/03_verify_after_deploy.sh`, `scripts/04_show_rollback_candidates.sh`, and `scripts/05_run_all_recommended_checks.sh` to handle preflight checks, pinned-digest deploys, verification, rollback guidance, and a set of recommended checks respectively.
- Added CLI bootstrap wrappers `scripts/bootstrap-install-all-clis.sh` and `scripts/install-all-clis.sh` which delegate to the existing `scripts/install-required-clis.sh` to simplify bootstrapping.
- Updated `scripts/install-required-clis.sh` to only install `flyctl` into `.tools` when it is not already available, and create a `fly` symlink to `flyctl` when appropriate to support both `fly` and `flyctl` command names.
- The preflight script validates Fly CLI presence, app access, optional Docker image inspection, and required secret names (`DATABASE_URL`, `SUPABASE_JWT_SECRET`, `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`), and the deploy script uses `fly deploy --image <digest> --strategy rolling --max-concurrent 1 --wait-timeout 10m --yes` for pinned-digest canary deploys.
- The recommended checks script exercises `pnpm` install/build/test steps, optional Fly config/checks, and a health `curl` to the live URL, with a fail-fast summary exit code on failures.

### Testing
- No automated tests were run against these new scripts as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03105955208330a22ac6f683b3abc3)