### PR TITLE
chore(ops): add deploy readiness verification script

### DIFF
--- a/scripts/verify-deploy-readiness.sh
+++ b/scripts/verify-deploy-readiness.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export PATH="$PWD/.tools/bin:$PATH"
+
+pnpm run setup:clis
+pnpm install --frozen-lockfile
+pnpm run env:check:frontend
+pnpm run env:check:supabase-client
+pnpm run build
+
+flyctl config validate --config fly.toml
+flyctl checks list -a infamous-freight-api
+curl -fsS https://infamous-freight-api.fly.dev/api/health/live


### PR DESCRIPTION
## Summary
- Adds `scripts/verify-deploy-readiness.sh` as a single repeatable deploy-readiness verification loop.
- Standardizes local tool PATH setup, CLI installation, frozen dependency install, frontend/Supabase env checks, build, Fly config/checks, and live API health verification.

## Validation
- Created from current `main` at `c81845ec447fe3433cd45d4904d297c968673187`.
- File-only operational script addition.
- Full shell execution must run in an authenticated repo terminal because Fly checks require Fly auth/context.

## Production impact
- No runtime application code changed.
- No Fly config, Dockerfile, auth, API, or web source changed.
- Low-risk ops-only addition.

## Rollback
- Revert commit `3075d790baaf2cb8a6973f2a18dd8412c4429c2b`, or delete `scripts/verify-deploy-readiness.sh`.
