### PR TITLE
Add local env and Fly verification scripts; bump AWS credentials action to v6.1.1

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -54,7 +54,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v6.1.1
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/scripts/fly-verify-live.sh
+++ b/scripts/fly-verify-live.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+set +x
+
+APP_NAME="${APP_NAME:-infamous-freight-api}"
+CONFIG_FILE="${CONFIG_FILE:-fly.toml}"
+LIVE_URL="${LIVE_URL:-https://${APP_NAME}.fly.dev/api/health/live}"
+
+if ! command -v flyctl >/dev/null 2>&1; then
+  echo "Installing flyctl..."
+  curl -fsSL https://fly.io/install.sh | sh
+  export FLYCTL_INSTALL="$HOME/.fly"
+  export PATH="$FLYCTL_INSTALL/bin:$PATH"
+fi
+
+if ! command -v flyctl >/dev/null 2>&1; then
+  echo "ERROR: flyctl still not found. Run:"
+  echo 'export FLYCTL_INSTALL="$HOME/.fly"'
+  echo 'export PATH="$FLYCTL_INSTALL/bin:$PATH"'
+  exit 1
+fi
+
+if [ -z "${FLY_API_TOKEN:-}" ]; then
+  read -r -s -p "Enter FLY_API_TOKEN: " FLY_API_TOKEN
+  echo
+  export FLY_API_TOKEN
+fi
+
+echo "==> flyctl version"
+flyctl version
+
+echo "==> Fly auth"
+flyctl auth whoami
+
+echo "==> Validate Fly config"
+flyctl config validate --config "$CONFIG_FILE"
+
+echo "==> Fly app status"
+flyctl status -a "$APP_NAME"
+
+echo "==> Fly checks"
+flyctl checks list -a "$APP_NAME" || {
+  echo "WARNING: checks list failed; continuing to HTTP health check."
+}
+
+echo "==> HTTP live health"
+curl -fsSIL --retry 3 --retry-delay 2 --retry-all-errors "$LIVE_URL"
+
+echo "==> HTTP live health body"
+curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors "$LIVE_URL"
+echo
+
+echo "PASS: Fly auth, config, app status, and live health check completed."

--- a/scripts/use-local-env.sh
+++ b/scripts/use-local-env.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+set +x
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TOOLS_DIR="$REPO_ROOT/.tools/bin"
+LOCAL_ENV_DIR="$HOME/.config/infamous-freight"
+LOCAL_ENV_FILE="$LOCAL_ENV_DIR/local.env"
+
+mkdir -p "$LOCAL_ENV_DIR"
+chmod 700 "$LOCAL_ENV_DIR"
+
+export PATH="$TOOLS_DIR:$HOME/.fly/bin:$PATH"
+
+if [ -f "$LOCAL_ENV_FILE" ]; then
+  # shellcheck disable=SC1090
+  source "$LOCAL_ENV_FILE"
+else
+  cat > "$LOCAL_ENV_FILE" <<'ENVEOF'
+# Infamous Freight local secrets
+# Fill these in locally only. Do not commit this file.
+
+# Fly.io
+export FLY_API_TOKEN=""
+
+# GitHub CLI token is optional if you use `gh auth login`
+export GH_TOKEN=""
+
+# Supabase
+export SUPABASE_ACCESS_TOKEN=""
+export SUPABASE_PROJECT_ID=""
+
+# Stripe
+export STRIPE_API_KEY=""
+export STRIPE_WEBHOOK_SECRET=""
+
+# Netlify
+export NETLIFY_AUTH_TOKEN=""
+export NETLIFY_SITE_ID=""
+
+# App
+export NODE_ENV="development"
+ENVEOF
+
+  chmod 600 "$LOCAL_ENV_FILE"
+  echo "Created $LOCAL_ENV_FILE"
+  echo "Fill it with real values, then rerun:"
+  echo "  source scripts/use-local-env.sh"
+  return 0 2>/dev/null || exit 0
+fi
+
+echo "==> Environment loaded"
+echo "Repo: $REPO_ROOT"
+echo "Tools: $TOOLS_DIR"
+
+echo "==> CLI availability"
+for cli in flyctl supabase stripe gh netlify docker jq shellcheck; do
+  if command -v "$cli" >/dev/null 2>&1; then
+    printf "✅ %s: %s\n" "$cli" "$(command -v "$cli")"
+  else
+    printf "⚠️  %s missing\n" "$cli"
+  fi
+done
+
+echo "==> Secret presence check"
+for var in FLY_API_TOKEN SUPABASE_ACCESS_TOKEN STRIPE_API_KEY NETLIFY_AUTH_TOKEN; do
+  if [ -n "${!var:-}" ]; then
+    echo "✅ $var set"
+  else
+    echo "⚠️  $var missing"
+  fi
+done


### PR DESCRIPTION
### Motivation

- Ensure developer convenience for loading local secrets and verifying Fly deployments via simple reusable scripts.
- Provide a lightweight runtime check for Fly app health and configuration to catch deployment issues quickly.
- Update the GitHub Actions AWS credentials action to a current stable version for compatibility and security.

### Description

- Bump `aws-actions/configure-aws-credentials` from `v1` to `v6.1.1` in `.github/workflows/aws.yml` to use the newer action version.  
- Add `scripts/fly-verify-live.sh`, an executable script that installs `flyctl` if missing, validates Fly config with `flyctl config validate`, checks app status, lists checks, and performs HTTP health probes against `LIVE_URL`.  
- Add `scripts/use-local-env.sh`, an executable script that creates and loads a local env file at `~/.config/infamous-freight/local.env`, sets up `PATH` to include repo tools, and prints CLI availability and presence of key secrets.  

### Testing

- No automated tests were run for these changes; runtime verification is expected to occur when the workflow is executed or scripts are sourced on developer machines.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05440e54d08330b865e469b6cad8c4)