### PR TITLE
fix(extension): use canonical www domain

### DIFF
--- a/apps/web/extension/src/popup.html
+++ b/apps/web/extension/src/popup.html
@@ -60,7 +60,7 @@
         </div>
         <button class="btn btn-primary" id="connect-btn">Connect Account</button>
         <p style="font-size:11px;color:#666;margin-top:8px;">
-          Get your API key from <a href="https://infamousfreight.com/settings/api" target="_blank" style="color:#ff3d00;">Settings → API</a>
+          Get your API key from <a href="https://www.infamousfreight.com/settings/api" target="_blank" style="color:#ff3d00;">Settings → API</a>
         </p>
       </div>
     </div>

--- a/apps/web/extension/src/popup.js
+++ b/apps/web/extension/src/popup.js
@@ -35,7 +35,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   });
 
   openDashboardBtn?.addEventListener('click', () => {
-    chrome.tabs.create({ url: 'https://infamousfreight.com/dispatch' });
+    chrome.tabs.create({ url: 'https://www.infamousfreight.com/dispatch' });
   });
 
   function showState(connected) {


### PR DESCRIPTION
## Summary

Updates browser extension links to use the canonical `https://www.infamousfreight.com` domain directly.

## Why

Owner direction: all public Infamous Freight paths should use the canonical www domain. The Manus-owned `.co` domain must remain separate and must not be used as a fallback.

## What changed

- Updated the extension dashboard link to the canonical www domain.
- Updated the extension settings link to the canonical www domain.

## Verification

Static link-only change. Confirm extension popup links open the canonical www domain.

## Risk

Low. No `.co` references added. No app runtime behavior changed.