### PR TITLE
ci(smoke): add production browser render checks

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -2,6 +2,8 @@ name: Smoke Test
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '17 */6 * * *'
   workflow_run:
     workflows:
       - CI/CD — Infamous Freight
@@ -18,15 +20,16 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  NODE_VERSION: '22'
   WEB_URL: https://www.infamousfreight.com
   BARE_SITE_URL: https://infamousfreight.com
   API_URL: https://infamous-freight-api.fly.dev
 
 jobs:
   smoke-test:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:
@@ -35,11 +38,32 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Run production smoke script
+      - name: Setup pnpm
+        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v4.1.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browser
+        run: pnpm -C apps/web exec playwright install chromium --with-deps
+
+      - name: Run production HTTP/API smoke script
         shell: bash
         run: |
           set -euo pipefail
           bash scripts/production-smoke-test.sh
+
+      - name: Run production browser render smoke test
+        shell: bash
+        run: |
+          set -euo pipefail
+          SITE_URL="${WEB_URL}" pnpm -C apps/web run smoke:render
 
       - name: Capture production smoke evidence
         if: always()
@@ -54,14 +78,16 @@ jobs:
             echo "- Web URL: ${WEB_URL}"
             echo "- Bare URL: ${BARE_SITE_URL}"
             echo "- API URL: ${API_URL}"
-            echo "- Script: scripts/production-smoke-test.sh"
+            echo "- HTTP/API script: scripts/production-smoke-test.sh"
+            echo "- Browser render script: apps/web/scripts/smoke-render.mjs"
             echo ""
             echo "## Expected checks"
             echo ""
             echo "- Canonical frontend returns success"
             echo "- Bare domain redirects to canonical www host"
+            echo "- Browser-rendered pages leave the loading shell"
             echo "- API liveness passes at ${API_URL}/api/health/live"
             echo "- API readiness passes at ${API_URL}/api/health/ready"
             echo ""
-            echo "If this workflow failed, paste the failed step output into docs/LAUNCH_EVIDENCE_LOG.md and keep issue #2212 open."
+            echo "If this workflow failed, paste the failed step output into docs/LAUNCH_EVIDENCE_LOG.md and keep the production-repair tracking issue open."
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Adds browser-render verification to the production smoke workflow so `www.infamousfreight.com` is checked with JavaScript execution, not just HTTP text fetches.

## What changed

- Adds a scheduled production smoke run every 6 hours.
- Installs workspace dependencies and Chromium in the smoke workflow.
- Runs the existing HTTP/API smoke script.
- Runs `pnpm -C apps/web run smoke:render` against `https://www.infamousfreight.com`.
- Updates workflow summary evidence to include the browser-render check.

## Why

The static HTML response contains the fallback loading shell by design. The real production health signal is whether the browser-rendered React app leaves that shell.

## Risk

Low. Workflow-only change. No application runtime changes.