### PR TITLE
ops: add monitoring package verification script

### DIFF
--- a/scripts/verify-monitoring-package.sh
+++ b/scripts/verify-monitoring-package.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+missing=()
+
+required_paths=(
+  "apps/api/src/integrations/pagerduty.ts"
+  "apps/api/src/integrations/sentry.ts"
+  "apps/api/src/middleware/monitoring.ts"
+  "apps/api/src/middleware/security-headers.ts"
+  "apps/api/src/middleware/logging.ts"
+  "apps/api/src/monitoring/database.ts"
+  "apps/api/src/monitoring/performance.ts"
+  "apps/api/src/automation/incident-response.ts"
+  ".github/workflows/ci-cd.yml"
+  "COMPLETE_DEPLOYMENT_GUIDE.md"
+  "APP_TS_INTEGRATION.ts"
+  "MISSING_COMPONENTS_ANALYSIS.md"
+  "IMPLEMENTATION_CHECKLIST.md"
+)
+
+for path in "${required_paths[@]}"; do
+  if [[ ! -f "$path" ]]; then
+    missing+=("$path")
+  fi
+done
+
+required_patterns=(
+  "PAGERDUTY_ROUTING_KEY"
+  "SENTRY_DSN"
+)
+
+for pattern in "${required_patterns[@]}"; do
+  if ! grep -R --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=dist --exclude-dir=build -q "$pattern" .; then
+    missing+=("repo reference containing $pattern")
+  fi
+done
+
+if (( ${#missing[@]} > 0 )); then
+  {
+    echo "::error::Monitoring package verification failed. Missing expected files/references:"
+    for item in "${missing[@]}"; do
+      echo "- ${item}"
+    done
+    echo ""
+    echo "This check verifies whether the previously claimed PagerDuty/Sentry/monitoring package actually landed in the repo."
+    echo "If these modules are intentionally not required, update this script and the related issue with the real production monitoring source of truth."
+  } >&2
+  exit 1
+fi
+
+echo "Monitoring package verification passed. Claimed production monitoring files and env references are present."


### PR DESCRIPTION
## Summary
Explain what changed and why.

## Launch impact
- [ ] No launch impact
- [ ] Private beta readiness
- [ ] Paid beta readiness
- [ ] Public launch readiness
- [ ] Production hotfix

## Area changed
- [ ] Web app
- [ ] API
- [ ] Database or Prisma
- [ ] Auth or roles
- [ ] Billing or Stripe
- [ ] Notifications
- [ ] Freight workflow
- [ ] Deployment or CI/CD
- [ ] Documentation only

## Verification
Paste the commands or checks run.

```bash
# Example
pnpm run build
pnpm run test
pnpm run validate
```

## Evidence
Add screenshots, logs, links, or notes that prove the change works.

## Risk checklist
- [ ] No secrets committed
- [ ] No production data included
- [ ] Role/access behavior considered
- [ ] Billing/payment behavior considered
- [ ] Rollback path identified
- [ ] Docs updated where needed

## Launch gate checklist
- [ ] API health remains valid
- [ ] Web app still loads
- [ ] Quote intake still works or was not touched
- [ ] Tracking flow still works or was not touched
- [ ] Admin/operator flow still works or was not touched
- [ ] Notifications still work or were not touched

## Follow-up issues
Link any blockers, deferred tasks, or evidence gaps.
