### PR TITLE
ci: pin pnpm and node setup versions in required-checks

### DIFF
--- a/.github/workflows/required-checks.yml
+++ b/.github/workflows/required-checks.yml
@@ -41,14 +41,14 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4.1.0
         with:
           run_install: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v6.4.0
         with:
-          node-version: 22
+          node-version: "22"
           cache: pnpm
 
       - name: Install dependencies


### PR DESCRIPTION
### Motivation
- Ensure the `required-checks` CI workflow uses the repository's expected pinned setup action versions and a standard string `node-version` so installs stay consistent and reproducible.

### Description
- Updated `.github/workflows/required-checks.yml` to use `pnpm/action-setup@v4.1.0`, `actions/setup-node@v6.4.0`, and set `node-version` to the quoted string `"22"`.

### Testing
- Verified the change with `git diff -- .github/workflows/required-checks.yml`, searched the file with `rg -n "pnpm/action-setup|actions/setup-node|node-version" .github/workflows/required-checks.yml`, committed the update with `git commit`, and recorded PR metadata via `make_pr`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a053b4cfda48330ba80726b52d6272c)