### PR TITLE
Resolve Supabase server config and validate environment variables

### DIFF
--- a/apps/web/src/lib/supabase/server.ts
+++ b/apps/web/src/lib/supabase/server.ts
@@ -1,27 +1,44 @@
 import { createServerClient, parseCookieHeader, serializeCookieHeader } from '@supabase/ssr'
 
+function resolveSupabaseServerConfig() {
+  const runtimeEnv = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env
+
+  const supabaseUrl = runtimeEnv?.SUPABASE_URL ?? import.meta.env.VITE_SUPABASE_URL
+  const supabasePublishableKey =
+    runtimeEnv?.SUPABASE_PUBLISHABLE_KEY ?? import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY
+
+  if (!supabaseUrl || !supabasePublishableKey) {
+    throw new Error(
+      'Supabase server client is not configured. Set SUPABASE_URL and SUPABASE_PUBLISHABLE_KEY, or VITE_SUPABASE_URL and VITE_SUPABASE_PUBLISHABLE_KEY.'
+    )
+  }
+
+  if (supabaseUrl.startsWith('postgres://') || supabaseUrl.startsWith('postgresql://')) {
+    throw new Error('Invalid Supabase URL for server client. Use SUPABASE_URL/VITE_SUPABASE_URL, not a Postgres DATABASE_URL.')
+  }
+
+  return { supabaseUrl, supabasePublishableKey }
+}
+
 export function createClient(request: Request) {
   const headers = new Headers()
+  const { supabaseUrl, supabasePublishableKey } = resolveSupabaseServerConfig()
 
-  const supabase = createServerClient(
-    process.env.VITE_SUPABASE_URL!,
-    process.env.VITE_SUPABASE_PUBLISHABLE_KEY!,
-    {
-      cookies: {
-        getAll() {
-          return parseCookieHeader(request.headers.get('Cookie') ?? '') as {
-            name: string
-            value: string
-          }[]
-        },
-        setAll(cookiesToSet) {
-          cookiesToSet.forEach(({ name, value, options }) =>
-            headers.append('Set-Cookie', serializeCookieHeader(name, value, options))
-          )
-        },
+  const supabase = createServerClient(supabaseUrl, supabasePublishableKey, {
+    cookies: {
+      getAll() {
+        return parseCookieHeader(request.headers.get('Cookie') ?? '') as {
+          name: string
+          value: string
+        }[]
       },
-    }
-  )
+      setAll(cookiesToSet) {
+        cookiesToSet.forEach(({ name, value, options }) =>
+          headers.append('Set-Cookie', serializeCookieHeader(name, value, options))
+        )
+      },
+    },
+  })
 
   return { supabase, headers }
 }


### PR DESCRIPTION
### Motivation
- Ensure the Supabase server client can be configured from both `process.env` and `import.meta.env` across different runtimes and provide clearer errors when misconfigured.
- Prevent accidentally passing a Postgres `DATABASE_URL` (e.g. `postgres://...`) into the Supabase client by validating the URL shape.

### Description
- Added `resolveSupabaseServerConfig()` to read `SUPABASE_URL` and `SUPABASE_PUBLISHABLE_KEY` from `globalThis.process.env` or `import.meta.env` and to throw descriptive errors when values are missing or the URL looks like a Postgres `DATABASE_URL`.
- Updated `createClient(request: Request)` to call `resolveSupabaseServerConfig()` and use the resolved `supabaseUrl` and `supabasePublishableKey` instead of directly accessing `process.env.VITE_SUPABASE_*`.
- Kept the existing cookie parsing/serializing behavior with `parseCookieHeader` and `serializeCookieHeader` and preserved returning `{ supabase, headers }` from `createClient`.

### Testing
- Ran TypeScript type-check and a local development build to ensure the module compiles successfully, and they completed without errors.
- Verified the `createClient` function still returns `{ supabase, headers }` and that cookie handling logic remains unchanged via local smoke testing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0332c38e7c83309feb84ac0844c4a6)