### PR TITLE
security: expand frontend env secret guardrails

### DIFF
--- a/scripts/check-client-env-safety.sh
+++ b/scripts/check-client-env-safety.sh
@@ -17,11 +17,40 @@ DISALLOWED_KEYS=(
   SUPABASE_DATABASE_URL
   SUPABASE_SERVICE_KEY
   SUPABASE_SERVICE_ROLE_KEY
+  SUPABASE_JWT_SECRET
   STRIPE_SECRET_KEY
   STRIPE_WEBHOOK_SECRET
   OPENAI_API_KEY
   ANTHROPIC_API_KEY
   JWT_SECRET
+  GITHUB
+  GITHUB_TOKEN
+  GH_TOKEN
+  FLY
+  FLY_API_TOKEN
+  NETLIFY_AUTH_TOKEN
+  STACKBIT_API_SECRET
+  PRIVATE_KEY
+  CLIENT_SECRET
+  API_SECRET
+)
+
+DISALLOWED_KEY_PATTERNS=(
+  '(^|_)SERVICE_ROLE(_|$)'
+  '(^|_)SERVICE_KEY(_|$)'
+  '(^|_)JWT_SECRET$'
+  '(^|_)SECRET(_|$)'
+  '(^|_)PRIVATE_KEY$'
+  '(^|_)ACCESS_TOKEN$'
+  '(^|_)AUTH_TOKEN$'
+)
+
+DISALLOWED_VALUE_PATTERNS=(
+  'postgres(ql)?://'
+  'ghp_[A-Za-z0-9_]+'
+  'github_pat_[A-Za-z0-9_]+'
+  'flyv1[[:alnum:]_:-]+'
+  '-----BEGIN [A-Z ]*PRIVATE KEY-----'
 )
 
 if ! compgen -G "$WEB_ENV_GLOB" > /dev/null; then
@@ -29,13 +58,25 @@ if ! compgen -G "$WEB_ENV_GLOB" > /dev/null; then
   exit 1
 fi
 
+is_allowed_non_vite_key() {
+  local key="$1"
+
+  for allowed_key in "${ALLOWED_NON_VITE_KEYS[@]}"; do
+    if [[ "$key" == "$allowed_key" ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
 violations=()
 while IFS= read -r env_file; do
   [[ -f "$env_file" ]] || continue
 
   # 1) Explicit deny-list of backend secrets.
   for key in "${DISALLOWED_KEYS[@]}"; do
-    if grep -Eq "^${key}=" "$env_file"; then
+    if grep -Eiq "^${key}=" "$env_file"; then
       violations+=("${env_file}: disallowed key ${key}")
     fi
   done
@@ -45,12 +86,14 @@ while IFS= read -r env_file; do
     violations+=("${env_file}: public/browser-prefixed DATABASE_URL variables are not allowed")
   fi
 
-  # 3) Disallow Postgres URLs under any frontend-public key.
-  if grep -Eq '^(VITE|PUBLIC|NEXT_PUBLIC|REACT_APP)_[A-Za-z0-9_]*=.*postgres(ql)?://' "$env_file"; then
-    violations+=("${env_file}: public/browser-prefixed env value contains a Postgres URL")
-  fi
+  # 3) Disallow unsafe values under any frontend-public key.
+  for value_pattern in "${DISALLOWED_VALUE_PATTERNS[@]}"; do
+    if grep -Eiq "^(VITE|PUBLIC|NEXT_PUBLIC|REACT_APP)_[A-Za-z0-9_]*=.*${value_pattern}" "$env_file"; then
+      violations+=("${env_file}: public/browser-prefixed env value matches unsafe secret pattern")
+    fi
+  done
 
-  # 4) Allow only VITE_* and known build-time keys.
+  # 4) Allow only VITE_* and known build-time keys. Then reject public secret-like names.
   while IFS= read -r line || [[ -n "$line" ]]; do
     [[ "$line" =~ ^[[:space:]]*# ]] && continue
     [[ "$line" =~ ^[[:space:]]*$ ]] && continue
@@ -62,18 +105,15 @@ while IFS= read -r env_file; do
     key="$(echo "$key" | xargs)"
 
     if [[ "$key" == VITE_* ]]; then
+      for key_pattern in "${DISALLOWED_KEY_PATTERNS[@]}"; do
+        if [[ "$key" =~ $key_pattern ]]; then
+          violations+=("${env_file}: public key ${key} matches server-only secret pattern")
+        fi
+      done
       continue
     fi
 
-    allowed=false
-    for allowed_key in "${ALLOWED_NON_VITE_KEYS[@]}"; do
-      if [[ "$key" == "$allowed_key" ]]; then
-        allowed=true
-        break
-      fi
-    done
-
-    if [[ "$allowed" == false ]]; then
+    if ! is_allowed_non_vite_key "$key"; then
       violations+=("${env_file}: non-public key ${key} must be VITE_* or explicitly allowlisted")
     fi
   done < "$env_file"
@@ -86,7 +126,8 @@ if (( ${#violations[@]} > 0 )); then
       echo "- ${violation}"
     done
     echo "Only VITE_* public keys (plus approved Sentry build-time keys) are allowed in apps/web/.env* files."
-    echo "Use VITE_SUPABASE_URL for Supabase browser clients; never use DATABASE_URL or SUPABASE_DATABASE_URL in frontend env files."
+    echo "Use VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY for Supabase browser clients."
+    echo "Never expose service-role keys, JWT secrets, provider tokens, database URLs, or private keys to frontend env files."
   } >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

Expands the frontend environment safety check so browser/client env files reject additional server-only secret names and secret-shaped values.

## Why

During the Netlify production repair, several server-side credentials or sensitive-looking provider tokens were visible in the frontend Netlify deploy environment surface. Direct deletion through the connector was blocked by platform safety controls, so this PR prevents the same class of mistake from landing in frontend env files again.

## What changed

- Adds server-only names to the deny list, including service-role/JWT secrets, provider tokens, private keys, and generic secret names.
- Adds value-shape detection for Postgres URLs, GitHub PATs, Fly tokens, and private key blocks under public/browser-prefixed env keys.
- Keeps approved Sentry build-time variables allowlisted.

## Verification

Run:

```bash
pnpm run env:check:frontend
```

## Follow-up required outside this PR

Rotate/remove the currently exposed Netlify production variables from the Netlify UI or provider dashboards. Do not rely on this PR alone for already-exposed credentials.