### PR TITLE
Lazy-load ShipmentRouteMap and defer MapLibre CSS import

### DIFF
--- a/apps/web/src/components/LazyShipmentRouteMap.tsx
+++ b/apps/web/src/components/LazyShipmentRouteMap.tsx
@@ -1,9 +1,13 @@
 import { Suspense, lazy } from 'react';
 
-const ShipmentRouteMap = lazy(async () => {
+const loadShipmentRouteMap = async () => {
   const mod = await import('./ShipmentRouteMap');
   return { default: mod.ShipmentRouteMap };
-});
+};
+
+const ShipmentRouteMap = lazy(loadShipmentRouteMap);
+
+export const preloadShipmentRouteMap = () => void loadShipmentRouteMap();
 
 type LazyShipmentRouteMapProps = {
   origin: string;

--- a/apps/web/src/components/LazyShipmentRouteMap.tsx
+++ b/apps/web/src/components/LazyShipmentRouteMap.tsx
@@ -1,0 +1,27 @@
+import { Suspense, lazy } from 'react';
+
+const ShipmentRouteMap = lazy(async () => {
+  const mod = await import('./ShipmentRouteMap');
+  return { default: mod.ShipmentRouteMap };
+});
+
+type LazyShipmentRouteMapProps = {
+  origin: string;
+  destination: string;
+  status: string;
+  className?: string;
+};
+
+const mapFallback = (
+  <div className="flex min-h-[320px] items-center justify-center rounded-2xl border border-infamous-border bg-[#101010] p-6 text-center text-sm text-[#B88989]">
+    Loading route map…
+  </div>
+);
+
+export const LazyShipmentRouteMap: React.FC<LazyShipmentRouteMapProps> = ({ origin, destination, status, className }) => (
+  <div className={className}>
+    <Suspense fallback={mapFallback}>
+      <ShipmentRouteMap origin={origin} destination={destination} status={status} />
+    </Suspense>
+  </div>
+);

--- a/apps/web/src/components/ShipmentRouteMap.tsx
+++ b/apps/web/src/components/ShipmentRouteMap.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { GeoJSONSource, LngLatBoundsLike, Map } from 'maplibre-gl';
-import 'maplibre-gl/dist/maplibre-gl.css';
 
 type ShipmentRouteMapProps = {
   origin: string;
@@ -96,6 +95,7 @@ export const ShipmentRouteMap: React.FC<ShipmentRouteMapProps> = ({ origin, dest
     let mapInstance: Map | null = null;
 
     const initializeMap = async () => {
+      await import('maplibre-gl/dist/maplibre-gl.css');
       const { default: maplibregl } = await import('maplibre-gl');
       if (isCancelled || !containerRef.current) return;
 

--- a/apps/web/src/pages/CustomerPortalPage.tsx
+++ b/apps/web/src/pages/CustomerPortalPage.tsx
@@ -18,7 +18,7 @@ import {
   Truck,
 } from 'lucide-react';
 import { demoQuotes, demoShipments } from '@/data/mvpFreightData';
-import { ShipmentRouteMap } from '@/components/ShipmentRouteMap';
+import { LazyShipmentRouteMap } from '@/components/LazyShipmentRouteMap';
 
 const statusColorMap: Record<string, string> = {
   'In Transit': 'badge-blue',
@@ -196,7 +196,7 @@ const CustomerPortalPage: React.FC = () => {
                   </div>
                 </div>
                 <div className="h-[280px]">
-                  <ShipmentRouteMap
+                  <LazyShipmentRouteMap
                     origin={selectedShipment.origin}
                     destination={selectedShipment.destination}
                     status={selectedShipment.status.toLowerCase().replace(/\s+/g, '_')}

--- a/apps/web/src/pages/CustomerPortalPage.tsx
+++ b/apps/web/src/pages/CustomerPortalPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import {
   AlertTriangle,
@@ -18,7 +18,7 @@ import {
   Truck,
 } from 'lucide-react';
 import { demoQuotes, demoShipments } from '@/data/mvpFreightData';
-import { LazyShipmentRouteMap } from '@/components/LazyShipmentRouteMap';
+import { LazyShipmentRouteMap, preloadShipmentRouteMap } from '@/components/LazyShipmentRouteMap';
 
 const statusColorMap: Record<string, string> = {
   'In Transit': 'badge-blue',
@@ -59,6 +59,11 @@ const recentDocuments = [
 const CustomerPortalPage: React.FC = () => {
   const [trackingInput, setTrackingInput] = useState('');
   const [selectedShipment, setSelectedShipment] = useState(demoShipments[0]);
+
+  useEffect(() => {
+    preloadShipmentRouteMap();
+  }, []);
+
   return (
     <div className="min-h-screen bg-infamous-dark px-5 py-8 text-[#F5E8E8] lg:px-6">
       <div className="mx-auto max-w-7xl">

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   Truck, AlertTriangle, Activity, ChevronRight, Package,
@@ -8,7 +8,7 @@ import {
   AlertCircle, Bell, Plus, DollarSign,
 } from 'lucide-react';
 import WidgetErrorBoundary from '@/components/ui/WidgetErrorBoundary';
-import { LazyShipmentRouteMap } from '@/components/LazyShipmentRouteMap';
+import { LazyShipmentRouteMap, preloadShipmentRouteMap } from '@/components/LazyShipmentRouteMap';
 
 interface ActiveLoad {
   ref: string;
@@ -99,6 +99,10 @@ const DashboardPage: React.FC = () => {
   const [selectedLoad, setSelectedLoad] = useState<ActiveLoad>(mockActiveLoads[0]);
   const [searchQuery, setSearchQuery] = useState('');
   const [alertFilter, setAlertFilter] = useState<string>('all');
+
+  useEffect(() => {
+    preloadShipmentRouteMap();
+  }, []);
 
   const filteredLoads = mockActiveLoads.filter((load) => {
     if (!searchQuery) return true;

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -8,7 +8,7 @@ import {
   AlertCircle, Bell, Plus, DollarSign,
 } from 'lucide-react';
 import WidgetErrorBoundary from '@/components/ui/WidgetErrorBoundary';
-import { ShipmentRouteMap } from '@/components/ShipmentRouteMap';
+import { LazyShipmentRouteMap } from '@/components/LazyShipmentRouteMap';
 
 interface ActiveLoad {
   ref: string;
@@ -189,7 +189,7 @@ const DashboardPage: React.FC = () => {
               </div>
             </div>
             <div className="h-[320px]">
-              <ShipmentRouteMap origin="Atlanta, GA" destination="Dallas, TX" status="in_transit" />
+              <LazyShipmentRouteMap origin="Atlanta, GA" destination="Dallas, TX" status="in_transit" />
             </div>
           </div>
         </WidgetErrorBoundary>

--- a/apps/web/src/pages/ShipmentDetailPage.tsx
+++ b/apps/web/src/pages/ShipmentDetailPage.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import {
   ArrowLeft,
@@ -17,7 +18,7 @@ import {
   User,
   XCircle,
 } from 'lucide-react';
-import { LazyShipmentRouteMap } from '@/components/LazyShipmentRouteMap';
+import { LazyShipmentRouteMap, preloadShipmentRouteMap } from '@/components/LazyShipmentRouteMap';
 
 const timelineSteps = [
   { key: 'quote_created', label: 'Quote Created', date: 'Apr 25, 2026 · 9:15 AM' },
@@ -142,6 +143,10 @@ const statusColorMap: Record<string, string> = {
 const ShipmentDetailPage: React.FC = () => {
   const { trackingId } = useParams<{ trackingId: string }>();
   const shipment = shipmentData[trackingId as keyof typeof shipmentData];
+
+  useEffect(() => {
+    preloadShipmentRouteMap();
+  }, []);
 
   if (!shipment) {
     return (

--- a/apps/web/src/pages/ShipmentDetailPage.tsx
+++ b/apps/web/src/pages/ShipmentDetailPage.tsx
@@ -17,7 +17,7 @@ import {
   User,
   XCircle,
 } from 'lucide-react';
-import { ShipmentRouteMap } from '@/components/ShipmentRouteMap';
+import { LazyShipmentRouteMap } from '@/components/LazyShipmentRouteMap';
 
 const timelineSteps = [
   { key: 'quote_created', label: 'Quote Created', date: 'Apr 25, 2026 · 9:15 AM' },
@@ -255,7 +255,7 @@ const ShipmentDetailPage: React.FC = () => {
                 </h2>
               </div>
               <div className="h-72 lg:h-80">
-                <ShipmentRouteMap origin={shipment.origin} destination={shipment.destination} status={shipment.status} />
+                <LazyShipmentRouteMap origin={shipment.origin} destination={shipment.destination} status={shipment.status} />
               </div>
             </div>
 

--- a/apps/web/src/pages/ShipmentTrackingPage.tsx
+++ b/apps/web/src/pages/ShipmentTrackingPage.tsx
@@ -16,7 +16,7 @@ import {
 import { demoShipments } from '@/data/mvpFreightData';
 import { trackPublicEvent } from '@/lib/analytics';
 import { getPublicShipment, PublicShipment } from '@/lib/publicFreightApi';
-import { LazyShipmentRouteMap } from '@/components/LazyShipmentRouteMap';
+import { LazyShipmentRouteMap, preloadShipmentRouteMap } from '@/components/LazyShipmentRouteMap';
 
 const TIMELINE_STEPS = [
   { key: 'quote_created', label: 'Quote Created' },
@@ -100,6 +100,10 @@ const ShipmentTrackingPage: React.FC = () => {
       setLoading(false);
     }
   };
+
+  useEffect(() => {
+    preloadShipmentRouteMap();
+  }, []);
 
   useEffect(() => {
     if (searchParams.get('tracking')) {

--- a/apps/web/src/pages/ShipmentTrackingPage.tsx
+++ b/apps/web/src/pages/ShipmentTrackingPage.tsx
@@ -16,7 +16,7 @@ import {
 import { demoShipments } from '@/data/mvpFreightData';
 import { trackPublicEvent } from '@/lib/analytics';
 import { getPublicShipment, PublicShipment } from '@/lib/publicFreightApi';
-import { ShipmentRouteMap } from '@/components/ShipmentRouteMap';
+import { LazyShipmentRouteMap } from '@/components/LazyShipmentRouteMap';
 
 const TIMELINE_STEPS = [
   { key: 'quote_created', label: 'Quote Created' },
@@ -199,7 +199,7 @@ const ShipmentTrackingPage: React.FC = () => {
 
               {/* Map */}
               <div className="rounded-xl border border-infamous-border bg-infamous-card overflow-hidden">
-                <ShipmentRouteMap
+                <LazyShipmentRouteMap
                   origin={shipment.origin}
                   destination={shipment.destination}
                   status={shipment.status}


### PR DESCRIPTION
### Motivation

- Reduce initial bundle size and improve page load performance by loading the heavy map component only when needed.
- Avoid importing `maplibre-gl` CSS at module-evaluation time which can cause unnecessary asset inclusion or SSR issues.

### Description

- Add a new `LazyShipmentRouteMap.tsx` that uses `React.lazy` and `Suspense` with a `mapFallback` UI to lazily load `ShipmentRouteMap`.
- Replace direct usages of `ShipmentRouteMap` with `LazyShipmentRouteMap` in `CustomerPortalPage.tsx`, `DashboardPage.tsx`, `ShipmentDetailPage.tsx`, and `ShipmentTrackingPage.tsx`.
- Move the top-level `import 'maplibre-gl/dist/maplibre-gl.css'` into the map initialization flow by adding `await import('maplibre-gl/dist/maplibre-gl.css')` inside the async `initializeMap` in `ShipmentRouteMap.tsx` so CSS is loaded only when the map is initialized.

### Testing

- Ran the TypeScript build via `yarn build` to ensure no type errors and the app compiles successfully, and it succeeded.
- Ran the project's test suite via `yarn test` and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0376c64c108330830295f9dd73693c)